### PR TITLE
MQTT: fix for incorrect UNSUBSCRIBE decoding / encoding

### DIFF
--- a/src/DotNetty.Codecs.Mqtt/MqttEncoder.cs
+++ b/src/DotNetty.Codecs.Mqtt/MqttEncoder.cs
@@ -335,7 +335,7 @@ namespace DotNetty.Codecs.Mqtt
                 foreach (string topic in packet.TopicFilters)
                 {
                     byte[] topicFilterBytes = EncodeStringInUtf8(topic);
-                    payloadBufferSize += 2 + topicFilterBytes.Length + 1; // length, value, QoS
+                    payloadBufferSize += StringSizeLength + topicFilterBytes.Length; // length, value
                     encodedTopicFilters.Add(topicFilterBytes);
                 }
 

--- a/src/DotNetty.Codecs.Mqtt/Packets/SubAckPacket.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/SubAckPacket.cs
@@ -14,7 +14,7 @@ namespace DotNetty.Codecs.Mqtt.Packets
 
         public IReadOnlyList<QualityOfService> ReturnCodes { get; set; }
 
-        public static SubAckPacket Confirm(SubscribePacket subscribePacket, QualityOfService maxQoS)
+        public static SubAckPacket InResponseTo(SubscribePacket subscribePacket, QualityOfService maxQoS)
         {
             var subAckPacket = new SubAckPacket
             {

--- a/src/DotNetty.Codecs.Mqtt/Packets/SubscribePacket.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/SubscribePacket.cs
@@ -7,6 +7,16 @@ namespace DotNetty.Codecs.Mqtt.Packets
 
     public sealed class SubscribePacket : PacketWithId
     {
+        public SubscribePacket()
+        {
+        }
+
+        public SubscribePacket(int packetId, params SubscriptionRequest[] requests)
+        {
+            this.PacketId = packetId;
+            this.Requests = requests;
+        }
+
         public override PacketType PacketType
         {
             get { return PacketType.SUBSCRIBE; }

--- a/src/DotNetty.Codecs.Mqtt/Packets/UnsubAckPacket.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/UnsubAckPacket.cs
@@ -9,5 +9,13 @@ namespace DotNetty.Codecs.Mqtt.Packets
         {
             get { return PacketType.UNSUBACK; }
         }
+
+        public static UnsubAckPacket InResponseTo(UnsubscribePacket unsubscribePacket)
+        {
+            return new UnsubAckPacket
+            {
+                PacketId = unsubscribePacket.PacketId
+            };
+        }
     }
 }

--- a/src/DotNetty.Codecs.Mqtt/Packets/UnsubscribePacket.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/UnsubscribePacket.cs
@@ -7,6 +7,16 @@ namespace DotNetty.Codecs.Mqtt.Packets
 
     public sealed class UnsubscribePacket : PacketWithId
     {
+        public UnsubscribePacket()
+        {
+        }
+
+        public UnsubscribePacket(int packetId, params string[] topicFilters)
+        {
+            this.PacketId = packetId;
+            this.TopicFilters = topicFilters;
+        }
+
         public override PacketType PacketType
         {
             get { return PacketType.UNSUBSCRIBE; }

--- a/src/DotNetty.Codecs.Mqtt/Signatures.cs
+++ b/src/DotNetty.Codecs.Mqtt/Signatures.cs
@@ -30,7 +30,7 @@ namespace DotNetty.Codecs.Mqtt
         public const byte PingReq = (int)PacketType.PINGREQ << 4;
         public const byte PingResp = (int)PacketType.PINGRESP << 4;
         public const byte Disconnect = (int)PacketType.DISCONNECT << 4;
-        public const byte Unsubscribe = (int)PacketType.UNSUBSCRIBE << 4;
+        public const byte Unsubscribe = ((int)PacketType.UNSUBSCRIBE << 4) | QoS1Signature;
         public const byte UnsubAck = (int)PacketType.UNSUBACK << 4;
     }
 }


### PR DESCRIPTION
motivation: Fix #5.

Also, adding convenient overload ctors on packets.