### PR TITLE
MQTT codec v1.1

### DIFF
--- a/DotNetty.sln
+++ b/DotNetty.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Common", "src\DotNetty.Common\DotNetty.Common.csproj", "{DE58FE41-5E99-44E5-86BC-FC9ED8761DAF}"
 EndProject
@@ -31,6 +31,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Buffers.Tests", "test\DotNetty.Buffers.Tests\DotNetty.Buffers.Tests.csproj", "{94E10283-E26E-441A-A2A7-D9671A6E9818}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Codecs.Tests", "test\DotNetty.Codecs.Tests\DotNetty.Codecs.Tests.csproj", "{F9566A9E-FABB-4A57-BF20-C1842AB87012}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Codecs.Mqtt.Tests", "test\DotNetty.Codecs.Mqtt.Tests\DotNetty.Codecs.Mqtt.Tests.csproj", "{F6019665-4C5E-4769-911A-FA1E83549BF5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -78,6 +80,10 @@ Global
 		{F9566A9E-FABB-4A57-BF20-C1842AB87012}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9566A9E-FABB-4A57-BF20-C1842AB87012}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9566A9E-FABB-4A57-BF20-C1842AB87012}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6019665-4C5E-4769-911A-FA1E83549BF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6019665-4C5E-4769-911A-FA1E83549BF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6019665-4C5E-4769-911A-FA1E83549BF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6019665-4C5E-4769-911A-FA1E83549BF5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,5 +99,6 @@ Global
 		{6E76FCAF-C7C8-4F45-8C95-0FD42F2AC83B} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 		{94E10283-E26E-441A-A2A7-D9671A6E9818} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 		{F9566A9E-FABB-4A57-BF20-C1842AB87012} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
+		{F6019665-4C5E-4769-911A-FA1E83549BF5} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 	EndGlobalSection
 EndGlobal

--- a/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
+++ b/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
@@ -35,6 +35,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Properties\Friends.cs" />
     <Compile Include="MqttEventSource.cs" />
     <Compile Include="MqttDecoder.cs" />
     <Compile Include="MqttEncoder.cs" />

--- a/src/DotNetty.Codecs.Mqtt/Packets/ConnectPacket.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/ConnectPacket.cs
@@ -14,28 +14,19 @@ namespace DotNetty.Codecs.Mqtt.Packets
 
         public string ProtocolName { get; set; }
 
-        public int ProtocolVersion { get; set; }
+        public int ProtocolLevel { get; set; }
 
         public bool CleanSession { get; set; }
 
-        public bool HasWill
-        {
-            get { return this.WillTopic != null; }
-        }
+        public bool HasWill { get; set; }
 
         public QualityOfService WillQualityOfService { get; set; }
 
         public bool WillRetain { get; set; }
 
-        public bool HasPassword
-        {
-            get { return this.Password != null; }
-        }
+        public bool HasPassword { get; set; }
 
-        public bool HasUsername
-        {
-            get { return this.Username != null; }
-        }
+        public bool HasUsername { get; set; }
 
         public int KeepAliveInSeconds { get; set; }
 
@@ -45,7 +36,7 @@ namespace DotNetty.Codecs.Mqtt.Packets
 
         public string ClientId { get; set; }
 
-        public string WillTopic { get; set; }
+        public string WillTopicName { get; set; }
 
         public IByteBuffer WillMessage { get; set; }
     }

--- a/src/DotNetty.Codecs.Mqtt/Packets/PublishPacket.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/PublishPacket.cs
@@ -76,6 +76,7 @@ namespace DotNetty.Codecs.Mqtt.Packets
         public IByteBufferHolder Copy()
         {
             var result = new PublishPacket(this.qos, this.duplicate, this.retainRequested);
+            result.TopicName = this.TopicName;
             result.Payload = this.Payload.Copy();
             return result;
         }
@@ -83,6 +84,7 @@ namespace DotNetty.Codecs.Mqtt.Packets
         IByteBufferHolder IByteBufferHolder.Duplicate()
         {
             var result = new PublishPacket(this.qos, this.duplicate, this.retainRequested);
+            result.TopicName = this.TopicName;
             result.Payload = this.Payload.Duplicate();
             return result;
         }

--- a/src/DotNetty.Codecs.Mqtt/Packets/SubscriptionRequest.cs
+++ b/src/DotNetty.Codecs.Mqtt/Packets/SubscriptionRequest.cs
@@ -3,10 +3,15 @@
 
 namespace DotNetty.Codecs.Mqtt.Packets
 {
-    public class SubscriptionRequest
+    using System;
+    using System.Diagnostics.Contracts;
+
+    public class SubscriptionRequest : IEquatable<SubscriptionRequest>
     {
         public SubscriptionRequest(string topicFilter, QualityOfService qualityOfService)
         {
+            Contract.Requires(!string.IsNullOrEmpty(topicFilter));
+
             this.TopicFilter = topicFilter;
             this.QualityOfService = qualityOfService;
         }
@@ -14,6 +19,12 @@ namespace DotNetty.Codecs.Mqtt.Packets
         public string TopicFilter { get; private set; }
 
         public QualityOfService QualityOfService { get; private set; }
+
+        public bool Equals(SubscriptionRequest other)
+        {
+            return this.QualityOfService == other.QualityOfService
+                && this.TopicFilter.Equals(other.TopicFilter, StringComparison.Ordinal);
+        }
 
         public override string ToString()
         {

--- a/src/DotNetty.Codecs.Mqtt/Properties/Friends.cs
+++ b/src/DotNetty.Codecs.Mqtt/Properties/Friends.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DotNetty.Codecs.Mqtt.Tests")]

--- a/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
+++ b/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F6019665-4C5E-4769-911A-FA1E83549BF5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DotNetty.Codecs.Mqtt.Tests</RootNamespace>
+    <AssemblyName>DotNetty.Codecs.Mqtt.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>cacc9365</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="MqttCodecTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
+      <Project>{5DE3C557-48BF-4CDB-9F47-474D343DD841}</Project>
+      <Name>DotNetty.Buffers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Codecs.Mqtt\DotNetty.Codecs.Mqtt.csproj">
+      <Project>{58ffea83-c956-49f9-9435-18332ad0e0d1}</Project>
+      <Name>DotNetty.Codecs.Mqtt</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Codecs\DotNetty.Codecs.csproj">
+      <Project>{2ABD244E-EF8F-460D-9C30-39116499E6E4}</Project>
+      <Name>DotNetty.Codecs</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj">
+      <Project>{DE58FE41-5E99-44E5-86BC-FC9ED8761DAF}</Project>
+      <Name>DotNetty.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Transport\DotNetty.Transport.csproj">
+      <Project>{8218C9EE-0A4A-432F-A12A-B54202F97B05}</Project>
+      <Name>DotNetty.Transport</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/DotNetty.Codecs.Mqtt.Tests/MqttCodecTests.cs
+++ b/test/DotNetty.Codecs.Mqtt.Tests/MqttCodecTests.cs
@@ -1,0 +1,253 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Codecs.Mqtt.Tests
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using DotNetty.Buffers;
+    using DotNetty.Codecs.Mqtt.Packets;
+    using DotNetty.Transport.Channels;
+    using Moq;
+    using Xunit;
+
+    public class MqttCodecTests
+    {
+        static readonly IByteBufferAllocator Allocator = new UnpooledByteBufferAllocator();
+
+        readonly MqttDecoder serverDecoder;
+        readonly MqttDecoder clientDecoder;
+        readonly Mock<IChannelHandlerContext> contextMock;
+
+        public MqttCodecTests()
+        {
+            this.serverDecoder = new MqttDecoder(true, 256 * 1024);
+            this.clientDecoder = new MqttDecoder(false, 256 * 1024);
+            this.contextMock = new Mock<IChannelHandlerContext>(MockBehavior.Strict);
+            this.contextMock.Setup(x => x.Removed).Returns(false);
+            this.contextMock.Setup(x => x.Allocator).Returns(UnpooledByteBufferAllocator.Default);
+        }
+
+        [Theory]
+        [InlineData("a", true, 0, null, null, "will/topic/name", new byte[] { 5, 3, 255, 6, 5 }, QualityOfService.ExactlyOnce, true)]
+        [InlineData("11a_2", false, 1, "user1", null, "will", new byte[0], QualityOfService.AtLeastOnce, false)]
+        [InlineData("abc/ж", false, 10, "", "pwd", null, null, null, false)]
+        [InlineData("", true, 1000, "имя", "密碼", null, null, null, false)]
+        public void TestConnectMessage(string clientId, bool cleanSession, int keepAlive, string userName,
+            string password, string willTopicName, byte[] willMessage, QualityOfService? willQos, bool willRetain)
+        {
+            var packet = new ConnectPacket();
+            packet.ClientId = clientId;
+            packet.CleanSession = cleanSession;
+            packet.KeepAliveInSeconds = keepAlive;
+            if (userName != null)
+            {
+                packet.Username = userName;
+                if (password != null)
+                {
+                    packet.Password = password;
+                }
+            }
+            if (willTopicName != null)
+            {
+                packet.WillTopicName = willTopicName;
+                packet.WillMessage = Unpooled.WrappedBuffer(willMessage);
+                packet.WillQualityOfService = willQos ?? QualityOfService.AtMostOnce;
+                packet.WillRetain = willRetain;
+            }
+
+            ConnectPacket recoded = this.RecodePacket(packet, true, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<ConnectPacket>()), Times.Once);
+            Assert.Equal(packet.ClientId, recoded.ClientId);
+            Assert.Equal(packet.CleanSession, recoded.CleanSession);
+            Assert.Equal(packet.KeepAliveInSeconds, recoded.KeepAliveInSeconds);
+            Assert.Equal(packet.HasUsername, recoded.HasUsername);
+            if (packet.HasUsername)
+            {
+                Assert.Equal(packet.Username, recoded.Username);
+            }
+            Assert.Equal(packet.HasPassword, recoded.HasPassword);
+            if (packet.HasPassword)
+            {
+                Assert.Equal(packet.Password, recoded.Password);
+            }
+            if (packet.HasWill)
+            {
+                Assert.Equal(packet.WillTopicName, recoded.WillTopicName);
+                Assert.True(ByteBufferUtil.Equals(Unpooled.WrappedBuffer(willMessage), recoded.WillMessage));
+                Assert.Equal(packet.WillQualityOfService, recoded.WillQualityOfService);
+                Assert.Equal(packet.WillRetain, recoded.WillRetain);
+            }
+        }
+
+        [Theory]
+        [InlineData(false, ConnectReturnCode.Accepted)]
+        [InlineData(true, ConnectReturnCode.Accepted)]
+        [InlineData(false, ConnectReturnCode.RefusedUnacceptableProtocolVersion)]
+        [InlineData(false, ConnectReturnCode.RefusedIdentifierRejected)]
+        [InlineData(false, ConnectReturnCode.RefusedServerUnavailable)]
+        [InlineData(false, ConnectReturnCode.RefusedBadUsernameOrPassword)]
+        [InlineData(false, ConnectReturnCode.RefusedNotAuthorized)]
+        public void TestConnAckMessage(bool sessionPresent, ConnectReturnCode returnCode)
+        {
+            var packet = new ConnAckPacket();
+            packet.SessionPresent = sessionPresent;
+            packet.ReturnCode = returnCode;
+
+            ConnAckPacket recoded = this.RecodePacket(packet, false, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<ConnAckPacket>()), Times.Once);
+            Assert.Equal(packet.SessionPresent, recoded.SessionPresent);
+            Assert.Equal(packet.ReturnCode, recoded.ReturnCode);
+        }
+
+        [Theory]
+        [InlineData(0, new[] { "+", "+/+", "//", "/#", "+//+" }, new[] {QualityOfService.ExactlyOnce, QualityOfService.AtLeastOnce, QualityOfService.AtMostOnce, QualityOfService.ExactlyOnce, QualityOfService.AtMostOnce})]
+        [InlineData(ushort.MaxValue, new[] { "a" }, new[] { QualityOfService.AtLeastOnce })]
+        public void TestSubscribeMessage(int packetId, string[] topicFilters, QualityOfService[] requestedQosValues)
+        {
+            var packet = new SubscribePacket(packetId, topicFilters.Zip(requestedQosValues, (topic, qos) => new SubscriptionRequest(topic, qos)).ToArray());
+
+            SubscribePacket recoded = this.RecodePacket(packet, true, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<SubscribePacket>()), Times.Once);
+            Assert.Equal(packet.Requests, recoded.Requests, EqualityComparer<SubscriptionRequest>.Default);
+            Assert.Equal(packet.PacketId, recoded.PacketId);
+        }
+
+        [Theory]
+        [InlineData(0, new[] { QualityOfService.ExactlyOnce, QualityOfService.AtLeastOnce, QualityOfService.AtMostOnce, QualityOfService.Failure, QualityOfService.AtMostOnce })]
+        [InlineData(ushort.MaxValue, new[] { QualityOfService.AtLeastOnce })]
+        public void TestSubAckMessage(int packetId, QualityOfService[] qosValues)
+        {
+            var packet = new SubAckPacket();
+            packet.PacketId = packetId;
+            packet.ReturnCodes = qosValues;
+
+            SubAckPacket recoded = this.RecodePacket(packet, false, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<SubAckPacket>()), Times.Once);
+            Assert.Equal(packet.ReturnCodes, recoded.ReturnCodes);
+            Assert.Equal(packet.PacketId, recoded.PacketId);
+        }
+
+        [Theory]
+        [InlineData(0, new[] { "+", "+/+", "//", "/#", "+//+" })]
+        [InlineData(ushort.MaxValue, new[] { "a" })]
+        public void TestUnsubscribeMessage(int packetId, string[] topicFilters)
+        {
+            var packet = new UnsubscribePacket(packetId, topicFilters);
+
+            UnsubscribePacket recoded = this.RecodePacket(packet, true, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<UnsubscribePacket>()), Times.Once);
+            Assert.Equal(packet.TopicFilters, recoded.TopicFilters);
+            Assert.Equal(packet.PacketId, recoded.PacketId);
+        }
+
+        [Theory]
+        [InlineData(QualityOfService.AtMostOnce, false, false, 0, "a", null)]
+        [InlineData(QualityOfService.ExactlyOnce, true, false, ushort.MaxValue, "/", new byte[0])]
+        [InlineData(QualityOfService.AtLeastOnce, false, true, 0, "a/b", new byte[] { 1, 2, 3 })]
+        [InlineData(QualityOfService.ExactlyOnce, true, true, 1, "topic/name/that/is/longer/than/256/characters/topic/name/that/is/longer/than/256/characters/topic/name/that/is/longer/than/256/characters/topic/name/that/is/longer/than/256/characters/topic/name/that/is/longer/than/256/characters/topic/name/that/is/longer/than/256/characters/", new byte[] { 1 })]
+        public void TestPublishMessage(QualityOfService qos, bool dup, bool retain, int packetId, string topicName, byte[] payload)
+        {
+            var packet = new PublishPacket(qos, dup, retain);
+            packet.TopicName = topicName;
+            if (qos > QualityOfService.AtMostOnce)
+            {
+                packet.PacketId = packetId;
+            }
+            packet.Payload = payload == null ? null : Unpooled.WrappedBuffer(payload);
+
+            PublishPacket recoded = this.RecodePacket(packet, false, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<PublishPacket>()), Times.Once);
+            Assert.Equal(packet.TopicName, recoded.TopicName);
+            if (packet.QualityOfService > QualityOfService.AtMostOnce)
+            {
+                Assert.Equal(packet.PacketId, recoded.PacketId);
+            }
+            Assert.True(ByteBufferUtil.Equals(payload == null ? Unpooled.Empty : Unpooled.WrappedBuffer(payload), recoded.Payload));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(128)]
+        [InlineData(256)]
+        [InlineData(257)]
+        [InlineData(ushort.MaxValue)]
+        public void TestPacketIdOnlyResponseMessages(int packetId)
+        {
+            this.TestPublishResponseMessage<PubAckPacket>(packetId, true);
+            this.TestPublishResponseMessage<PubAckPacket>(packetId, false);
+            this.TestPublishResponseMessage<PubRecPacket>(packetId, true);
+            this.TestPublishResponseMessage<PubRecPacket>(packetId, false);
+            this.TestPublishResponseMessage<PubRelPacket>(packetId, true);
+            this.TestPublishResponseMessage<PubRelPacket>(packetId, false);
+            this.TestPublishResponseMessage<PubCompPacket>(packetId, true);
+            this.TestPublishResponseMessage<PubCompPacket>(packetId, false);
+            this.TestPublishResponseMessage<UnsubAckPacket>(packetId, false);
+        }
+
+        void TestPublishResponseMessage<T>(int packetId, bool useServer)
+            where T : PacketWithId, new()
+        {
+            var packet = new T { PacketId = packetId };
+
+            T recoded = this.RecodePacket(packet, useServer, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<T>()), Times.Once);
+            this.contextMock.ResetCalls();
+            Assert.Equal(packet.PacketId, recoded.PacketId);
+        }
+
+        [Fact]
+        public void TestEmptyPacketMessages()
+        {
+            this.TestEmptyPacketMessage(PingReqPacket.Instance, true);
+            this.TestEmptyPacketMessage(PingRespPacket.Instance, false);
+            this.TestEmptyPacketMessage(DisconnectPacket.Instance, true);
+        }
+
+        void TestEmptyPacketMessage<T>(T packet, bool useServer)
+            where T : Packet
+        {
+            T recoded = this.RecodePacket(packet, useServer, true);
+
+            this.contextMock.Verify(x => x.FireChannelRead(It.IsAny<T>()), Times.Once);
+        }
+
+        T RecodePacket<T>(T packet, bool useServer, bool explodeForDecode)
+            where T : Packet
+        {
+            var output = new List<object>();
+            MqttEncoder.DoEncode(Allocator, packet, output);
+
+            T observedPacket = null;
+            this.contextMock.Setup(x => x.FireChannelRead(It.IsAny<T>()))
+                .Callback((object message) => observedPacket = Assert.IsAssignableFrom<T>(message))
+                .Returns(this.contextMock.Object);
+
+            foreach (IByteBuffer message in output)
+            {
+                MqttDecoder mqttDecoder = (useServer ? this.serverDecoder : this.clientDecoder);
+                if (explodeForDecode)
+                {
+                    while (message.IsReadable())
+                    {
+                        IByteBuffer finalBuffer = message.ReadBytes(1);
+                        mqttDecoder.ChannelRead(this.contextMock.Object, finalBuffer);
+                    }
+                }
+                else
+                {
+                    mqttDecoder.ChannelRead(this.contextMock.Object, message);
+                }
+            }
+            return observedPacket;
+        }
+    }
+}

--- a/test/DotNetty.Codecs.Mqtt.Tests/Properties/AssemblyInfo.cs
+++ b/test/DotNetty.Codecs.Mqtt.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DotNetty.Codecs.Mqtt.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DotNetty.Codecs.Mqtt.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4d4c9d88-34e3-41c3-955b-61da1ae07b7c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/DotNetty.Codecs.Mqtt.Tests/packages.config
+++ b/test/DotNetty.Codecs.Mqtt.Tests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+</packages>

--- a/test/DotNetty.Tests.End2End/End2EndTests.cs
+++ b/test/DotNetty.Tests.End2End/End2EndTests.cs
@@ -152,7 +152,7 @@ namespace DotNetty.Tests.End2End
                 ClientId = ClientId,
                 Username = "testuser",
                 Password = "notsafe",
-                WillTopic = "last/word",
+                WillTopicName = "last/word",
                 WillMessage = Unpooled.WrappedBuffer(Encoding.UTF8.GetBytes("oops"))
             });
 


### PR DESCRIPTION
- reworked decoder to use remaining length as an indicator for how many bytes need to be buffered before it makes sense to parse anything beyond the remaining length field in the packet.
- added happy path tests for re-coding for all packet types (#6). 
- bug fixes through testing.