### PR TITLE
Enable local/remote address caching and...

### DIFF
--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
@@ -334,9 +334,6 @@ namespace DotNetty.Transport.Channels.Sockets
 
             public void FinishConnect(SocketChannelAsyncOperation operation)
             {
-                // Note this method is invoked by the event loop only if the connection attempt was
-                // neither cancelled nor timed out.
-
                 Contract.Assert(this.channel.EventLoop.InEventLoop);
 
                 AbstractSocketChannel ch = this.Channel;

--- a/src/DotNetty.Transport/Channels/Sockets/TcpServerSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpServerSocketChannel.cs
@@ -55,12 +55,12 @@ namespace DotNetty.Transport.Channels.Sockets
             get { return this.Socket.IsBound; }
         }
 
-        public override EndPoint RemoteAddress
+        protected override EndPoint RemoteAddressInternal
         {
             get { return null; }
         }
 
-        public override EndPoint LocalAddress
+        protected override EndPoint LocalAddressInternal
         {
             get { return this.Socket.LocalEndPoint; }
         }
@@ -84,6 +84,8 @@ namespace DotNetty.Transport.Channels.Sockets
         {
             this.Socket.Bind(localAddress);
             this.Socket.Listen(this.config.Backlog);
+
+            this.CacheLocalAddress();
         }
 
         protected override void DoClose()

--- a/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
@@ -58,7 +58,7 @@ namespace DotNetty.Transport.Channels.Sockets
             this.config = new TcpSocketChannelConfig(this, socket);
             if (connected)
             {
-                this.SetState(StateFlags.Active);
+                this.OnConnected();
             }
         }
 
@@ -77,12 +77,12 @@ namespace DotNetty.Transport.Channels.Sockets
             get { return this.config; }
         }
 
-        public override EndPoint LocalAddress
+        protected override EndPoint LocalAddressInternal
         {
             get { return this.Socket.LocalEndPoint; }
         }
 
-        public override EndPoint RemoteAddress
+        protected override EndPoint RemoteAddressInternal
         {
             get { return this.Socket.RemoteEndPoint; }
         }
@@ -171,7 +171,16 @@ namespace DotNetty.Transport.Channels.Sockets
             {
                 operation.Dispose();
             }
+            this.OnConnected();
+        }
+
+        void OnConnected()
+        {
             this.SetState(StateFlags.Active);
+
+            // preserve local and remote addresses for later availability even if Socket fails
+            this.CacheLocalAddress();
+            this.CacheRemoteAddress();
         }
 
         protected override void DoDisconnect()


### PR DESCRIPTION
aggressively cache addresses when connected for Socket-based Channel implementations to prevent exceptions due to inconsistent behavior of underlying Socket (e.g. it throws when closed).

Fixes #20.