### PR TITLE
TlsHandler with proper WriteAsync/Flush semantics

### DIFF
--- a/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
+++ b/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
@@ -3,6 +3,10 @@
 
 namespace DotNetty.Buffers
 {
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Dervied buffer that forwards requests to the original underlying buffer
     /// </summary>
@@ -85,6 +89,12 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public override IByteBuffer GetBytes(int index, Stream destination, int length)
+        {
+            this.buffer.GetBytes(index, destination, length);
+            return this;
+        }
+
         public override IByteBuffer GetBytes(int index, IByteBuffer destination)
         {
             this.buffer.GetBytes(index, destination);
@@ -145,6 +155,11 @@ namespace DotNetty.Buffers
         {
             this.buffer.SetBytes(index, src, srcIndex, length);
             return this;
+        }
+
+        public override Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken)
+        {
+            return this.buffer.SetBytesAsync(index, src, length, cancellationToken);
         }
 
         public override bool HasArray

--- a/src/DotNetty.Buffers/IByteBuffer.cs
+++ b/src/DotNetty.Buffers/IByteBuffer.cs
@@ -245,6 +245,26 @@ namespace DotNetty.Buffers
         /// <exception cref="IndexOutOfRangeException">if the specified <see cref="index"/> is less than <c>0</c> or <c>index + 1</c> greater than <see cref="Capacity"/></exception>
         IByteBuffer GetBytes(int index, byte[] destination, int dstIndex, int length);
 
+        ///  <summary>
+        ///  Transfers this buffer's data to the specified stream starting at the
+        ///  specified absolute <c>index</c>.
+        ///  </summary>
+        ///  <remarks>
+        ///  This method does not modify <c>readerIndex</c> or <c>writerIndex</c> of
+        ///  this buffer.
+        ///  </remarks>
+        /// 
+        /// <param name="index">absolute index in this buffer to start getting bytes from</param>
+        /// <param name="destination">destination stream</param>
+        /// <param name="length">the number of bytes to transfer</param>
+
+        /// <exception cref="IndexOutOfRangeException">
+        ///          if the specified <c>index</c> is less than <c>0</c> or
+        ///          if <c>index + length</c> is greater than
+        ///             <c>this.capacity</c>
+        /// </exception> 
+        IByteBuffer GetBytes(int index, Stream destination, int length);
+
         /// <summary>
         /// Sets the specified boolean at the specified absolute <see cref="index"/> in this buffer.
         /// 
@@ -358,6 +378,23 @@ namespace DotNetty.Buffers
         IByteBuffer SetBytes(int index, byte[] src, int srcIndex, int length);
 
         /// <summary>
+        ///     Transfers the content of the specified source stream to this buffer
+        ///     starting at the specified absolute {@code index}.
+        ///     This method does not modify {@code readerIndex} or {@code writerIndex} of
+        ///     this buffer.
+        /// </summary>
+        /// <param name="index">absolute index in this byte buffer to start writing to</param>
+        /// <param name="src"></param>
+        /// <param name="length">number of bytes to transfer</param>
+        /// <param name="cancellationToken">cancellation token</param>
+        /// <returns>the actual number of bytes read in from the specified channel.</returns>
+        /// <exception cref="IndexOutOfRangeException">
+        ///     if the specified <c>index</c> is less than {@code 0} or
+        ///     if <c>index + length</c> is greater than <c>this.capacity</c>
+        /// </exception>
+        Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Gets a boolean at the current <see cref="ReaderIndex"/> and increases the <see cref="ReaderIndex"/>
         /// by <c>1</c> in this buffer.
         /// </summary>
@@ -426,7 +463,7 @@ namespace DotNetty.Buffers
         /// starting at the curent <see cref="ReaderIndex"/> until the destination becomes
         /// non-writable and increases the <see cref="ReaderIndex"/> by the number of transferred bytes.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">if <see cref="destination.WritableBytes"/> is greaer than <see cref="ReadableBytes"/>.</exception>
+        /// <exception cref="IndexOutOfRangeException">if <see cref="destination.WritableBytes"/> is greater than <see cref="ReadableBytes"/>.</exception>
         IByteBuffer ReadBytes(IByteBuffer destination);
 
         IByteBuffer ReadBytes(IByteBuffer destination, int length);
@@ -437,6 +474,8 @@ namespace DotNetty.Buffers
 
         IByteBuffer ReadBytes(byte[] destination, int dstIndex, int length);
 
+        IByteBuffer ReadBytes(Stream destination, int length);
+            
         /// <summary>
         /// Increases the current <see cref="ReaderIndex"/> by the specified <see cref="length"/> in this buffer.
         /// </summary>
@@ -515,8 +554,8 @@ namespace DotNetty.Buffers
 
         IByteBuffer ReadSlice(int length);
 
-        Task<int> WriteBytesAsync(Stream stream, int length);
+        Task WriteBytesAsync(Stream stream, int length);
 
-        Task<int> WriteBytesAsync(Stream stream, int length, CancellationToken cancellationToken);
+        Task WriteBytesAsync(Stream stream, int length, CancellationToken cancellationToken);
     }
 }

--- a/src/DotNetty.Buffers/SlicedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SlicedByteBuffer.cs
@@ -4,6 +4,9 @@
 namespace DotNetty.Buffers
 {
     using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     public sealed class SlicedByteBuffer : AbstractDerivedByteBuffer
     {
@@ -143,6 +146,13 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public override IByteBuffer GetBytes(int index, Stream destination, int length)
+        {
+            this.CheckIndex(index, length);
+            this.buffer.GetBytes(index + this.adjustment, destination, length);
+            return this;
+        }
+
         protected override void _SetByte(int index, int value)
         {
             this.buffer.SetByte(index + this.adjustment, value);
@@ -168,6 +178,12 @@ namespace DotNetty.Buffers
             this.CheckIndex(index, length);
             this.buffer.SetBytes(index + this.adjustment, src, srcIndex, length);
             return this;
+        }
+
+        public override Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken)
+        {
+            this.CheckIndex(index, length);
+            return this.buffer.SetBytesAsync(index + this.adjustment, src, length, cancellationToken);
         }
 
         public override IByteBuffer SetBytes(int index, IByteBuffer src, int srcIndex, int length)

--- a/src/DotNetty.Codecs/CodecException.cs
+++ b/src/DotNetty.Codecs/CodecException.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Codecs
+{
+    using System;
+
+    /// <summary>
+    ///     An <see cref="Exception" /> which is thrown by a codec.
+    /// </summary>
+    [Serializable]
+    public class CodecException : Exception
+    {
+        public CodecException()
+        {
+        }
+
+        public CodecException(string message, Exception innereException)
+            : base(message, innereException)
+        {
+        }
+
+        public CodecException(string message)
+            : base(message)
+        {
+        }
+
+        public CodecException(Exception innerException)
+            : base(null, innerException)
+        {
+        }
+    }
+}

--- a/src/DotNetty.Codecs/DotNetty.Codecs.csproj
+++ b/src/DotNetty.Codecs/DotNetty.Codecs.csproj
@@ -43,6 +43,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ByteToMessageDecoder.cs" />
+    <Compile Include="CodecException.cs" />
     <Compile Include="CorruptedFrameException.cs" />
     <Compile Include="DecoderException.cs" />
     <Compile Include="EncoderException.cs" />
@@ -51,6 +52,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReplayingDecoder.cs" />
     <Compile Include="TooLongFrameException.cs" />
+    <Compile Include="UnsupportedMessageTypeException.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotNetty.Buffers\DotNetty.Buffers.csproj">

--- a/src/DotNetty.Codecs/UnsupportedMessageTypeException.cs
+++ b/src/DotNetty.Codecs/UnsupportedMessageTypeException.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Codecs
+{
+    using System;
+    using System.Text;
+
+    /// <summary>
+    ///     Thrown if an unsupported message is received by an codec.
+    /// </summary>
+    [Serializable]
+    public class UnsupportedMessageTypeException : CodecException
+    {
+        public UnsupportedMessageTypeException(
+            object message, params Type[] expectedTypes)
+            : base(ComposeMessage(
+                message == null ? "null" : message.GetType().Name, expectedTypes))
+        {
+        }
+
+        public UnsupportedMessageTypeException()
+        {
+        }
+
+        public UnsupportedMessageTypeException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public UnsupportedMessageTypeException(string message)
+            : base(message)
+        {
+        }
+
+        public UnsupportedMessageTypeException(Exception innerException)
+            : base(innerException)
+        {
+        }
+
+        static string ComposeMessage(string actualType, params Type[] expectedTypes)
+        {
+            var buf = new StringBuilder(actualType);
+
+            if (expectedTypes != null && expectedTypes.Length > 0)
+            {
+                buf.Append(" (expected: ").Append(expectedTypes[0].Name);
+                for (int i = 1; i < expectedTypes.Length; i++)
+                {
+                    Type t = expectedTypes[i];
+                    if (t == null)
+                    {
+                        break;
+                    }
+                    buf.Append(", ").Append(t.Name);
+                }
+                buf.Append(')');
+            }
+
+            return buf.ToString();
+        }
+    }
+}

--- a/src/DotNetty.Common/Utilities/TaskEx.cs
+++ b/src/DotNetty.Common/Utilities/TaskEx.cs
@@ -35,5 +35,86 @@ namespace DotNetty.Common.Utilities
             tcs.TrySetException(exception);
             return tcs.Task;
         }
+
+        static readonly Action<Task, object> LinkOutcomeContinuationAction = (t, tcs) =>
+        {
+            switch (t.Status)
+            {
+                case TaskStatus.RanToCompletion:
+                    ((TaskCompletionSource)tcs).TryComplete();
+                    break;
+                case TaskStatus.Canceled:
+                    ((TaskCompletionSource)tcs).TrySetCanceled();
+                    break;
+                case TaskStatus.Faulted:
+                    ((TaskCompletionSource)tcs).TrySetException(t.Exception);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        };
+
+        public static void LinkOutcome(this Task task, TaskCompletionSource taskCompletionSource)
+        {
+            switch (task.Status)
+            {
+                case TaskStatus.RanToCompletion:
+                    taskCompletionSource.TryComplete();
+                    break;
+                case TaskStatus.Canceled:
+                    taskCompletionSource.TrySetCanceled();
+                    break;
+                case TaskStatus.Faulted:
+                    taskCompletionSource.TrySetException(task.Exception);
+                    break;
+                default:
+                    task.ContinueWith(
+                        LinkOutcomeContinuationAction,
+                        taskCompletionSource,
+                        TaskContinuationOptions.ExecuteSynchronously);
+                    break;
+            }
+        }
+
+        class LinkOutcomeActionHost<T>
+        {
+            public static readonly Action<Task<T>, object> Action =
+                (t, tcs) =>
+                {
+                    switch (t.Status)
+                    {
+                        case TaskStatus.RanToCompletion:
+                            ((TaskCompletionSource<T>)tcs).TrySetResult(t.Result);
+                            break;
+                        case TaskStatus.Canceled:
+                            ((TaskCompletionSource<T>)tcs).TrySetCanceled();
+                            break;
+                        case TaskStatus.Faulted:
+                            ((TaskCompletionSource<T>)tcs).TrySetException(t.Exception);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                };
+        }
+
+        public static void LinkOutcome<T>(this Task<T> task, TaskCompletionSource<T> taskCompletionSource)
+        {
+            switch (task.Status)
+            {
+                case TaskStatus.RanToCompletion:
+                    taskCompletionSource.TrySetResult(task.Result);
+                    break;
+                case TaskStatus.Canceled:
+                    taskCompletionSource.TrySetCanceled();
+                    break;
+                case TaskStatus.Faulted:
+                    taskCompletionSource.TrySetException(task.Exception);
+                    break;
+                default:
+                    task.ContinueWith(LinkOutcomeActionHost<T>.Action, taskCompletionSource, TaskContinuationOptions.ExecuteSynchronously);
+                    break;
+            }
+        }
     }
 }

--- a/src/DotNetty.Transport/Channels/PendingWriteQueue.cs
+++ b/src/DotNetty.Transport/Channels/PendingWriteQueue.cs
@@ -1,0 +1,345 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Channels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+    using System.Threading.Tasks;
+    using DotNetty.Common;
+    using DotNetty.Common.Concurrency;
+    using DotNetty.Common.Utilities;
+
+    /**
+ * A queue of write operations which are pending for later execution. It also updates the
+ * {@linkplain Channel#isWritable() writability} of the associated {@link Channel}, so that
+ * the pending write operations are also considered to determine the writability.
+ */
+
+    public sealed class PendingWriteQueue
+    {
+        //private static final InternalLogger logger = InternalLoggerFactory.getInstance(PendingWriteQueue.class);
+
+        readonly IChannelHandlerContext ctx;
+        readonly ChannelOutboundBuffer buffer;
+        readonly IMessageSizeEstimatorHandle estimatorHandle;
+
+        // head and tail pointers for the linked-list structure. If empty head and tail are null.
+        PendingWrite head;
+        PendingWrite tail;
+        int size;
+
+        public PendingWriteQueue(IChannelHandlerContext ctx)
+        {
+            Contract.Requires(ctx != null);
+
+            this.ctx = ctx;
+            this.buffer = ctx.Channel.Unsafe.OutboundBuffer;
+            this.estimatorHandle = ctx.Channel.Configuration.MessageSizeEstimator.NewHandle();
+        }
+
+        /**
+     * Returns {@code true} if there are no pending write operations left in this queue.
+     */
+
+        public bool IsEmpty
+        {
+            get
+            {
+                Contract.Assert(this.ctx.Executor.InEventLoop);
+
+                return this.head == null;
+            }
+        }
+
+        /**
+         * Returns the number of pending write operations.
+         */
+
+        public int Size
+        {
+            get
+            {
+                Contract.Assert(this.ctx.Executor.InEventLoop);
+
+                return this.size;
+            }
+        }
+
+        /**
+         * Add the given {@code msg} and {@link ChannelPromise}.
+         */
+
+        public Task Add(object msg)
+        {
+            Contract.Assert(this.ctx.Executor.InEventLoop);
+            Contract.Requires(msg != null);
+
+            int messageSize = this.estimatorHandle.Size(msg);
+            if (messageSize < 0)
+            {
+                // Size may be unknow so just use 0
+                messageSize = 0;
+            }
+            var promise = new TaskCompletionSource();
+            PendingWrite write = PendingWrite.NewInstance(msg, messageSize, promise);
+            PendingWrite currentTail = this.tail;
+            if (currentTail == null)
+            {
+                this.tail = this.head = write;
+            }
+            else
+            {
+                currentTail.Next = write;
+                this.tail = write;
+            }
+            this.size++;
+            // We need to guard against null as channel.Unsafe.OutboundBuffer may returned null
+            // if the channel was already closed when constructing the PendingWriteQueue.
+            // See https://github.com/netty/netty/issues/3967
+            if (this.buffer != null)
+            {
+                this.buffer.IncrementPendingOutboundBytes(write.Size);
+            }
+            return promise.Task;
+        }
+
+        /**
+         * Remove all pending write operation and fail them with the given {@link Throwable}. The message will be released
+         * via {@link ReferenceCountUtil#safeRelease(Object)}.
+         */
+
+        public void RemoveAndFailAll(Exception cause)
+        {
+            Contract.Assert(this.ctx.Executor.InEventLoop);
+            Contract.Requires(cause != null);
+
+            // Guard against re-entrance by directly reset
+            PendingWrite write = this.head;
+            this.head = this.tail = null;
+            this.size = 0;
+
+            while (write != null)
+            {
+                PendingWrite next = write.Next;
+                ReferenceCountUtil.SafeRelease(write.Msg);
+                TaskCompletionSource promise = write.Promise;
+                this.Recycle(write, false);
+                SafeFail(promise, cause);
+                write = next;
+            }
+            this.AssertEmpty();
+        }
+
+        /**
+         * Remove a pending write operation and fail it with the given {@link Throwable}. The message will be released via
+         * {@link ReferenceCountUtil#safeRelease(Object)}.
+         */
+
+        public void RemoveAndFail(Exception cause)
+        {
+            Contract.Assert(this.ctx.Executor.InEventLoop);
+            Contract.Requires(cause != null);
+
+            PendingWrite write = this.head;
+
+            if (write == null)
+            {
+                return;
+            }
+            ReferenceCountUtil.SafeRelease(write.Msg);
+            TaskCompletionSource promise = write.Promise;
+            SafeFail(promise, cause);
+            this.Recycle(write, true);
+        }
+
+        /**
+         * Remove all pending write operation and performs them via
+         * {@link ChannelHandlerContext#write(Object, ChannelPromise)}.
+         *
+         * @return  {@link ChannelFuture} if something was written and {@code null}
+         *          if the {@link PendingWriteQueue} is empty.
+         */
+
+        public Task RemoveAndWriteAll()
+        {
+            Contract.Assert(this.ctx.Executor.InEventLoop);
+
+            if (this.size == 1)
+            {
+                // No need to use ChannelPromiseAggregator for this case.
+                return this.RemoveAndWrite();
+            }
+            PendingWrite write = this.head;
+            if (write == null)
+            {
+                // empty so just return null
+                return null;
+            }
+
+            // Guard against re-entrance by directly reset
+            this.head = this.tail = null;
+            int currentSize = this.size;
+            this.size = 0;
+
+            var tasks = new List<Task>(currentSize);
+            while (write != null)
+            {
+                PendingWrite next = write.Next;
+                object msg = write.Msg;
+                TaskCompletionSource promise = write.Promise;
+                this.Recycle(write, false);
+                this.ctx.WriteAsync(msg).LinkOutcome(promise);
+                tasks.Add(promise.Task);
+                write = next;
+            }
+            this.AssertEmpty();
+            return Task.WhenAll(tasks);
+        }
+
+        void AssertEmpty()
+        {
+            Contract.Assert(this.tail == null && this.head == null && this.size == 0);
+        }
+
+        /**
+         * Removes a pending write operation and performs it via
+         * {@link ChannelHandlerContext#write(Object, ChannelPromise)}.
+         *
+         * @return  {@link ChannelFuture} if something was written and {@code null}
+         *          if the {@link PendingWriteQueue} is empty.
+         */
+
+        public Task RemoveAndWrite()
+        {
+            Contract.Assert(this.ctx.Executor.InEventLoop);
+
+            PendingWrite write = this.head;
+            if (write == null)
+            {
+                return null;
+            }
+            object msg = write.Msg;
+            TaskCompletionSource promise = write.Promise;
+            this.Recycle(write, true);
+            this.ctx.WriteAsync(msg).LinkOutcome(promise);
+            return promise.Task;
+        }
+
+        /// <summary>
+        ///     Removes a pending write operation and release it's message via {@link ReferenceCountUtil#safeRelease(Object)}.
+        /// </summary>
+        /// <returns><seealso cref="TaskCompletionSource" /> of the pending write or <c>null</c> if the queue is empty.</returns>
+        public TaskCompletionSource Remove()
+        {
+            Contract.Assert(this.ctx.Executor.InEventLoop);
+
+            PendingWrite write = this.head;
+            if (write == null)
+            {
+                return null;
+            }
+            TaskCompletionSource promise = write.Promise;
+            ReferenceCountUtil.SafeRelease(write.Msg);
+            this.Recycle(write, true);
+            return promise;
+        }
+
+        /// <summary>
+        ///     Return the current message or {@code null} if empty.
+        /// </summary>
+        public object Current
+        {
+            get
+            {
+                Contract.Assert(this.ctx.Executor.InEventLoop);
+
+                PendingWrite write = this.head;
+                if (write == null)
+                {
+                    return null;
+                }
+                return write.Msg;
+            }
+        }
+
+        void Recycle(PendingWrite write, bool update)
+        {
+            PendingWrite next = write.Next;
+            long writeSize = write.Size;
+
+            if (update)
+            {
+                if (next == null)
+                {
+                    // Handled last PendingWrite so rest head and tail
+                    // Guard against re-entrance by directly reset
+                    this.head = this.tail = null;
+                    this.size = 0;
+                }
+                else
+                {
+                    this.head = next;
+                    this.size--;
+                    Contract.Assert(this.size > 0);
+                }
+            }
+
+            write.Recycle();
+            // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
+            // if the channel was already closed when constructing the PendingWriteQueue.
+            // See https://github.com/netty/netty/issues/3967
+            if (this.buffer != null)
+            {
+                this.buffer.DecrementPendingOutboundBytes(writeSize);
+            }
+        }
+
+        static void SafeFail(TaskCompletionSource promise, Exception cause)
+        {
+            if ( /*!(promise instanceof VoidChannelPromise) && */!promise.TrySetException(cause))
+            {
+                // todo: log logger.warn("Failed to mark a promise as failure because it's done already: {}", promise, cause);
+            }
+        }
+
+        /**
+         * Holds all meta-data and construct the linked-list structure.
+         */
+
+        sealed class PendingWrite
+        {
+            static readonly ThreadLocalPool<PendingWrite> Pool = new ThreadLocalPool<PendingWrite>(handle => new PendingWrite(handle));
+
+            readonly ThreadLocalPool.Handle handle;
+            public PendingWrite Next;
+            public long Size;
+            public TaskCompletionSource Promise;
+            public object Msg;
+
+            PendingWrite(ThreadLocalPool.Handle handle)
+            {
+                this.handle = handle;
+            }
+
+            public static PendingWrite NewInstance(object msg, int size, TaskCompletionSource promise)
+            {
+                PendingWrite write = Pool.Take();
+                write.Size = size;
+                write.Msg = msg;
+                write.Promise = promise;
+                return write;
+            }
+
+            public void Recycle()
+            {
+                this.Size = 0;
+                this.Next = null;
+                this.Msg = null;
+                this.Promise = null;
+                this.handle.Release(this);
+            }
+        }
+    }
+}

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
@@ -464,6 +464,18 @@ namespace DotNetty.Transport.Channels.Sockets
                 cancellation.Cancel();
                 this.connectCancellation = null;
             }
+
+            SocketChannelAsyncOperation readOp = this.readOperation;
+            if (readOp != null)
+            {
+                readOp.Dispose();
+            }
+
+            SocketChannelAsyncOperation writeOp = this.writeOperation;
+            if (writeOp != null)
+            {
+                writeOp.Dispose();
+            }
         }
     }
 }

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Channels\IRecvByteBufAllocator.cs" />
     <Compile Include="Channels\IRecvByteBufAllocatorHandle.cs" />
     <Compile Include="Channels\PausableChannelEventExecutor.cs" />
+    <Compile Include="Channels\PendingWriteQueue.cs" />
     <Compile Include="Channels\PipelinePropagationAttribute.cs" />
     <Compile Include="Channels\PropagationDirections.cs" />
     <Compile Include="Channels\RejectedExecutionException.cs" />

--- a/test/DotNetty.Buffers.Tests/AbstractByteBufferTests.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractByteBufferTests.cs
@@ -23,12 +23,12 @@ namespace DotNetty.Buffers.Tests
             random.NextBytes(bytes);
 
             IByteBuffer buffer = Unpooled.Buffer(BufferCapacity);
-            int read;
+            int initialWriterIndex = buffer.WriterIndex;
             using (var stream = new PortionedMemoryStream(bytes, Enumerable.Repeat(1, int.MaxValue).Select(_ => random.Next(1, 10240))))
             {
-                read = await buffer.WriteBytesAsync(stream, CopyLength);
+                await buffer.WriteBytesAsync(stream, CopyLength);
             }
-            Assert.Equal(CopyLength, read);
+            Assert.Equal(CopyLength, buffer.WriterIndex - initialWriterIndex);
             Assert.True(ByteBufferUtil.Equals(Unpooled.WrappedBuffer(bytes.Slice(0, CopyLength)), buffer));
         }
     }

--- a/test/DotNetty.Tests.End2End/End2EndTests.cs
+++ b/test/DotNetty.Tests.End2End/End2EndTests.cs
@@ -76,6 +76,7 @@ namespace DotNetty.Tests.End2End
 
                 await Task.WhenAny(testPromise.Task, Task.Delay(TimeSpan.FromMinutes(1)));
                 Assert.True(testPromise.Task.IsCompleted);
+                testPromise.Task.Wait();
             }
             finally
             {


### PR DESCRIPTION
Fixes #29.
Ported PendingWriteQueue, EmptyByteBuffer and aligned ReadBytes and WriteBytesAsync with other similar methods.
TlsHandler now follows the same scheme (as close as possible with SslStream) as SslHandler in netty.