### PR TITLE
fixed casing issue with Mono build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,19 +9,19 @@ cd `dirname ${SCRIPT_PATH}` > /dev/null
 SCRIPT_PATH=`pwd`;
 popd  > /dev/null
 
-if ! [ -f $SCRIPT_PATH/.nuget/NuGet.exe ] 
+if ! [ -f $SCRIPT_PATH/.nuget/nuget.exe ] 
     then
         wget "https://www.nuget.org/nuget.exe" -P $SCRIPT_PATH/.nuget/
 fi
 
-mono $SCRIPT_PATH/.nuget/NuGet.exe update -self
+mono $SCRIPT_PATH/.nuget/nuget.exe update -self
 
-mono $SCRIPT_PATH/.nuget/NuGet.exe install FAKE -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion -Version 3.28.8
+mono $SCRIPT_PATH/.nuget/nuget.exe install FAKE -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion -Version 3.28.8
 
-mono $SCRIPT_PATH/.nuget/NuGet.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/packages/FAKE -ExcludeVersion -Version 2.0.0
+mono $SCRIPT_PATH/.nuget/nuget.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/packages/FAKE -ExcludeVersion -Version 2.0.0
 
 if ! [ -e $SCRIPT_PATH/packages/SourceLink.Fake/tools/SourceLink.fsx ] ; then
-	mono $SCRIPT_PATH/.nuget/NuGet.exe install SourceLink.Fake -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion
+	mono $SCRIPT_PATH/.nuget/nuget.exe install SourceLink.Fake -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion
 
 fi
 


### PR DESCRIPTION
This should allow the Mono builds to run again, combined with some other fixes I made on TeamCity