### PR TITLE
aligning Event Executors API

### DIFF
--- a/src/DotNetty.Common/Concurrency/ICallable`T.cs
+++ b/src/DotNetty.Common/Concurrency/ICallable`T.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Concurrency
+{
+    public interface ICallable<out T>
+    {
+        T Call();
+    }
+}

--- a/src/DotNetty.Common/Concurrency/IEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/IEventExecutor.cs
@@ -4,7 +4,6 @@
 namespace DotNetty.Common.Concurrency
 {
     using System;
-    using System.Diagnostics.Contracts;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -48,7 +47,7 @@ namespace DotNetty.Common.Concurrency
         bool IsInEventLoop(Thread thread);
 
         /// <summary>
-        ///     Returns an {@link IEventExecutor} that is not an {@link IWrappedEventExecutor}.
+        ///     Returns an <see cref="IEventExecutor" /> that is not an <see cref="IWrappedEventExecutor" />.
         /// </summary>
         /// <remarks>
         ///     <list type="bullet">
@@ -114,7 +113,7 @@ namespace DotNetty.Common.Concurrency
         /// different objects is needed.
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        void Schedule(Action<object> action, object state, TimeSpan delay, CancellationToken cancellationToken);
+        Task ScheduleAsync(Action<object> action, object state, TimeSpan delay, CancellationToken cancellationToken);
 
         /// <summary>
         /// Schedules the given action for execution after the specified delay would pass.
@@ -124,7 +123,7 @@ namespace DotNetty.Common.Concurrency
         /// different objects is needed.
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        void Schedule(Action<object> action, object state, TimeSpan delay);
+        Task ScheduleAsync(Action<object> action, object state, TimeSpan delay);
 
         /// <summary>
         /// Schedules the given action for execution after the specified delay would pass.
@@ -132,7 +131,7 @@ namespace DotNetty.Common.Concurrency
         /// <remarks>
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        void Schedule(Action action, TimeSpan delay, CancellationToken cancellationToken);
+        Task ScheduleAsync(Action action, TimeSpan delay, CancellationToken cancellationToken);
 
         /// <summary>
         /// Schedules the given action for execution after the specified delay would pass.
@@ -140,17 +139,7 @@ namespace DotNetty.Common.Concurrency
         /// <remarks>
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        void Schedule(Action action, TimeSpan delay);
-
-        /// <summary>
-        /// Schedules the given action for execution after the specified delay would pass.
-        /// </summary>
-        /// <remarks>
-        /// <paramref name="context"/> and <paramref name="state"/> parameters are useful when repeated execution of
-        /// an action against different objects in different context is needed.
-        /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
-        /// </remarks>
-        void Schedule(Action<object, object> action, object context, object state, TimeSpan delay);
+        Task ScheduleAsync(Action action, TimeSpan delay);
 
         /// <summary>
         /// Schedules the given action for execution after the specified delay would pass.
@@ -160,35 +149,74 @@ namespace DotNetty.Common.Concurrency
         /// an action against different objects in different context is needed.
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        void Schedule(Action<object, object> action, object context, object state, TimeSpan delay, CancellationToken cancellationToken);
+        Task ScheduleAsync(Action<object, object> action, object context, object state, TimeSpan delay);
 
         /// <summary>
-        /// Executes the given action and returns <see cref="Task" /> indicating completion of execution.
+        /// Schedules the given action for execution after the specified delay would pass.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="context"/> and <paramref name="state"/> parameters are useful when repeated execution of
+        /// an action against different objects in different context is needed.
+        /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
+        /// </remarks>
+        Task ScheduleAsync(Action<object, object> action, object context, object state, TimeSpan delay, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Executes the given function and returns <see cref="Task{T}" /> indicating completion status and result of execution.
         /// </summary>
         /// <remarks>
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        Task SubmitAsync(Func<Task> taskFunc);
+        Task<T> SubmitAsync<T>(Func<T> func);
 
         /// <summary>
-        /// Executes the given action and returns <see cref="Task" /> indicating completion of execution.
+        /// Executes the given action and returns <see cref="Task{T}" /> indicating completion status and result of execution.
+        /// </summary>
+        /// <remarks>
+        /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
+        /// </remarks>
+        Task<T> SubmitAsync<T>(Func<T> func, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Executes the given action and returns <see cref="Task{T}" /> indicating completion status and result of execution.
         /// </summary>
         /// <remarks>
         /// <paramref name="state"/> parameter is useful to when repeated execution of an action against
         /// different objects is needed.
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        Task SubmitAsync(Func<object, Task> taskFunc, object state);
+        Task<T> SubmitAsync<T>(Func<object, T> func, object state);
 
         /// <summary>
-        /// Executes the given action and returns <see cref="Task" /> indicating completion of execution.
+        /// Executes the given action and returns <see cref="Task{T}" /> indicating completion status and result of execution.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="state"/> parameter is useful to when repeated execution of an action against
+        /// different objects is needed.
+        /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
+        /// </remarks>
+        Task<T> SubmitAsync<T>(Func<object, T> func, object state, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Executes the given action and returns <see cref="Task{T}" /> indicating completion status and result of execution.
         /// </summary>
         /// <remarks>
         /// <paramref name="context"/> and <paramref name="state"/> parameters are useful when repeated execution of
         /// an action against different objects in different context is needed.
         /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
-        Task SubmitAsync(Func<object, object, Task> func, object context, object state);
+        Task<T> SubmitAsync<T>(Func<object, object, T> func, object context, object state);
+
+        /// <summary>
+        /// Executes the given action and returns <see cref="Task{T}" /> indicating completion status and result of execution.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="context"/> and <paramref name="state"/> parameters are useful when repeated execution of
+        /// an action against different objects in different context is needed.
+        /// <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
+        /// </remarks>
+        Task<T> SubmitAsync<T>(Func<object, object, T> func, object context, object state, CancellationToken cancellationToken);
+
 
         /// <summary>
         /// Shortcut method for <see cref="ShutdownGracefullyAsync(TimeSpan,TimeSpan)"/> with sensible default values.
@@ -198,7 +226,7 @@ namespace DotNetty.Common.Concurrency
         /// <summary>
         /// Signals this executor that the caller wants the executor to be shut down.  Once this method is called,
         /// <see cref="IsShuttingDown"/> starts to return <c>true</c>, and the executor prepares to shut itself down.
-        /// Unlike <see cref="Shutdown()"/>, graceful shutdown ensures that no tasks are submitted for <i>'the quiet period'</i>
+        /// Graceful shutdown ensures that no tasks are submitted for <i>'the quiet period'</i>
         /// (usually a couple seconds) before it shuts itself down.  If a task is submitted during the quiet period,
         /// it is guaranteed to be accepted and the quiet period will start over.
         /// </summary>

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -125,6 +125,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Concurrency\ICallable`T.cs" />
     <Compile Include="Deque.cs" />
     <Compile Include="Properties\Friends.cs" />
     <Compile Include="Concurrency\AbstractEventExecutor.cs" />

--- a/src/DotNetty.Common/Timestamp.cs
+++ b/src/DotNetty.Common/Timestamp.cs
@@ -21,6 +21,8 @@ namespace DotNetty.Common
 
         public static readonly PreciseTimeSpan Zero = new PreciseTimeSpan(0);
 
+        public static readonly PreciseTimeSpan MinusOne = new PreciseTimeSpan(-1);
+
         public static PreciseTimeSpan FromStart
         {
             get { return new PreciseTimeSpan(GetTimeChangeSinceStart()); }

--- a/src/DotNetty.Common/Utilities/MpscLinkedQueue.cs
+++ b/src/DotNetty.Common/Utilities/MpscLinkedQueue.cs
@@ -8,7 +8,7 @@ namespace DotNetty.Common.Utilities
     using System.Diagnostics.Contracts;
     using System.Threading;
 
-    class MpscLinkedQueue<T> : MpscLinkedQueueTailRef<T>, IEnumerable<T>
+    sealed class MpscLinkedQueue<T> : MpscLinkedQueueTailRef<T>, IEnumerable<T>
         where T : class
     {
 #pragma warning disable 169 // padded reference

--- a/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
@@ -299,7 +299,7 @@ namespace DotNetty.Transport.Bootstrapping
                     // stop accept new connections for 1 second to allow the channel to recover
                     // See https://github.com/netty/netty/issues/1328
                     config.AutoRead = false;
-                    ctx.Channel.EventLoop.Schedule(() => { config.AutoRead = true; }, TimeSpan.FromSeconds(1));
+                    ctx.Channel.EventLoop.ScheduleAsync(() => { config.AutoRead = true; }, TimeSpan.FromSeconds(1));
                 }
                 // still let the ExceptionCaught event flow through the pipeline to give the user
                 // a chance to do something with it

--- a/src/DotNetty.Transport/Channels/AbstractChannel.cs
+++ b/src/DotNetty.Transport/Channels/AbstractChannel.cs
@@ -976,7 +976,7 @@ namespace DotNetty.Transport.Channels
         }
 
         /// <summary>
-        /// Schedule a read operation.
+        /// ScheduleAsync a read operation.
         /// </summary>
         protected abstract void DoBeginRead();
 

--- a/src/DotNetty.Transport/Channels/ChannelHandlerAdapter.cs
+++ b/src/DotNetty.Transport/Channels/ChannelHandlerAdapter.cs
@@ -7,7 +7,7 @@ namespace DotNetty.Transport.Channels
     using System.Net;
     using System.Threading.Tasks;
 
-    public abstract class ChannelHandlerAdapter : IChannelHandler
+    public class ChannelHandlerAdapter : IChannelHandler
     {
         internal bool Added;
 

--- a/src/DotNetty.Transport/Channels/PausableChannelEventExecutor.cs
+++ b/src/DotNetty.Transport/Channels/PausableChannelEventExecutor.cs
@@ -4,6 +4,7 @@
 namespace DotNetty.Transport.Channels
 {
     using System;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Common.Concurrency;
@@ -37,119 +38,98 @@ namespace DotNetty.Transport.Channels
 
         public void Execute(IRunnable command)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
+            this.VerifyAcceptingNewTasks();
             this.Unwrap().Execute(command);
         }
 
         public void Execute(Action<object> action, object state)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
+            this.VerifyAcceptingNewTasks();
             this.Unwrap().Execute(action, state);
         }
 
         public void Execute(Action action)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
+            this.VerifyAcceptingNewTasks();
             this.Unwrap().Execute(action);
         }
 
-        public void Schedule(Action<object> action, object state, TimeSpan delay, CancellationToken cancellationToken)
+        public Task ScheduleAsync(Action<object> action, object state, TimeSpan delay, CancellationToken cancellationToken)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            this.Unwrap().Schedule(action, state, delay, cancellationToken);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().ScheduleAsync(action, state, delay, cancellationToken);
         }
 
-        public void Schedule(Action<object> action, object state, TimeSpan delay)
+        public Task ScheduleAsync(Action<object> action, object state, TimeSpan delay)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            this.Unwrap().Schedule(action, state, delay);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().ScheduleAsync(action, state, delay);
         }
 
-        public void Schedule(Action<object, object> action, object context, object state, TimeSpan delay, CancellationToken cancellationToken)
+        public Task ScheduleAsync(Action<object, object> action, object context, object state, TimeSpan delay, CancellationToken cancellationToken)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            this.Unwrap().Schedule(action, context, state, delay, cancellationToken);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().ScheduleAsync(action, context, state, delay, cancellationToken);
         }
 
-        public void Schedule(Action<object, object> action, object context, object state, TimeSpan delay)
+        public Task ScheduleAsync(Action<object, object> action, object context, object state, TimeSpan delay)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            this.Unwrap().Schedule(action, context, state, delay);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().ScheduleAsync(action, context, state, delay);
         }
 
-        public void Schedule(Action action, TimeSpan delay, CancellationToken cancellationToken)
+        public Task ScheduleAsync(Action action, TimeSpan delay, CancellationToken cancellationToken)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            this.Unwrap().Schedule(action, delay, cancellationToken);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().ScheduleAsync(action, delay, cancellationToken);
         }
 
-        public void Schedule(Action action, TimeSpan delay)
+        public Task ScheduleAsync(Action action, TimeSpan delay)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            this.Unwrap().Schedule(action, delay);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().ScheduleAsync(action, delay);
         }
 
-        public Task SubmitAsync(Func<object, Task> taskFunc, object state)
+        public Task<T> SubmitAsync<T>(Func<T> func)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            return this.Unwrap().SubmitAsync(taskFunc, state);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().SubmitAsync(func);
         }
 
-        public Task SubmitAsync(Func<Task> taskFunc)
+        public Task<T> SubmitAsync<T>(Func<T> func, CancellationToken cancellationToken)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            return this.Unwrap().SubmitAsync(taskFunc);
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().SubmitAsync(func, cancellationToken);
+        }
+
+        public Task<T> SubmitAsync<T>(Func<object, T> func, object state)
+        {
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().SubmitAsync(func, state);
+        }
+
+        public Task<T> SubmitAsync<T>(Func<object, T> func, object state, CancellationToken cancellationToken)
+        {
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().SubmitAsync(func, state, cancellationToken);
+        }
+
+        public Task<T> SubmitAsync<T>(Func<object, object, T> func, object context, object state)
+        {
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().SubmitAsync(func, context, state);
+        }
+
+        public Task<T> SubmitAsync<T>(Func<object, object, T> func, object context, object state, CancellationToken cancellationToken)
+        {
+            this.VerifyAcceptingNewTasks();
+            return this.Unwrap().SubmitAsync(func, context, state, cancellationToken);
         }
 
         public void Execute(Action<object, object> action, object context, object state)
         {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
+            this.VerifyAcceptingNewTasks();
             this.Unwrap().Execute(action, context, state);
-        }
-
-        public Task SubmitAsync(Func<object, object, Task> func, object context, object state)
-        {
-            if (!this.IsAcceptingNewTasks)
-            {
-                throw new RejectedExecutionException();
-            }
-            return this.Unwrap().SubmitAsync(func, context, state);
         }
 
         public bool IsShuttingDown
@@ -167,7 +147,6 @@ namespace DotNetty.Transport.Channels
             return this.Unwrap().ShutdownGracefullyAsync(quietPeriod, timeout);
         }
 
-
         public Task TerminationCompletion
         {
             get { return this.Unwrap().TerminationCompletion; }
@@ -181,6 +160,15 @@ namespace DotNetty.Transport.Channels
         public bool IsTerminated
         {
             get { return this.Unwrap().IsTerminated; }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        void VerifyAcceptingNewTasks()
+        {
+            if (!this.IsAcceptingNewTasks)
+            {
+                throw new RejectedExecutionException();
+            }
         }
     }
 }

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
@@ -255,7 +255,7 @@ namespace DotNetty.Transport.Channels.Sockets
                         {
                             CancellationTokenSource cts = ch.connectCancellation = new CancellationTokenSource();
 
-                            ch.EventLoop.Schedule(
+                            ch.EventLoop.ScheduleAsync(
                                 c =>
                                 {
                                     // todo: make static / cache delegate?..

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -111,7 +111,7 @@
       <Name>DotNetty.Transport</Name>
     </ProjectReference>
     <ProjectReference Include="..\DotNetty.Tests.Common\DotNetty.Tests.Common.csproj">
-      <Project>{EDF30087-8B53-4432-84B8-D21BD9F49E95}</Project>
+      <Project>{edf30087-8b53-4432-84b8-d21bd9f49e95}</Project>
       <Name>DotNetty.Tests.Common</Name>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Motivation:
Better align Event Executors API with netty (Schedule and Submit methods) and remove redundancy in SingleThreadEventExecutor

Modifications:
- changed Schedule method overloads to return `Task` and therefore also renamed it to `ScheduleAsync`
- changed `SubmitAsync` method overloads to work with `Func<T>` -> `Task<T>`
- updated `SingleThreadEventExecutor` to inherit from `AbstractSchedulingEventExecutor`

extras
- added support for cancellation in scheduled tasks
- fixed `ExecutorTaskScheduler.TryDequeue` and related functionality

Results:
- `SingleThreadEventExecutor` is part of Event Executor hierarchy
- It is easier to port / implement functionality that relies on continuations for `ScheduleAsync` or result of `SubmitAsync`'s future.