### PR TITLE
Fix #55

### DIFF
--- a/src/DotNetty.Buffers/EmptyByteBuffer.cs
+++ b/src/DotNetty.Buffers/EmptyByteBuffer.cs
@@ -407,7 +407,7 @@ namespace DotNetty.Buffers
 
         public IByteBuffer SkipBytes(int length)
         {
-            throw new IndexOutOfRangeException();
+            return this.CheckLength(length);
         }
 
         public IByteBuffer WriteBoolean(bool value)
@@ -492,12 +492,12 @@ namespace DotNetty.Buffers
 
         public byte[] ToArray()
         {
-            throw new IndexOutOfRangeException();
+            return ByteArrayExtensions.Empty;
         }
 
         public IByteBuffer Duplicate()
         {
-            throw new IndexOutOfRangeException();
+            return this;
         }
 
         public IByteBuffer WithOrder(ByteOrder endianness)

--- a/src/DotNetty.Transport/Channels/Groups/DefaultChannelGroup.cs
+++ b/src/DotNetty.Transport/Channels/Groups/DefaultChannelGroup.cs
@@ -310,18 +310,19 @@ namespace DotNetty.Transport.Channels.Groups
 
         static object SafeDuplicate(object message)
         {
-            if (message is IByteBuffer)
+            var buffer = message as IByteBuffer;
+            if (buffer != null)
             {
-                return ((IByteBuffer)message).Duplicate().Retain();
+                return buffer.Duplicate().Retain();
             }
-            else if (message is IByteBufferHolder)
+
+            var byteBufferHolder = message as IByteBufferHolder;
+            if (byteBufferHolder != null)
             {
-                return ((IByteBufferHolder)message).Duplicate().Retain();
+                return byteBufferHolder.Duplicate().Retain();
             }
-            else
-            {
-                return ReferenceCountUtil.Retain(message);
-            }
+
+            return ReferenceCountUtil.Retain(message);
         }
 
         public override bool Equals(object obj)
@@ -355,13 +356,14 @@ namespace DotNetty.Transport.Channels.Groups
 
         public bool Remove(IChannelId channelId)
         {
-            IChannel ch = null;
+            IChannel ch;
 
             if (this.serverChannels.TryRemove(channelId, out ch))
             {
                 return true;
             }
-            else if (this.nonServerChannels.TryRemove(channelId, out ch))
+
+            if (this.nonServerChannels.TryRemove(channelId, out ch))
             {
                 return true;
             }

--- a/src/DotNetty.Transport/Channels/Groups/DefaultChannelGroupCompletionSource.cs
+++ b/src/DotNetty.Transport/Channels/Groups/DefaultChannelGroupCompletionSource.cs
@@ -34,7 +34,7 @@ namespace DotNetty.Transport.Channels.Groups
                 this.futures.Add(pair.Key, pair.Value);
                 pair.Value.ContinueWith(x =>
                 {
-                    bool success = x.IsCompleted && !x.IsFaulted && !x.IsCanceled;
+                    bool success = x.Status == TaskStatus.RanToCompletion;
                     bool callSetDone;
                     lock (this)
                     {
@@ -48,7 +48,7 @@ namespace DotNetty.Transport.Channels.Groups
                         }
 
                         callSetDone = this.successCount + this.failureCount == this.futures.Count;
-                        Debug.Assert(this.successCount + this.failureCount <= this.futures.Count);
+                        Contract.Assert(this.successCount + this.failureCount <= this.futures.Count);
                     }
 
                     if (callSetDone)

--- a/src/DotNetty.Transport/Channels/Sockets/SocketAsyncOperationPayloadPool.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/SocketAsyncOperationPayloadPool.cs
@@ -1,3 +1,0 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -111,7 +111,6 @@
     <Compile Include="Channels\NotYetConnectedException.cs" />
     <Compile Include="Channels\IServerChannel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Channels\Sockets\SocketAsyncOperationPayloadPool.cs" />
     <Compile Include="Channels\DefaultChannelConfiguration.cs" />
     <Compile Include="Properties\Friends.cs" />
   </ItemGroup>


### PR DESCRIPTION
Motivation:
revisit EmptyByteBuffer port to ensure complete functionality

Modifications:
- ported trivial implementation of ToArray, Duplicate and other methods
- minor cleanup

Result:
EmptyByteBuffer does not throw exceptions when operation can be completed in a trivial way (0 byte length is enough to complete the operation).