### PR TITLE
Implemented ToString methods in ByteBuffer for user convenience.

### DIFF
--- a/examples/Echo.Client/EchoClientHandler.cs
+++ b/examples/Echo.Client/EchoClientHandler.cs
@@ -31,11 +31,8 @@ namespace Echo.Client
         {
             var byteBuffer = message as IByteBuffer;
             if (byteBuffer != null)
-            {
-                this.buffer.Initialize();
-                byteBuffer.Duplicate().ReadBytes(this.buffer, 0, byteBuffer.ReadableBytes);
-                string msg = Encoding.UTF8.GetString(this.buffer);
-                Console.WriteLine("Received from server: " + msg);
+            {                
+                Console.WriteLine("Received from server: " + byteBuffer.ToString(Encoding.UTF8));
             }
             context.WriteAsync(message);
         }

--- a/examples/Echo.Server/EchoServerHandler.cs
+++ b/examples/Echo.Server/EchoServerHandler.cs
@@ -3,12 +3,19 @@
 namespace Echo.Server
 {
     using System;
+    using System.Text;
+    using DotNetty.Buffers;
     using DotNetty.Transport.Channels;
 
     public class EchoServerHandler : ChannelHandlerAdapter
     {
         public override void ChannelRead(IChannelHandlerContext context, object message)
         {
+            IByteBuffer buffer = message as IByteBuffer;
+            if (buffer != null)
+            {
+                Console.WriteLine("Received from client: " + buffer.ToString(Encoding.UTF8));
+            }            
             context.WriteAsync(message);
         }
 

--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -6,6 +6,7 @@ namespace DotNetty.Buffers
     using System;
     using System.Diagnostics.Contracts;
     using System.IO;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Common;
@@ -921,6 +922,16 @@ namespace DotNetty.Buffers
         protected void DiscardMarkers()
         {
             this.markedReaderIndex = this.markedWriterIndex = 0;
+        }
+
+        public string ToString(Encoding encoding)
+        {
+            return this.ToString(ReaderIndex, ReadableBytes, encoding);
+        }
+
+        public string ToString(int index, int length, Encoding encoding)
+        {
+            return ByteBufferUtil.DecodeString(this, index, length, encoding);
         }
     }
 }

--- a/src/DotNetty.Buffers/AdvancedLeakAwareByteBuf.cs
+++ b/src/DotNetty.Buffers/AdvancedLeakAwareByteBuf.cs
@@ -4,6 +4,7 @@
 namespace DotNetty.Buffers
 {
     using System.IO;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Common;
@@ -625,5 +626,17 @@ namespace DotNetty.Buffers
             }
             return deallocated;
         }
+
+        public override string ToString(Encoding encoding)
+        {
+            RecordLeakNonRefCountingOperation();
+            return base.ToString(encoding);
+        }
+
+        public override string ToString(int index, int length, Encoding encoding)
+        {
+            RecordLeakNonRefCountingOperation();
+            return base.ToString(index, length, encoding);
+        }        
     }
 }

--- a/src/DotNetty.Buffers/ByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/ByteBufferUtil.cs
@@ -569,5 +569,32 @@ namespace DotNetty.Buffers
                 dump.Append('|');
             }
         }
+
+        public static string DecodeString(IByteBuffer src, int readerIndex, int len, Encoding encoding)
+        {
+            if (len == 0)
+            {
+                return string.Empty;
+            }
+
+            if (src.HasArray)
+            {
+                return encoding.GetString(src.Array, readerIndex, len);
+            }
+            else
+            {
+                IByteBuffer buffer = src.Allocator.Buffer(len);
+                try
+                {
+                    buffer.WriteBytes(src, readerIndex, len);
+                    return encoding.GetString(buffer.Array, 0, len);
+                }
+                finally
+                {
+                    // Release the temporary buffer again.
+                    buffer.Release();
+                }
+            }
+        }
     }
 }

--- a/src/DotNetty.Buffers/EmptyByteBuffer.cs
+++ b/src/DotNetty.Buffers/EmptyByteBuffer.cs
@@ -6,6 +6,7 @@ namespace DotNetty.Buffers
     using System;
     using System.Diagnostics.Contracts;
     using System.IO;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Common;
@@ -643,6 +644,17 @@ namespace DotNetty.Buffers
                 throw new IndexOutOfRangeException();
             }
             return this;
+        }
+
+        public string ToString(Encoding encoding)
+        {
+            return string.Empty;
+        }
+
+        public string ToString(int index, int length, Encoding encoding)
+        {
+            CheckIndex(index, length);
+            return this.ToString(encoding);
         }
     }
 }

--- a/src/DotNetty.Buffers/IByteBuffer.cs
+++ b/src/DotNetty.Buffers/IByteBuffer.cs
@@ -5,6 +5,7 @@ namespace DotNetty.Buffers
 {
     using System;
     using System.IO;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Common;
@@ -585,5 +586,9 @@ namespace DotNetty.Buffers
         Task WriteBytesAsync(Stream stream, int length);
 
         Task WriteBytesAsync(Stream stream, int length, CancellationToken cancellationToken);
+
+        string ToString(Encoding encoding);
+
+        string ToString(int index, int length, Encoding encoding);
     }
 }

--- a/src/DotNetty.Buffers/SwappedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SwappedByteBuffer.cs
@@ -7,6 +7,7 @@ namespace DotNetty.Buffers
     using System.Diagnostics.Contracts;
     using System.IO;
     using System.Linq;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Common;
@@ -668,6 +669,16 @@ namespace DotNetty.Buffers
         public override string ToString()
         {
             return "Swapped(" + this.buf + ")";
+        }
+
+        public string ToString(Encoding encoding)
+        {
+            return buf.ToString(encoding);
+        }
+
+        public string ToString(int index, int length, Encoding encoding)
+        {
+            return buf.ToString(index, length, encoding);
         }
     }
 }

--- a/src/DotNetty.Buffers/WrappedByteBuf.cs
+++ b/src/DotNetty.Buffers/WrappedByteBuf.cs
@@ -5,6 +5,7 @@ namespace DotNetty.Buffers
 {
     using System.Diagnostics.Contracts;
     using System.IO;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Common;
@@ -723,6 +724,16 @@ namespace DotNetty.Buffers
         public virtual bool Release(int decrement)
         {
             return this.Buf.Release(decrement);
+        }
+
+        public virtual string ToString(Encoding encoding)
+        {
+            return Buf.ToString(encoding);
+        }
+
+        public virtual string ToString(int index, int length, Encoding encoding)
+        {
+            return Buf.ToString(index, length, encoding);
         }
     }
 }


### PR DESCRIPTION
I implemented ToString methods in ByteBuffer for user convenience. And modified echo examples.
These methods were implemented in Netty(Java).

# Java version
```java
// In ByteBuf.java
public abstract String toString(Charset charset);
public abstract String toString(int index, int length, Charset charset);
```

# C# version
```C#
// In IByteBuffer.cs
string ToString(Encoding encoding);
string ToString(int index, int length, Encoding encoding);
```

# Usages in EchoClientHandler.cs
## Before
```C#
this.buffer.Initialize();
byteBuffer.Duplicate().ReadBytes(this.buffer, 0, byteBuffer.ReadableBytes);
string msg = Encoding.UTF8.GetString(this.buffer);
Console.WriteLine("Received from server: " + msg);
```

## After
```C#
Console.WriteLine("Received from server: " + byteBuffer.ToString(Encoding.Default));
```