### PR TITLE
Fixes premature completion of async operations (#66)

### DIFF
--- a/src/DotNetty.Common/Concurrency/TaskCompletionSource.cs
+++ b/src/DotNetty.Common/Concurrency/TaskCompletionSource.cs
@@ -34,6 +34,11 @@ namespace DotNetty.Common.Concurrency
             return true;
         }
 
+        public override string ToString()
+        {
+            return "TaskCompletionSource[status: " + this.Task.Status.ToString() + "]";
+        }
+
         static TaskCompletionSource CreateVoidTcs()
         {
             var tcs = new TaskCompletionSource();


### PR DESCRIPTION
Motivation:
Due to misuse of IEventExecutor.SubmitAsync in
DefaultChannelHandlerInvoker and Bootstrap, async operations return future
that is completed after first sync part of operation is through.

Modifications:
DefaultChannelHandlerInvoker and Bootstrap are modified to complete
returned future only after the whole async operation is completed.

Result:
chaining async operations does not result in intermittent failures due to
premature access to channel, errors potentially appearing in later stages
of async operations are also properly reported through failure of the
future.