### PR TITLE
Enables setting options specific to DefaultSocketChannelConfiguration…

### DIFF
--- a/src/DotNetty.Transport/Channels/Sockets/DefaultSocketChannelConfiguration.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/DefaultSocketChannelConfiguration.cs
@@ -8,7 +8,7 @@ namespace DotNetty.Transport.Channels.Sockets
     using System.Net.Sockets;
 
     /// <summary>
-    /// The default {@link SocketChannelConfig} implementation.
+    ///     The default {@link SocketChannelConfig} implementation.
     /// </summary>
     public class DefaultSocketChannelConfiguration : DefaultChannelConfiguration, ISocketChannelConfiguration
     {
@@ -22,7 +22,13 @@ namespace DotNetty.Transport.Channels.Sockets
             this.Socket = socket;
 
             // Enable TCP_NODELAY by default if possible.
-            socket.NoDelay = true;
+            try
+            {
+                this.TcpNoDelay = true;
+            }
+            catch
+            {
+            }
         }
 
         public override T GetOption<T>(ChannelOption<T> option)
@@ -61,6 +67,53 @@ namespace DotNetty.Transport.Channels.Sockets
             }
 
             return base.GetOption(option);
+        }
+
+        public override bool SetOption<T>(ChannelOption<T> option, T value)
+        {
+            if (base.SetOption(option, value))
+            {
+                return true;
+            }
+
+            if (ChannelOption.SoRcvbuf.Equals(option))
+            {
+                this.ReceiveBufferSize = (int)(object)value;
+            }
+            else if (ChannelOption.SoSndbuf.Equals(option))
+            {
+                this.SendBufferSize = (int)(object)value;
+            }
+            else if (ChannelOption.TcpNodelay.Equals(option))
+            {
+                this.TcpNoDelay = (bool)(object)value;
+            }
+            else if (ChannelOption.SoKeepalive.Equals(option))
+            {
+                this.KeepAlive = (bool)(object)value;
+            }
+            else if (ChannelOption.SoReuseaddr.Equals(option))
+            {
+                this.ReuseAddress = (bool)(object)value;
+            }
+            else if (ChannelOption.SoLinger.Equals(option))
+            {
+                this.Linger = (int)(object)value;
+            }
+            //else if (option == IP_TOS)
+            //{
+            //    setTrafficClass((Integer)value);
+            //}
+            else if (ChannelOption.AllowHalfClosure.Equals(option))
+            {
+                this.allowHalfClosure = (bool)(object)value;
+            }
+            else
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public bool AllowHalfClosure

--- a/src/DotNetty.Transport/Channels/Sockets/ISocketChannelConfiguration.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/ISocketChannelConfiguration.cs
@@ -5,5 +5,18 @@ namespace DotNetty.Transport.Channels.Sockets
 {
     public interface ISocketChannelConfiguration : IChannelConfiguration
     {
+        bool AllowHalfClosure { get; set; }
+
+        int ReceiveBufferSize { get; set; }
+
+        int SendBufferSize { get; set; }
+
+        int Linger { get; set; }
+
+        bool KeepAlive { get; set; }
+
+        bool ReuseAddress { get; set; }
+
+        bool TcpNoDelay { get; set; }
     }
 }


### PR DESCRIPTION
… (fix #68)

Motivation:
Fix a bug that breaks setting options specific to socket-based channel implementations

Modifications:
Added SetOption overload accepting socket-specific options to DefaultSocketChannelConfiguration

Result:
It is possible to modify send/receive buffer size and other settings through SetOption on Bootstrap.