### PR TITLE
Fixes pooled buffer's AdjustCapacity to properly set the length

### DIFF
--- a/src/DotNetty.Buffers/PooledByteBuffer.cs
+++ b/src/DotNetty.Buffers/PooledByteBuffer.cs
@@ -65,7 +65,9 @@ namespace DotNetty.Buffers
             }
 
             // todo: fall through to here means buffer pool is being used inefficiently. consider providing insight on such events
-            return base.AdjustCapacity(newCapacity);
+            base.AdjustCapacity(newCapacity);
+            this.length = newCapacity;
+            return this;
         }
 
         public override IByteBuffer Copy(int index, int length)

--- a/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
+++ b/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
@@ -74,7 +74,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -84,6 +86,7 @@
     <Compile Include="PortionedMemoryStream.cs" />
     <Compile Include="AbstractByteBufferTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PooledBufferAllocatorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/test/DotNetty.Buffers.Tests/PooledBufferAllocatorTests.cs
+++ b/test/DotNetty.Buffers.Tests/PooledBufferAllocatorTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Buffers.Tests
+{
+    using Xunit;
+
+    public class PooledBufferAllocatorTests
+    {
+        [Theory]
+        [InlineData(16 * 1024, 10, new[] {16 * 1024 - 100, 8 * 1024})]
+        [InlineData(16 * 1024, 0, new[] { 16 * 1024 - 100, 8 * 1024 })]
+        [InlineData(1024, 2 * 1024, new[] { 16 * 1024 - 100, 8 * 1024 })]
+        [InlineData(1024, 0, new[] { 1024, 1 })]
+        [InlineData(1024, 0, new[] { 1024, 0, 10 * 1024 })]
+        public void PooledBufferGrowTest(int bufferSize, int startSize, int[] writeSizes)
+        {
+            var alloc = new PooledByteBufferAllocator(bufferSize, int.MaxValue);
+            IByteBuffer buffer = alloc.Buffer(startSize);
+            int wrote = 0;
+            foreach (int size in writeSizes)
+            {
+                buffer.WriteBytes(Unpooled.WrappedBuffer(new byte[size]));
+                wrote += size;
+            }
+
+            Assert.Equal(wrote, buffer.ReadableBytes);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
Fix a bug #71.

Modifications:
Set length property of a PooledByteBuffer in case of a switch of underlying array to unpooled.

Results:
PooledByteBufferAllocator can work with buffers bigger than pooled buffer's original capacity.