### PR TITLE
Hotfix: poll task from the queue.

### DIFF
--- a/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
@@ -403,11 +403,14 @@ namespace DotNetty.Common.Concurrency
                     IScheduledRunnable nextScheduledTask = this.ScheduledTaskQueue.Peek();
                     if (nextScheduledTask != null)
                     {
-                        TimeSpan wakeUpTimeout = (nextScheduledTask.Deadline - PreciseTimeSpan.FromStart).ToTimeSpan();
-                        if (this.emptyEvent.Wait(wakeUpTimeout))
+                        PreciseTimeSpan wakeupTimeout = nextScheduledTask.Deadline - PreciseTimeSpan.FromStart;
+                        if (wakeupTimeout.Ticks > 0)
                         {
-                            // woken up before the next scheduled task was due
-                            task = this.taskQueue.Dequeue();
+                            if (this.emptyEvent.Wait(wakeupTimeout.ToTimeSpan()))
+                            {
+                                // woken up before the next scheduled task was due
+                                task = this.taskQueue.Dequeue();
+                            }
                         }
                     }
                     else

--- a/src/DotNetty.Common/PreciseTimeSpan.cs
+++ b/src/DotNetty.Common/PreciseTimeSpan.cs
@@ -15,8 +15,14 @@ namespace DotNetty.Common
         readonly long ticks;
 
         PreciseTimeSpan(long ticks)
+            : this()
         {
             this.ticks = ticks;
+        }
+
+        public long Ticks
+        {
+            get { return this.ticks; }
         }
 
         public static readonly PreciseTimeSpan Zero = new PreciseTimeSpan(0);

--- a/test/DotNetty.Common.Tests/ThreadLocalPoolTest.cs
+++ b/test/DotNetty.Common.Tests/ThreadLocalPoolTest.cs
@@ -88,7 +88,7 @@ namespace DotNetty.Common.Tests
             Random rand = new Random();
             for (int i = 0; i < 50; i++)
             {
-                this.MaxCapacityTest(rand.Next((1000) + 256)); // 256 - 1256
+                this.MaxCapacityTest(rand.Next(1000) + 256); // 256 - 1256
             }
         }
 


### PR DESCRIPTION
Fixed polling task from the queue.

Motivation:

Polling task from queue is calculating timeout incorrectly.

Modifications:

Timeout calculation has been fixed

Result:

Event executer works as it should now