### PR TITLE
Fixes ByteBuffer+Stream integration, TLS neg, STEE Shutdown

### DIFF
--- a/examples/Echo.Client/Program.cs
+++ b/examples/Echo.Client/Program.cs
@@ -8,6 +8,7 @@ namespace Echo.Client
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
+    using DotNetty.Codecs;
     using DotNetty.Common.Internal.Logging;
     using DotNetty.Handlers.Tls;
     using DotNetty.Transport.Bootstrapping;
@@ -42,10 +43,12 @@ namespace Echo.Client
                             string targetHost = cert.GetNameInfo(X509NameType.DnsName, false);
                             pipeline.AddLast(TlsHandler.Client(targetHost, null, (sender, certificate, chain, errors) => true));
                         }
+                        pipeline.AddLast(new LengthFieldPrepender(2));
+                        pipeline.AddLast(new LengthFieldBasedFrameDecoder(ushort.MaxValue, 0, 2, 0, 2));
 
                         pipeline.AddLast(new EchoClientHandler());
                     }));
-                
+
                 IChannel bootstrapChannel = await bootstrap.ConnectAsync(new IPEndPoint(EchoClientSettings.Host, EchoClientSettings.Port));
 
                 Console.ReadLine();

--- a/examples/Echo.Server/Program.cs
+++ b/examples/Echo.Server/Program.cs
@@ -7,6 +7,7 @@ namespace Echo.Server
     using System.Diagnostics.Tracing;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
+    using DotNetty.Codecs;
     using DotNetty.Common.Internal.Logging;
     using DotNetty.Handlers.Logging;
     using DotNetty.Handlers.Tls;
@@ -41,6 +42,8 @@ namespace Echo.Server
                         {
                             pipeline.AddLast(TlsHandler.Server(new X509Certificate2("dotnetty.com.pfx", "password")));
                         }
+                        pipeline.AddLast(new LengthFieldPrepender(2));
+                        pipeline.AddLast(new LengthFieldBasedFrameDecoder(ushort.MaxValue, 0, 2, 0, 2));
 
                         pipeline.AddLast(new EchoServerHandler());
                     }));

--- a/src/DotNetty.Buffers/ByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/ByteBufferUtil.cs
@@ -635,10 +635,11 @@ namespace DotNetty.Buffers
             else
             {
                 IByteBuffer buffer = src.Allocator.Buffer(len);
+                Contract.Assert(buffer.HasArray, "Operation expects allocator to operate array-based buffers.");
                 try
                 {
                     buffer.WriteBytes(src, readerIndex, len);
-                    return encoding.GetString(buffer.Array, 0, len);
+                    return encoding.GetString(buffer.Array, buffer.ArrayOffset, len);
                 }
                 finally
                 {

--- a/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
@@ -148,7 +148,7 @@ namespace DotNetty.Buffers
 
         public override IByteBuffer GetBytes(int index, Stream destination, int length)
         {
-            destination.Write(this.Array, this.ArrayOffset + this.ReaderIndex, this.ReadableBytes);
+            destination.Write(this.Array, this.ArrayOffset + index, length);
             return this;
         }
 

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -247,7 +247,7 @@ namespace DotNetty.Handlers.Tls
                 this.state = oldState | State.Authenticating;
                 if (this.isServer)
                 {
-                    this.sslStream.AuthenticateAsServerAsync(this.certificate) // todo: change to begin/end
+                    this.sslStream.AuthenticateAsServerAsync(this.certificate, false, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false) // todo: change to begin/end
                         .ContinueWith(AuthenticationCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);
                 }
                 else

--- a/test/DotNetty.Common.Tests/Concurrency/SingleThreadEventExecutorTests.cs
+++ b/test/DotNetty.Common.Tests/Concurrency/SingleThreadEventExecutorTests.cs
@@ -118,6 +118,21 @@ namespace DotNetty.Common.Tests.Concurrency
             Assert.True(task.IsCompleted);
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(200)]
+        public async Task ShutdownWhileIdle(int delayInMs)
+        {
+            var scheduler = new SingleThreadEventExecutor("test", TimeSpan.FromMilliseconds(10));
+            if (delayInMs > 0)
+            {
+                Thread.Sleep(delayInMs);
+            }
+            Task shutdownTask = scheduler.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(50), TimeSpan.FromSeconds(1));
+            await Task.WhenAny(shutdownTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.True(shutdownTask.IsCompleted);
+        }
+
         class Container<T>
         {
             public T Value;

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -21,6 +21,7 @@
     <NuGetPackageImportStamp>8624fbb3</NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Motivation:
Fix up top priority issues to ensure proper working state with recent changes.

Modifications:
- TlsHandler negotiates TLS 1.0+ on server side (#89)
- STEE properly supports graceful shutdown (#7)
- UnpooledHeapByteBuffer.GetBytes honors received index and length (#88)
- Echo E2E test uses length-prefix based framing (#90)

Result:
Setting up DotNetty does not require workarounds for shutdown and hacks to enable negotiation of higher versions of TLS. Tests are passing even with new SslStream behavior.