### PR TITLE
added NBench support + End2End performance spec for TcpSocketChannel

### DIFF
--- a/DotNetty.sln
+++ b/DotNetty.sln
@@ -55,6 +55,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Microbench", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Tests.Common", "test\DotNetty.Tests.Common\DotNetty.Tests.Common.csproj", "{EDF30087-8B53-4432-84B8-D21BD9F49E95}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Transport.Tests.Performance", "test\DotNetty.Transport.Tests.Performance\DotNetty.Transport.Tests.Performance.csproj", "{F2C39894-476D-441D-878F-23A03B848E06}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -150,6 +152,12 @@ Global
 		{EDF30087-8B53-4432-84B8-D21BD9F49E95}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EDF30087-8B53-4432-84B8-D21BD9F49E95}.Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{EDF30087-8B53-4432-84B8-D21BD9F49E95}.Signed|Any CPU.Build.0 = Release|Any CPU
+		{F2C39894-476D-441D-878F-23A03B848E06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2C39894-476D-441D-878F-23A03B848E06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2C39894-476D-441D-878F-23A03B848E06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2C39894-476D-441D-878F-23A03B848E06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2C39894-476D-441D-878F-23A03B848E06}.Signed|Any CPU.ActiveCfg = Release|Any CPU
+		{F2C39894-476D-441D-878F-23A03B848E06}.Signed|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -172,5 +180,6 @@ Global
 		{BA163586-F875-4488-9188-53A4A14DFD34} = {2F51997C-2026-47CC-A4F8-7560BEC4D918}
 		{D0D45DCD-EF82-43FA-8B95-D85D50378806} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 		{EDF30087-8B53-4432-84B8-D21BD9F49E95} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
+		{F2C39894-476D-441D-878F-23A03B848E06} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 	EndGlobalSection
 EndGlobal

--- a/build.cmd
+++ b/build.cmd
@@ -22,6 +22,7 @@ copy %CACHED_NUGET% .nuget\nuget.exe > nul
 .nuget\NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -Version 4.25.4
 
 .nuget\NuGet.exe install xunit.runner.console -OutputDirectory packages\FAKE -ExcludeVersion -Version 2.1.0
+.nuget\NuGet.exe install NBench.Runner -OutputDirectory packages -ExcludeVersion -Version 0.2.1
 
 if not exist packages\SourceLink.Fake\tools\SourceLink.fsx ( 
   .nuget\nuget.exe install SourceLink.Fake -OutputDirectory packages -ExcludeVersion

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,8 @@ mono $SCRIPT_PATH/.nuget/nuget.exe update -self
 
 mono $SCRIPT_PATH/.nuget/nuget.exe install FAKE -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion -Version 4.25.4
 
-mono $SCRIPT_PATH/.nuget/nuget.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/packages/FAKE -ExcludeVersion -Version 2.0.0
+mono $SCRIPT_PATH/.nuget/nuget.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/packages/FAKE -ExcludeVersion -Version 2.1.0
+mono $SCRIPT_PATH/.nuget/nuget.exe install NBench.Runner -OutputDirectory packages -ExcludeVersion -Version 0.2.1
 
 if ! [ -e $SCRIPT_PATH/packages/SourceLink.Fake/tools/SourceLink.fsx ] ; then
 	mono $SCRIPT_PATH/.nuget/nuget.exe install SourceLink.Fake -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion

--- a/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
+++ b/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
@@ -96,6 +96,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/test/DotNetty.Common.Tests/ResourceLeakDetectorTest.cs
+++ b/test/DotNetty.Common.Tests/ResourceLeakDetectorTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -22,3 +25,4 @@ namespace DotNetty.Common.Tests
         }
     }
 }
+

--- a/test/DotNetty.Common.Tests/app.config
+++ b/test/DotNetty.Common.Tests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/DotNetty.Tests.Common/app.config
+++ b/test/DotNetty.Tests.Common/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -121,6 +121,7 @@
       <Link>dotnetty.com.pfx</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="app.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/test/DotNetty.Tests.End2End/app.config
+++ b/test/DotNetty.Tests.End2End/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
+++ b/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
@@ -1,15 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{EDF30087-8B53-4432-84B8-D21BD9F49E95}</ProjectGuid>
+    <ProjectGuid>{F2C39894-476D-441D-878F-23A03B848E06}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DotNetty.Tests.Common</RootNamespace>
-    <AssemblyName>DotNetty.Tests.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>DotNetty.Transport.Tests.Performance</RootNamespace>
+    <AssemblyName>DotNetty.Transport.Tests.Performance</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -17,9 +16,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,27 +35,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.2.0.1406.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NBench, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NBench.0.2.1\lib\net45\NBench.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -67,32 +48,39 @@
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestBase.cs" />
-    <Compile Include="TestScenarioRunner.cs" />
-    <Compile Include="TestScenarioStep.cs" />
-    <Compile Include="XUnitOutputSink.cs" />
+    <Compile Include="Sockets\TcpSocketChannelPerfSpec.cs" />
+    <Compile Include="Utilities\CounterHandlerInbound.cs" />
+    <Compile Include="Utilities\CounterHandlerOutbound.cs" />
+    <Compile Include="Utilities\IReadFinishedSignal.cs" />
+    <Compile Include="Utilities\ManualResetEventSlimReadFinishedSignal.cs" />
+    <Compile Include="Utilities\ReadFinishedHandler.cs" />
+    <Compile Include="Utilities\SimpleReadFinishedSignal.cs" />
+    <Compile Include="Utilities\TaskCompletionSourceFinishedSignal.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
+      <Project>{5de3c557-48bf-4cdb-9f47-474d343dd841}</Project>
+      <Name>DotNetty.Buffers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Codecs\DotNetty.Codecs.csproj">
+      <Project>{2abd244e-ef8f-460d-9c30-39116499e6e4}</Project>
+      <Name>DotNetty.Codecs</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj">
-      <Project>{DE58FE41-5E99-44E5-86BC-FC9ED8761DAF}</Project>
+      <Project>{de58fe41-5e99-44e5-86bc-fc9ed8761daf}</Project>
       <Name>DotNetty.Common</Name>
     </ProjectReference>
     <ProjectReference Include="..\..\src\DotNetty.Transport\DotNetty.Transport.csproj">
-      <Project>{8218C9EE-0A4A-432F-A12A-B54202F97B05}</Project>
+      <Project>{8218c9ee-0a4a-432f-a12a-b54202f97b05}</Project>
       <Name>DotNetty.Transport</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
@@ -114,12 +102,6 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/DotNetty.Transport.Tests.Performance/Properties/AssemblyInfo.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("DotNetty.Transport.Tests.Performance")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DotNetty.Transport.Tests.Performance")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("f2c39894-476d-441d-878f-23a03b848e06")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelPerfSpec.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelPerfSpec.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Sockets
+{
+    using System;
+    using System.Net;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DotNetty.Buffers;
+    using DotNetty.Codecs;
+    using DotNetty.Transport.Bootstrapping;
+    using DotNetty.Transport.Channels;
+    using DotNetty.Transport.Channels.Sockets;
+    using DotNetty.Transport.Tests.Performance.Utilities;
+    using NBench;
+
+    public class TcpChannelPerfSpecs
+    {
+        const string InboundThroughputCounterName = "inbound ops";
+
+        const string OutboundThroughputCounterName = "outbound ops";
+
+        // The number of times we're going to warmup + run each benchmark
+        public const int IterationCount = 5;
+        public const int WriteCount = 1000000;
+
+        public const int MessagesPerMinute = 1000000;
+        public TimeSpan Timeout = TimeSpan.FromMinutes((double)WriteCount / MessagesPerMinute);
+
+        static readonly IPEndPoint TEST_ADDRESS = new IPEndPoint(IPAddress.IPv6Loopback, 0);
+        protected readonly ManualResetEventSlim ResetEvent = new ManualResetEventSlim(false);
+        IChannel clientChannel;
+        Counter inboundThroughputCounter;
+        Counter outboundThroughputCounter;
+
+        IChannel serverChannel;
+        IReadFinishedSignal signal;
+
+        protected Bootstrap ClientBootstrap;
+
+        protected IEventLoopGroup ClientGroup;
+
+        byte[] message;
+        protected ServerBootstrap ServerBoostrap;
+        protected IEventLoopGroup ServerGroup;
+        protected IEventLoopGroup WorkerGroup;
+
+        IByteBufferAllocator serverBufferAllocator;
+        IByteBufferAllocator clientBufferAllocator;
+
+        static TcpChannelPerfSpecs()
+        {
+            // Disable the logging factory
+            //LoggingFactory.DefaultFactory = new NoOpLoggerFactory();
+        }
+
+        protected virtual IChannelHandler GetEncoder()
+        {
+            return new LengthFieldPrepender(4, false);
+        }
+
+        protected virtual IChannelHandler GetDecoder()
+        {
+            return new LengthFieldBasedFrameDecoder(int.MaxValue, 0, 4, 0, 4);
+        }
+
+        [PerfSetup]
+        public void SetUp(BenchmarkContext context)
+        {
+            this.ClientGroup = new MultithreadEventLoopGroup(1);
+            this.ServerGroup = new MultithreadEventLoopGroup(1);
+            this.WorkerGroup = new MultithreadEventLoopGroup();
+
+            Encoding iso = Encoding.GetEncoding("ISO-8859-1");
+            this.message = iso.GetBytes("ABC");
+
+            this.inboundThroughputCounter = context.GetCounter(InboundThroughputCounterName);
+            this.outboundThroughputCounter = context.GetCounter(OutboundThroughputCounterName);
+            var counterHandler = new CounterHandlerInbound(this.inboundThroughputCounter);
+            this.signal = new ManualResetEventSlimReadFinishedSignal(this.ResetEvent);
+
+            // reserve up to 10mb of 16kb buffers on both client and server; we're only sending about 700k worth of messages
+            this.serverBufferAllocator = new PooledByteBufferAllocator(256, 10 * 1024 * 1024 / Environment.ProcessorCount);
+            this.clientBufferAllocator = new PooledByteBufferAllocator(256, 10 * 1024 * 1024 / Environment.ProcessorCount);
+
+            ServerBootstrap sb = new ServerBootstrap()
+                .Group(this.ServerGroup, this.WorkerGroup)
+                .Channel<TcpServerSocketChannel>()
+                .ChildOption(ChannelOption.Allocator, this.serverBufferAllocator)
+                .ChildHandler(new ActionChannelInitializer<TcpSocketChannel>(channel => {
+                    channel.Pipeline
+                    .AddLast(this.GetEncoder())
+                    .AddLast(this.GetDecoder())
+                    .AddLast(counterHandler)
+                    .AddLast(new CounterHandlerOutbound(this.outboundThroughputCounter))
+                    .AddLast(new ReadFinishedHandler(this.signal, WriteCount));
+                }));
+
+            Bootstrap cb = new Bootstrap()
+                .Group(this.ClientGroup)
+                .Channel<TcpSocketChannel>()
+                .Option(ChannelOption.Allocator, this.clientBufferAllocator)
+                .Handler(new ActionChannelInitializer<TcpSocketChannel>(
+                channel =>
+                {
+                    channel.Pipeline
+                    .AddLast(this.GetEncoder())
+                    .AddLast(this.GetDecoder())
+                    .AddLast(counterHandler)
+                    .AddLast(new CounterHandlerOutbound(this.outboundThroughputCounter));
+                }));
+
+            // start server
+            this.serverChannel = sb.BindAsync(TEST_ADDRESS).Result;
+
+            // connect to server
+            this.clientChannel = cb.ConnectAsync(this.serverChannel.LocalAddress).Result;
+        }
+
+        [PerfBenchmark(Description = "Measures how quickly and with how much GC overhead a TcpSocketChannel --> TcpServerSocketChannel connection can decode / encode realistic messages, 100 writes per flush",
+            NumberOfIterations = IterationCount, RunMode = RunMode.Iterations)]
+        [CounterMeasurement(InboundThroughputCounterName)]
+        [CounterMeasurement(OutboundThroughputCounterName)]
+        [GcMeasurement(GcMetric.TotalCollections, GcGeneration.AllGc)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        public void TcpChannel_Duplex_Throughput_100_messages_per_flush(BenchmarkContext context)
+        {
+            for (int i = 0; i < WriteCount; i++)
+            {
+                this.clientChannel.WriteAsync(Unpooled.WrappedBuffer(this.message));
+                if (i % 100 == 0) // flush every 100 writes
+                {
+                    this.clientChannel.Flush();
+                }
+            }
+            this.clientChannel.Flush();
+            this.ResetEvent.Wait(this.Timeout);
+        }
+
+        [PerfCleanup]
+        public void TearDown()
+        {
+            CloseChannel(this.clientChannel);
+            CloseChannel(this.serverChannel);
+            Task.WaitAll(this.ClientGroup.ShutdownGracefullyAsync(), this.ServerGroup.ShutdownGracefullyAsync(), this.WorkerGroup.ShutdownGracefullyAsync());
+        }
+
+        static void CloseChannel(IChannel cc)
+        {
+            cc?.CloseAsync().Wait();
+        }
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/CounterHandlerInbound.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/CounterHandlerInbound.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Utilities
+{
+    using DotNetty.Transport.Channels;
+    using NBench;
+
+    class CounterHandlerInbound : ChannelHandlerAdapter
+    {
+        readonly Counter throughput;
+
+        public CounterHandlerInbound(Counter throughput)
+        {
+            this.throughput = throughput;
+        }
+
+        public override void ChannelRead(IChannelHandlerContext context, object message)
+        {
+            this.throughput.Increment();
+            context.FireChannelRead(message);
+        }
+
+        public override bool IsSharable
+        {
+           get { return true; }
+        }
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/CounterHandlerOutbound.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/CounterHandlerOutbound.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Utilities
+{
+    using System.Threading.Tasks;
+    using DotNetty.Transport.Channels;
+    using NBench;
+
+    class CounterHandlerOutbound : ChannelHandlerAdapter
+    {
+        readonly Counter throughput;
+
+        public CounterHandlerOutbound(Counter throughput)
+        {
+            this.throughput = throughput;
+        }
+
+        public override Task WriteAsync(IChannelHandlerContext context, object message)
+        {
+            this.throughput.Increment();
+            return context.WriteAsync(message);
+        }
+        public override bool IsSharable
+        {
+            get { return true; }
+        }
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/IReadFinishedSignal.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/IReadFinishedSignal.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Utilities
+{
+    public interface IReadFinishedSignal
+    {
+        bool Finished { get; }
+
+        void Signal();
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/ManualResetEventSlimReadFinishedSignal.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/ManualResetEventSlimReadFinishedSignal.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Utilities
+{
+    using System.Threading;
+
+    public class ManualResetEventSlimReadFinishedSignal : IReadFinishedSignal
+    {
+        readonly ManualResetEventSlim manualResetEventSlim;
+
+        public ManualResetEventSlimReadFinishedSignal(ManualResetEventSlim manualResetEventSlim)
+        {
+            this.manualResetEventSlim = manualResetEventSlim;
+        }
+
+        public void Signal()
+        {
+            this.manualResetEventSlim.Set();
+        }
+
+        public bool Finished => this.manualResetEventSlim.IsSet;
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/ReadFinishedHandler.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/ReadFinishedHandler.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Utilities
+{
+    using DotNetty.Transport.Channels;
+
+    public class ReadFinishedHandler : ChannelHandlerAdapter
+    {
+        readonly int expectedReads;
+        readonly IReadFinishedSignal signal;
+        int actualReads;
+
+        public ReadFinishedHandler(IReadFinishedSignal signal, int expectedReads)
+        {
+            this.signal = signal;
+            this.expectedReads = expectedReads;
+        }
+
+        public override void ChannelRead(IChannelHandlerContext context, object message)
+        {
+            if (++this.actualReads == this.expectedReads)
+            {
+                this.signal.Signal();
+            }
+            context.FireChannelRead(message);
+        }
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/SimpleReadFinishedSignal.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/SimpleReadFinishedSignal.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Utilities
+{
+    public class SimpleReadFinishedSignal : IReadFinishedSignal
+    {
+        public void Signal()
+        {
+            this.Finished = true;
+        }
+
+        public bool Finished { get; private set; }
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/TaskCompletionSourceFinishedSignal.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/TaskCompletionSourceFinishedSignal.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Utilities
+{
+    using DotNetty.Common.Concurrency;
+
+    public class TaskCompletionSourceFinishedSignal : IReadFinishedSignal
+    {
+        readonly TaskCompletionSource tcs;
+
+        public TaskCompletionSourceFinishedSignal(TaskCompletionSource tcs)
+        {
+            this.tcs = tcs;
+        }
+
+        public void Signal()
+        {
+            this.tcs.TryComplete();
+        }
+
+        public bool Finished => this.tcs.Task.IsCompleted;
+    }
+}
+

--- a/test/DotNetty.Transport.Tests.Performance/packages.config
+++ b/test/DotNetty.Transport.Tests.Performance/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<packages>
+  <package id="NBench" version="0.2.1" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Added NBench support to the build scripts, a sample NBench project, and a port of a benchmark I wrote for Helios that measures duplex end-to-end performance using a realistic encoding pipeline.