### PR TITLE
added inbound only TcpSocketChannel benchmark

### DIFF
--- a/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
+++ b/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
@@ -52,6 +52,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Sockets\TcpSocketChannelInboundOnlyPerfSpec.cs" />
     <Compile Include="Sockets\TcpSocketChannelPerfSpec.cs" />
     <Compile Include="Utilities\CounterHandlerInbound.cs" />
     <Compile Include="Utilities\CounterHandlerOutbound.cs" />

--- a/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelInboundOnlyPerfSpec.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelInboundOnlyPerfSpec.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Transport.Tests.Performance.Sockets
+{
+    using System;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DotNetty.Buffers;
+    using DotNetty.Codecs;
+    using DotNetty.Transport.Bootstrapping;
+    using DotNetty.Transport.Channels;
+    using DotNetty.Transport.Channels.Sockets;
+    using DotNetty.Transport.Tests.Performance.Utilities;
+    using NBench;
+
+    public class TcpSocketChannelInboundOnlyPerfSpecs
+    {
+        const string InboundThroughputCounterName = "inbound ops";
+
+        const string OutboundThroughputCounterName = "outbound ops";
+
+        // The number of times we're going to warmup + run each benchmark
+        public const int IterationCount = 5;
+        public const int WriteCount = 1000000;
+
+        public const int MessagesPerMinute = 1000000;
+        public TimeSpan Timeout = TimeSpan.FromMinutes((double)WriteCount / MessagesPerMinute);
+
+        static readonly IPEndPoint TEST_ADDRESS = new IPEndPoint(IPAddress.IPv6Loopback, 0);
+        protected readonly ManualResetEventSlim ResetEvent = new ManualResetEventSlim(false);
+        Counter inboundThroughputCounter;
+        Counter outboundThroughputCounter;
+
+        IChannel serverChannel;
+        IReadFinishedSignal signal;
+
+        protected System.Net.Sockets.Socket ClientSocket;
+        protected NetworkStream Stream;
+
+        byte[] message;
+        protected ServerBootstrap ServerBoostrap;
+        protected IEventLoopGroup ServerGroup;
+        protected IEventLoopGroup WorkerGroup;
+
+        IByteBufferAllocator serverBufferAllocator;
+
+        static TcpSocketChannelInboundOnlyPerfSpecs()
+        {
+            // Disable the logging factory
+            //LoggingFactory.DefaultFactory = new NoOpLoggerFactory();
+        }
+
+        protected virtual IChannelHandler GetEncoder()
+        {
+            return new LengthFieldPrepender(4, false);
+        }
+
+        protected virtual IChannelHandler GetDecoder()
+        {
+            return new LengthFieldBasedFrameDecoder(int.MaxValue, 0, 4, 0, 4);
+        }
+
+        [PerfSetup]
+        public void SetUp(BenchmarkContext context)
+        {
+            this.ServerGroup = new MultithreadEventLoopGroup(1);
+            this.WorkerGroup = new MultithreadEventLoopGroup();
+
+            Encoding iso = Encoding.GetEncoding("ISO-8859-1");
+            this.message = Unpooled.Buffer().WriteInt(3).WriteBytes(iso.GetBytes("ABC")).ToArray();
+
+            this.inboundThroughputCounter = context.GetCounter(InboundThroughputCounterName);
+            this.outboundThroughputCounter = context.GetCounter(OutboundThroughputCounterName);
+            var counterHandler = new CounterHandlerInbound(this.inboundThroughputCounter);
+            this.signal = new ManualResetEventSlimReadFinishedSignal(this.ResetEvent);
+
+            // using default settings
+            this.serverBufferAllocator = new PooledByteBufferAllocator();
+
+            ServerBootstrap sb = new ServerBootstrap()
+                .Group(this.ServerGroup, this.WorkerGroup)
+                .Channel<TcpServerSocketChannel>()
+                .ChildOption(ChannelOption.Allocator, this.serverBufferAllocator)
+                .ChildHandler(new ActionChannelInitializer<TcpSocketChannel>(channel => {
+                    channel.Pipeline
+                    .AddLast(this.GetEncoder())
+                    .AddLast(this.GetDecoder())
+                    .AddLast(counterHandler)
+                    .AddLast(new CounterHandlerOutbound(this.outboundThroughputCounter))
+                    .AddLast(new ReadFinishedHandler(this.signal, WriteCount));
+                }));
+
+            // start server
+            this.serverChannel = sb.BindAsync(TEST_ADDRESS).Result;
+
+            // connect to server
+            var address = (IPEndPoint)this.serverChannel.LocalAddress;
+            this.ClientSocket = new System.Net.Sockets.Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+            this.ClientSocket.Connect(address.Address, address.Port);
+
+            this.Stream = new NetworkStream(this.ClientSocket, true);
+        }
+
+        [PerfBenchmark(Description = "Measures how quickly and with how much GC overhead a TcpSocketChannel --> TcpServerSocketChannel connection can decode / encode realistic messages, 100 writes per flush",
+            NumberOfIterations = IterationCount, RunMode = RunMode.Iterations)]
+        [CounterMeasurement(InboundThroughputCounterName)]
+        [CounterMeasurement(OutboundThroughputCounterName)]
+        [GcMeasurement(GcMetric.TotalCollections, GcGeneration.AllGc)]
+        [MemoryMeasurement(MemoryMetric.TotalBytesAllocated)]
+        public void TcpChannel_InboundOnly_Throughput(BenchmarkContext context)
+        {
+            for (int i = 0; i < WriteCount; i++)
+            {
+                this.Stream.Write(this.message, 0, this.message.Length);
+            }
+            this.ResetEvent.Wait(this.Timeout);
+        }
+
+        [PerfCleanup]
+        public void TearDown()
+        {
+            try
+            {
+                this.Stream.Close();
+            }
+            finally
+            {
+                CloseChannel(this.serverChannel);
+                Task.WaitAll(this.ServerGroup.ShutdownGracefullyAsync(), this.WorkerGroup.ShutdownGracefullyAsync());
+            }
+        }
+
+        static void CloseChannel(IChannel cc)
+        {
+            cc?.CloseAsync().Wait();
+        }
+    }
+}
+


### PR DESCRIPTION
Uses a basic tcp `Socket` and `NetworkStream` to write to an inbound `TcpServerSocketChannel` to measure read-only performance.