### PR TITLE
Adds Schedule support for IRunnable actions.

### DIFF
--- a/src/DotNetty.Common/Concurrency/AbstractEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/AbstractEventExecutor.cs
@@ -52,6 +52,11 @@ namespace DotNetty.Common.Concurrency
             this.Execute(new ActionTaskQueueNode(action));
         }
 
+        public virtual IScheduledTask Schedule(IRunnable action, TimeSpan delay)
+        {
+            throw new NotSupportedException();
+        }
+
         public virtual IScheduledTask Schedule(Action action, TimeSpan delay)
         {
             throw new NotSupportedException();

--- a/src/DotNetty.Common/Concurrency/AbstractScheduledEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/AbstractScheduledEventExecutor.cs
@@ -92,23 +92,38 @@ namespace DotNetty.Common.Concurrency
             return scheduledTask != null && scheduledTask.Deadline <= PreciseTimeSpan.FromStart;
         }
 
+        public override IScheduledTask Schedule(IRunnable action, TimeSpan delay)
+        {
+            Contract.Requires(action != null);
+
+            return this.Schedule(new RunnableScheduledTask(this, action, PreciseTimeSpan.Deadline(delay)));
+        }
+
         public override IScheduledTask Schedule(Action action, TimeSpan delay)
         {
+            Contract.Requires(action != null);
+
             return this.Schedule(new ActionScheduledTask(this, action, PreciseTimeSpan.Deadline(delay)));
         }
 
         public override IScheduledTask Schedule(Action<object> action, object state, TimeSpan delay)
         {
+            Contract.Requires(action != null);
+
             return this.Schedule(new StateActionScheduledTask(this, action, state, PreciseTimeSpan.Deadline(delay)));
         }
 
         public override IScheduledTask Schedule(Action<object, object> action, object context, object state, TimeSpan delay)
         {
+            Contract.Requires(action != null);
+
             return this.Schedule(new StateActionWithContextScheduledTask(this, action, context, state, PreciseTimeSpan.Deadline(delay)));
         }
 
         public override Task ScheduleAsync(Action action, TimeSpan delay, CancellationToken cancellationToken)
         {
+            Contract.Requires(action != null);
+
             if (cancellationToken.IsCancellationRequested)
             {
                 return TaskEx.Cancelled;

--- a/src/DotNetty.Common/Concurrency/IEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/IEventExecutor.cs
@@ -38,8 +38,7 @@ namespace DotNetty.Common.Concurrency
         ///     Returns <c>true</c> if all tasks have completed following shut down.
         /// </summary>
         /// <remarks>
-        ///     Note that <see cref="IsTerminated" /> is never <c>true</c> unless either <see cref="ShutdownGracefullyAsync()" />
-        ///     or <see cref="ShutdownNow()" /> was called first.
+        ///     Note that <see cref="IsTerminated" /> is never <c>true</c> unless <see cref="ShutdownGracefullyAsync()" /> was called first.
         /// </remarks>
         bool IsTerminated { get; }
 
@@ -48,33 +47,6 @@ namespace DotNetty.Common.Concurrency
         ///     <c>false></c> otherwise.
         /// </summary>
         bool IsInEventLoop(Thread thread);
-
-        /// <summary>
-        ///     Returns an <see cref="IEventExecutor" /> that is not an <see cref="IWrappedEventExecutor" />.
-        /// </summary>
-        /// <remarks>
-        ///     <list type="bullet">
-        ///         <item>
-        ///             <description>
-        ///                 A <see cref="IWrappedEventExecutor" /> implementing this method must return the underlying
-        ///                 <see cref="IEventExecutor" /> while making sure that it's not a <see cref="IWrappedEventExecutor" />
-        ///                 (e.g. by multiple calls to <see cref="Unwrap()" />).
-        ///             </description>
-        ///         </item>
-        ///         <item>
-        ///             <description>
-        ///                 An <see cref="IEventExecutor" /> that is not a <see cref="IWrappedEventExecutor" /> must return a
-        ///                 reference to itself.
-        ///             </description>
-        ///         </item>
-        ///         <item>
-        ///             <description>
-        ///                 This method must not return null.
-        ///             </description>
-        ///         </item>
-        ///     </list>
-        /// </remarks>
-        IEventExecutor Unwrap();
 
         /// <summary>
         ///     Executes the given task.
@@ -107,6 +79,14 @@ namespace DotNetty.Common.Concurrency
         ///     <para>Threading specifics are determined by <c>IEventExecutor</c> implementation.</para>
         /// </remarks>
         void Execute(Action<object, object> action, object context, object state);
+
+        /// <summary>
+        ///     Creates and executes a one-shot action that becomes enabled after the given delay.
+        /// </summary>
+        /// <param name="action">the task to execute</param>
+        /// <param name="delay">the time from now to delay execution</param>
+        /// <returns>an <see cref="IScheduledTask" /> representing pending completion of the task.</returns>
+        IScheduledTask Schedule(IRunnable action, TimeSpan delay);
 
         /// <summary>
         ///     Schedules the given action for execution after the specified delay would pass.

--- a/src/DotNetty.Common/Concurrency/IWrappedEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/IWrappedEventExecutor.cs
@@ -1,9 +1,0 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-namespace DotNetty.Common.Concurrency
-{
-    public interface IWrappedEventExecutor : IEventExecutor
-    {
-    }
-}

--- a/src/DotNetty.Common/Concurrency/RunnableScheduledTask.cs
+++ b/src/DotNetty.Common/Concurrency/RunnableScheduledTask.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Concurrency
+{
+    sealed class RunnableScheduledTask : ScheduledTask
+    {
+        readonly IRunnable action;
+
+        public RunnableScheduledTask(AbstractScheduledEventExecutor executor, IRunnable action, PreciseTimeSpan deadline)
+            : base(executor, deadline, new TaskCompletionSource())
+        {
+            this.action = action;
+        }
+
+        protected override void Execute() => this.action.Run();
+    }
+}

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Concurrency\ICallable`T.cs" />
     <Compile Include="Concurrency\IScheduledRunnable.cs" />
     <Compile Include="Concurrency\IScheduledTask.cs" />
+    <Compile Include="Concurrency\RunnableScheduledTask.cs" />
     <Compile Include="Concurrency\ScheduledAsyncTask.cs" />
     <Compile Include="Concurrency\ScheduledTask.cs" />
     <Compile Include="Concurrency\StateActionScheduledAsyncTask.cs" />
@@ -175,7 +176,6 @@
     <Compile Include="Concurrency\ExecutorTaskScheduler.cs" />
     <Compile Include="Concurrency\IEventExecutor.cs" />
     <Compile Include="Concurrency\IRunnable.cs" />
-    <Compile Include="Concurrency\IWrappedEventExecutor.cs" />
     <Compile Include="Concurrency\SingleThreadEventExecutor.cs" />
     <Compile Include="Concurrency\TaskCompletionSource.cs" />
     <Compile Include="Internal\Logging\AbstractInternalLogger.cs" />

--- a/src/DotNetty.Transport/Channels/DefaultChannelPipeline.cs
+++ b/src/DotNetty.Transport/Channels/DefaultChannelPipeline.cs
@@ -473,7 +473,7 @@ namespace DotNetty.Transport.Channels
             IEventExecutor executor;
             bool inEventLoop;
 
-            lock (this.head)
+            lock (this)
             {
                 CheckMultiplicity(newHandler);
 
@@ -788,7 +788,7 @@ namespace DotNetty.Transport.Channels
                 IEventExecutor executor = ctx.Executor;
                 if (!inEventLoop && !executor.IsInEventLoop(currentThread))
                 {
-                    executor.Unwrap().Execute((self, c) => ((DefaultChannelPipeline)self).DestroyUp((AbstractChannelHandlerContext)c, true), this, ctx);
+                    executor.Execute((self, c) => ((DefaultChannelPipeline)self).DestroyUp((AbstractChannelHandlerContext)c, true), this, ctx);
                     break;
                 }
 
@@ -811,7 +811,7 @@ namespace DotNetty.Transport.Channels
                 IEventExecutor executor = ctx.Executor;
                 if (inEventLoop || executor.IsInEventLoop(currentThread))
                 {
-                    lock (this.head)
+                    lock (this)
                     {
                         Remove0(ctx);
                         this.CallHandlerRemoved0(ctx);
@@ -819,7 +819,7 @@ namespace DotNetty.Transport.Channels
                 }
                 else
                 {
-                    executor.Unwrap().Execute((self, c) => ((DefaultChannelPipeline)self).DestroyDown(Thread.CurrentThread, (AbstractChannelHandlerContext)c, true), this, ctx);
+                    executor.Execute((self, c) => ((DefaultChannelPipeline)self).DestroyDown(Thread.CurrentThread, (AbstractChannelHandlerContext)c, true), this, ctx);
                     break;
                 }
 

--- a/src/DotNetty.Transport/Channels/Embedded/EmbeddedEventLoop.cs
+++ b/src/DotNetty.Transport/Channels/Embedded/EmbeddedEventLoop.cs
@@ -40,11 +40,6 @@ namespace DotNetty.Transport.Channels.Embedded
             return true;
         }
 
-        IEventExecutor IEventExecutor.Unwrap()
-        {
-            return this.Unwrap();
-        }
-
         public override void Execute(IRunnable command)
         {
             if (command == null)


### PR DESCRIPTION
Motivation:
Improving support for future porting efforts relying on special implementations of `IRunnable` tasks.

Modifications:
- Added `IEventExecutor.Schedule(IRunnable, TimeSpan)` overload
- Extra: cleaning out `IEventExecutor.Unwrap` and related `IWrappedEventExecutor`.
- Extra: fixing synchronization in `DefaultChannelPipeline`'s `Replace` and `DestroyDown` methods.

Result:
Better support for `IRunnable` implementations in execution model.