### PR TITLE
Enables multi-buffer send in TcpSocketChannel. Remove constraints on …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ TestResults/
 .nuget/
 .fake/
 _ReSharper.*/
+.idea/
+*.sln.iml
 packages/
 artifacts/
 PublishProfiles/

--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -668,6 +668,16 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public abstract int IoBufferCount { get; }
+
+        public ArraySegment<byte> GetIoBuffer() => this.GetIoBuffer(this.ReaderIndex, this.ReadableBytes);
+
+        public abstract ArraySegment<byte> GetIoBuffer(int index, int length);
+
+        public ArraySegment<byte>[] GetIoBuffers() => this.GetIoBuffers(this.ReaderIndex, this.ReadableBytes);
+
+        public abstract ArraySegment<byte>[] GetIoBuffers(int index, int length);
+
         public async Task WriteBytesAsync(Stream stream, int length, CancellationToken cancellationToken)
         {
             this.EnsureAccessible();

--- a/src/DotNetty.Buffers/AbstractDerivedByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractDerivedByteBuffer.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Buffers
 {
+    using System;
     using DotNetty.Common;
 
     /// <summary>
@@ -45,5 +46,7 @@ namespace DotNetty.Buffers
         public sealed override bool Release() => this.Unwrap().Release();
 
         public sealed override bool Release(int decrement) => this.Unwrap().Release(decrement);
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length) => this.Unwrap().GetIoBuffer(index, length);
     }
 }

--- a/src/DotNetty.Buffers/ByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/ByteBufferUtil.cs
@@ -542,7 +542,7 @@ namespace DotNetty.Buffers
         }
 
         /// <summary>
-        ///     Encode the given <see cref="CharBuffer" /> using the given <see cref="Encoding" /> into a new
+        ///     Encode the given <see cref="string" /> using the given <see cref="Encoding" /> into a new
         ///     <see cref="IByteBuffer" /> which
         ///     is allocated via the <see cref="IByteBufferAllocator" />.
         /// </summary>
@@ -552,7 +552,7 @@ namespace DotNetty.Buffers
         public static IByteBuffer EncodeString(IByteBufferAllocator alloc, string src, Encoding encoding) => EncodeString0(alloc, src, encoding, 0);
 
         /// <summary>
-        ///     Encode the given <see cref="CharBuffer" /> using the given <see cref="Encoding" /> into a new
+        ///     Encode the given <see cref="string" /> using the given <see cref="Encoding" /> into a new
         ///     <see cref="IByteBuffer" /> which
         ///     is allocated via the <see cref="IByteBufferAllocator" />.
         /// </summary>
@@ -572,8 +572,8 @@ namespace DotNetty.Buffers
 
             try
             {
-                encoding.GetBytes(src, 0, src.Length, dst.Array, dst.ArrayOffset);
-                dst.SetWriterIndex(length);
+                int written = encoding.GetBytes(src, 0, src.Length, dst.Array, dst.ArrayOffset + dst.WriterIndex);
+                dst.SetWriterIndex(dst.WriterIndex + written);
                 release = false;
 
                 return dst;

--- a/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
+++ b/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Buffers
 {
+    using System;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
@@ -155,6 +156,10 @@ namespace DotNetty.Buffers
         {
             return this.buffer.SetBytesAsync(index, src, length, cancellationToken);
         }
+
+        public override int IoBufferCount => this.Unwrap().IoBufferCount;
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length) => this.Unwrap().GetIoBuffers(index, length);
 
         public override bool HasArray => this.buffer.HasArray;
 

--- a/src/DotNetty.Buffers/EmptyByteBuffer.cs
+++ b/src/DotNetty.Buffers/EmptyByteBuffer.cs
@@ -17,6 +17,9 @@ namespace DotNetty.Buffers
     /// </summary>
     public sealed class EmptyByteBuffer : IByteBuffer
     {
+        static readonly ArraySegment<byte> EmptyBuffer = new ArraySegment<byte>(ArrayExtensions.ZeroBytes);
+        static readonly ArraySegment<byte>[] EmptyBuffers = { EmptyBuffer };
+
         readonly IByteBufferAllocator allocator;
         readonly ByteOrder order;
         readonly string str;
@@ -455,6 +458,24 @@ namespace DotNetty.Buffers
         public IByteBuffer WriteBytes(byte[] src, int srcIndex, int length)
         {
             return this.CheckLength(length);
+        }
+
+        public int IoBufferCount => 1;
+
+        public ArraySegment<byte> GetIoBuffer() => EmptyBuffer;
+
+        public ArraySegment<byte> GetIoBuffer(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            return this.GetIoBuffer();
+        }
+
+        public ArraySegment<byte>[] GetIoBuffers() => EmptyBuffers;
+
+        public ArraySegment<byte>[] GetIoBuffers(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            return this.GetIoBuffers();
         }
 
         public bool HasArray => true;

--- a/src/DotNetty.Buffers/IByteBuffer.cs
+++ b/src/DotNetty.Buffers/IByteBuffer.cs
@@ -580,7 +580,7 @@ namespace DotNetty.Buffers
         ///     non-writable and increases the <see cref="ReaderIndex" /> by the number of transferred bytes.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if <see cref="destination.WritableBytes" /> is greater than
+        ///     if <c>destination.<see cref="WritableBytes" /></c> is greater than
         ///     <see cref="ReadableBytes" />.
         /// </exception>
         IByteBuffer ReadBytes(IByteBuffer destination);
@@ -628,6 +628,90 @@ namespace DotNetty.Buffers
         IByteBuffer WriteBytes(byte[] src);
 
         IByteBuffer WriteBytes(byte[] src, int srcIndex, int length);
+
+        /// <summary>
+        ///     Returns the maximum <see cref="ArraySegment{T}" /> of <see cref="Byte" /> that this buffer holds. Note that
+        ///     <see cref="GetIoBuffers()" />
+        ///     or <see cref="GetIoBuffers(int,int)" /> might return a less number of <see cref="ArraySegment{T}" />s of
+        ///     <see cref="Byte" />.
+        /// </summary>
+        /// <returns>
+        ///     <c>-1</c> if this buffer cannot represent its content as <see cref="ArraySegment{T}" /> of <see cref="Byte" />.
+        ///     the number of the underlying {@link ByteBuffer}s if this buffer has at least one underlying segment.
+        ///     Note that this method does not return <c>0</c> to avoid confusion.
+        /// </returns>
+        /// <seealso cref="GetIoBuffer()" />
+        /// <seealso cref="GetIoBuffer(int,int)" />
+        /// <seealso cref="GetIoBuffers()" />
+        /// <seealso cref="GetIoBuffers(int,int)" />
+        int IoBufferCount { get; }
+
+        /// <summary>
+        ///     Exposes this buffer's readable bytes as an <see cref="ArraySegment{T}" /> of <see cref="Byte" />. Returned segment
+        ///     shares the content with this buffer. This method is identical
+        ///     to <c>buf.GetIoBuffer(buf.ReaderIndex, buf.ReadableBytes)</c>. This method does not
+        ///     modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.  Please note that the
+        ///     returned segment will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content as <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffers()" />
+        /// <seealso cref="GetIoBuffers(int,int)" />
+        ArraySegment<byte> GetIoBuffer();
+
+        /// <summary>
+        ///     Exposes this buffer's sub-region as an <see cref="ArraySegment{T}" /> of <see cref="Byte" />. Returned segment
+        ///     shares the content with this buffer. This method does not
+        ///     modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer. Please note that the
+        ///     returned segment will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content as <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffers()" />
+        /// <seealso cref="GetIoBuffers(int,int)" />
+        ArraySegment<byte> GetIoBuffer(int index, int length);
+
+        /// <summary>
+        ///     Exposes this buffer's readable bytes as an array of <see cref="ArraySegment{T}" /> of <see cref="Byte" />. Returned
+        ///     segments
+        ///     share the content with this buffer. This method does not
+        ///     modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.  Please note that
+        ///     returned segments will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content with <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffer()" />
+        /// <seealso cref="GetIoBuffer(int,int)" />
+        ArraySegment<byte>[] GetIoBuffers();
+
+        /// <summary>
+        ///     Exposes this buffer's bytes as an array of <see cref="ArraySegment{T}" /> of <see cref="Byte" /> for the specified
+        ///     index and length.
+        ///     Returned segments share the content with this buffer. This method does
+        ///     not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer. Please note that
+        ///     returned segments will not see the changes of this buffer if this buffer is a dynamic
+        ///     buffer and it adjusted its capacity.
+        /// </summary>
+        /// <exception cref="NotSupportedException">
+        ///     if this buffer cannot represent its content with <see cref="ArraySegment{T}" />
+        ///     of <see cref="Byte" />
+        /// </exception>
+        /// <seealso cref="IoBufferCount" />
+        /// <seealso cref="GetIoBuffer()" />
+        /// <seealso cref="GetIoBuffer(int,int)" />
+        ArraySegment<byte>[] GetIoBuffers(int index, int length);
 
         /// <summary>
         ///     Flag that indicates if this <see cref="IByteBuffer" /> is backed by a byte array or not

--- a/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Buffers
 {
+    using System;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
@@ -185,6 +186,17 @@ namespace DotNetty.Buffers
         //    index = idx(index);
         //    return (ByteBuffer)internalNioBuffer().clear().position(index).limit(index + length);
         //}
+
+        public override int IoBufferCount => 1;
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            index = index + this.Offset;
+            return new ArraySegment<byte>(this.Memory, index, length);
+        }
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length) => new[] { this.GetIoBuffer(index, length) };
 
         public override bool HasArray => true;
 

--- a/src/DotNetty.Buffers/SlicedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SlicedByteBuffer.cs
@@ -59,6 +59,20 @@ namespace DotNetty.Buffers
             throw new NotSupportedException("sliced buffer");
         }
 
+        public override int IoBufferCount => this.Unwrap().IoBufferCount;
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            return this.Unwrap().GetIoBuffer(index + this.adjustment, length);
+        }
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            return this.Unwrap().GetIoBuffers(index + this.adjustment, length);
+        }
+
         public override bool HasArray => this.buffer.HasArray;
 
         public override byte[] Array => this.buffer.Array;

--- a/src/DotNetty.Buffers/SwappedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SwappedByteBuffer.cs
@@ -561,14 +561,21 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public int IoBufferCount => this.buf.IoBufferCount;
+
+        public ArraySegment<byte> GetIoBuffer() => this.buf.GetIoBuffer();
+
+        public ArraySegment<byte> GetIoBuffer(int index, int length) => this.buf.GetIoBuffer(index, length);
+
+        public ArraySegment<byte>[] GetIoBuffers() => this.buf.GetIoBuffers();
+
+        public ArraySegment<byte>[] GetIoBuffers(int index, int length) => this.buf.GetIoBuffers(index, length);
+
         public bool HasArray => this.buf.HasArray;
 
         public byte[] Array => this.buf.Array;
 
-        public byte[] ToArray()
-        {
-            return this.buf.ToArray().Reverse().ToArray();
-        }
+        public byte[] ToArray() => this.buf.ToArray();
 
         public IByteBuffer Duplicate()
         {

--- a/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Buffers
 {
+    using System;
     using System.Diagnostics.Contracts;
     using System.IO;
     using System.Threading;
@@ -97,6 +98,16 @@ namespace DotNetty.Buffers
             }
             return this;
         }
+
+        public override int IoBufferCount => 1;
+
+        public override ArraySegment<byte> GetIoBuffer(int index, int length)
+        {
+            this.EnsureAccessible();
+            return new ArraySegment<byte>(this.array, index, length);
+        }
+
+        public override ArraySegment<byte>[] GetIoBuffers(int index, int length) => new[] { this.GetIoBuffer(index, length) };
 
         public override bool HasArray => true;
 

--- a/src/DotNetty.Buffers/WrappedByteBuf.cs
+++ b/src/DotNetty.Buffers/WrappedByteBuf.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Buffers
 {
+    using System;
     using System.Diagnostics.Contracts;
     using System.IO;
     using System.Text;
@@ -521,6 +522,16 @@ namespace DotNetty.Buffers
             this.Buf.WriteBytes(src, srcIndex, length);
             return this;
         }
+
+        public int IoBufferCount => this.Buf.IoBufferCount;
+
+        public ArraySegment<byte> GetIoBuffer() => this.Buf.GetIoBuffer();
+
+        public ArraySegment<byte> GetIoBuffer(int index, int length) => this.Buf.GetIoBuffer(index, length);
+
+        public ArraySegment<byte>[] GetIoBuffers() => this.Buf.GetIoBuffers();
+
+        public ArraySegment<byte>[] GetIoBuffers(int index, int length) => this.Buf.GetIoBuffers(index, length);
 
         public virtual Task WriteBytesAsync(Stream input, int length, CancellationToken cancellationToken)
         {

--- a/src/DotNetty.Common/Utilities/MpscLinkedQueue.cs
+++ b/src/DotNetty.Common/Utilities/MpscLinkedQueue.cs
@@ -29,9 +29,6 @@ namespace DotNetty.Common.Utilities
         // offer() appends a new node next to the tail using AtomicReference.getAndSet()
         // poll() removes head from the linked list and promotes the 1st element to the head,
         // setting its value to null if possible.
-        //
-        // Also note that this class : AtomicReference for the "tail" slot (which is the one that is appended to)
-        // since Unsafe does not expose XCHG operation intrinsically.
         public MpscLinkedQueue()
         {
             MpscLinkedQueueNode<T> tombstone = new DefaultNode(null);
@@ -174,12 +171,12 @@ namespace DotNetty.Common.Utilities
 
     abstract class MpscLinkedQueueHeadRef<T> : MpscLinkedQueuePad0<T>
     {
-        volatile MpscLinkedQueueNode<T> headRef;
+        MpscLinkedQueueNode<T> headRef;
 
         protected MpscLinkedQueueNode<T> HeadRef
         {
-            get { return this.headRef; }
-            set { this.headRef = value; }
+            get { return Volatile.Read(ref this.headRef); }
+            set { Volatile.Write(ref this.headRef, value); }
         }
     }
 
@@ -231,12 +228,12 @@ namespace DotNetty.Common.Utilities
 
     abstract class MpscLinkedQueueTailRef<T> : MpscLinkedQueuePad1<T>
     {
-        volatile MpscLinkedQueueNode<T> tailRef;
+        MpscLinkedQueueNode<T> tailRef;
 
         protected MpscLinkedQueueNode<T> TailRef
         {
-            get { return this.tailRef; }
-            set { this.tailRef = value; }
+            get { return Volatile.Read(ref this.tailRef); }
+            set { Volatile.Write(ref this.tailRef, value); }
         }
 
         protected MpscLinkedQueueNode<T> GetAndSetTailRef(MpscLinkedQueueNode<T> value)

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketMessageChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketMessageChannel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace DotNetty.Transport.Channels.Sockets
@@ -9,12 +9,12 @@ namespace DotNetty.Transport.Channels.Sockets
     using System.Net.Sockets;
 
     /// <summary>
-    ///     {@link AbstractNioChannel} base class for {@link Channel}s that operate on messages.
+    /// {@link AbstractNioChannel} base class for {@link Channel}s that operate on messages.
     /// </summary>
     public abstract class AbstractSocketMessageChannel : AbstractSocketChannel
     {
         /// <summary>
-        ///     @see {@link AbstractNioChannel#AbstractNioChannel(Channel, SelectableChannel, int)}
+        /// @see {@link AbstractNioChannel#AbstractNioChannel(Channel, SelectableChannel, int)}
         /// </summary>
         protected AbstractSocketMessageChannel(IChannel parent, Socket socket)
             : base(parent, socket)
@@ -35,7 +35,10 @@ namespace DotNetty.Transport.Channels.Sockets
             {
             }
 
-            new AbstractSocketMessageChannel Channel => (AbstractSocketMessageChannel)this.channel;
+            new AbstractSocketMessageChannel Channel
+            {
+                get { return (AbstractSocketMessageChannel)this.channel; }
+            }
 
             public override void FinishRead(SocketChannelAsyncOperation operation)
             {
@@ -43,7 +46,7 @@ namespace DotNetty.Transport.Channels.Sockets
                 AbstractSocketMessageChannel ch = this.Channel;
                 ch.ResetState(StateFlags.ReadScheduled);
                 IChannelConfiguration config = ch.Configuration;
-                if (!config.AutoRead && !ch.ReadPending)
+                if (!ch.ReadPending && !config.AutoRead)
                 {
                     // ChannelConfig.setAutoRead(false) was called in the meantime
                     //removeReadOp(); -- noop with IOCP, just don't schedule receive again
@@ -126,7 +129,7 @@ namespace DotNetty.Transport.Channels.Sockets
                     // /// The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
                     //
                     // See https://github.com/netty/netty/issues/2254
-                    if (!closed && (config.AutoRead || ch.ReadPending))
+                    if (!closed && (ch.ReadPending || config.AutoRead))
                     {
                         ch.DoBeginRead();
                     }
@@ -203,18 +206,22 @@ namespace DotNetty.Transport.Channels.Sockets
         //}
 
         /// <summary>
-        ///     Returns {@code true} if we should continue the write loop on a write error.
+        /// Returns {@code true} if we should continue the write loop on a write error.
         /// </summary>
-        protected virtual bool ContinueOnWriteError => false;
+        protected virtual bool ContinueOnWriteError
+        {
+            get { return false; }
+        }
 
         /// <summary>
-        ///     Read messages into the given array and return the amount which was read.
+        /// Read messages into the given array and return the amount which was read.
         /// </summary>
         protected abstract int DoReadMessages(List<object> buf);
 
         /// <summary>
-        ///     Write a message to the underlying {@link java.nio.channels.Channel}.
-        ///     @return {@code true} if and only if the message has been written
+        /// Write a message to the underlying {@link java.nio.channels.Channel}.
+        ///
+        /// @return {@code true} if and only if the message has been written
         /// </summary>
         protected abstract bool DoWriteMessage(object msg, ChannelOutboundBuffer input);
     }

--- a/src/DotNetty.Transport/Channels/Sockets/TcpServerSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpServerSocketChannel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace DotNetty.Transport.Channels.Sockets

--- a/test/DotNetty.Codecs.Tests/Frame/LengthFieldBasedFrameDecoderTests.cs
+++ b/test/DotNetty.Codecs.Tests/Frame/LengthFieldBasedFrameDecoderTests.cs
@@ -25,7 +25,7 @@ namespace DotNetty.Codecs.Tests.Frame
                 ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] { 0, 0, 0, 1, (byte)'A' }));
                 var buf = ch.ReadInbound<IByteBuffer>();
                 Encoding iso = Encoding.GetEncoding("ISO-8859-1");
-                Assert.Equal("A", iso.GetString(buf.ToArray()));
+                Assert.Equal("A", buf.ToString(iso));
                 buf.Release();
             }
         }
@@ -47,7 +47,7 @@ namespace DotNetty.Codecs.Tests.Frame
                 ch.WriteInbound(Unpooled.WrappedBuffer(new byte[] { 0, 0, 0, 0, 0, 1, (byte)'A' }));
                 var buf = ch.ReadInbound<IByteBuffer>();
                 Encoding iso = Encoding.GetEncoding("ISO-8859-1");
-                Assert.Equal("A", iso.GetString(buf.ToArray()));
+                Assert.Equal("A", buf.ToString(iso));
                 buf.Release();
             }
         }

--- a/test/DotNetty.Tests.End2End/End2EndTests.cs
+++ b/test/DotNetty.Tests.End2End/End2EndTests.cs
@@ -213,7 +213,7 @@ namespace DotNetty.Tests.End2End
             var publishPacket = Assert.IsType<PublishPacket>(currentMessageFunc());
             Assert.Equal(QualityOfService.AtLeastOnce, publishPacket.QualityOfService);
             Assert.Equal(PublishS2CQos1Topic, publishPacket.TopicName);
-            Assert.Equal(PublishS2CQos1Payload, Encoding.UTF8.GetString(publishPacket.Payload.ToArray()));
+            Assert.Equal(PublishS2CQos1Payload, publishPacket.Payload.ToString(Encoding.UTF8));
 
             yield return TestScenarioStep.Messages(
                 PubAckPacket.InResponseTo(publishPacket),
@@ -330,7 +330,7 @@ namespace DotNetty.Tests.End2End
                 yield return TestScenarioStep.Message(Unpooled.WrappedBuffer(Encoding.UTF8.GetBytes(message)));
 
                 var responseMessage = Assert.IsAssignableFrom<IByteBuffer>(currentMessageFunc());
-                Assert.Equal(message, Encoding.UTF8.GetString(responseMessage.ToArray()));
+                Assert.Equal(message, responseMessage.ToString(Encoding.UTF8));
             }
         }
     }

--- a/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
+++ b/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
@@ -74,12 +74,19 @@
       <Project>{de58fe41-5e99-44e5-86bc-fc9ed8761daf}</Project>
       <Name>DotNetty.Common</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Handlers\DotNetty.Handlers.csproj">
+      <Project>{09628314-f44e-445e-9f0d-cbe33b736ac3}</Project>
+      <Name>DotNetty.Handlers</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\DotNetty.Transport\DotNetty.Transport.csproj">
       <Project>{8218c9ee-0a4a-432f-a12a-b54202f97b05}</Project>
       <Name>DotNetty.Transport</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="..\..\shared\dotnetty.com.pfx">
+      <Link>dotnetty.com.pfx</Link>
+    </EmbeddedResource>
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/test/DotNetty.Transport.Tests.Performance/Utilities/ReadFinishedHandler.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Utilities/ReadFinishedHandler.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Transport.Tests.Performance.Utilities
 {
+    using System;
     using DotNetty.Common.Utilities;
     using DotNetty.Transport.Channels;
 
@@ -26,5 +27,7 @@ namespace DotNetty.Transport.Tests.Performance.Utilities
                 this.signal.Signal();
             }
         }
+
+        public override void ExceptionCaught(IChannelHandlerContext context, Exception exception) => Console.WriteLine(exception.ToString());
     }
 }


### PR DESCRIPTION
…IByteBuffer for writing.

Motivation:
In order to avoid buffer copies and yet perform IO efficiently,
it is essential to support sending multiple byte sequences in one call.
Also there should be no additional constraints on `IByteBuffer` implementations
in order to be accepted by `TcpSocketChannel` for sending.

Modifications:
- `IoBufferCount`, `GetIoBuffer()`, `GetIoBuffers()` are ported to `IByteBuffer` and implementations.
- `ChannelOutboundBuffer` is extended to leverage `*IoBuffer*` members in order to prepare buffer batches for sending.
- `TcpSocketChannel` and its ancestors were extended to support sending (sync and async) a list of array segments.
- Extra: fixes `WriterIndex` positioning in `ByteBufferUtil.EncodeString(..)`.

Result:
A benchmark of single client channel writing to a single server channel runs 3 times faster at 150K op/sec (vs 53K op/sec before) with no increase in CPU consumption.
`CompositeByteBuffer` can be used directly in `IChannel.WriteAsync`.