### PR TITLE
Adds attribute support in Channel, Bootstrap [#78]

### DIFF
--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -196,10 +196,17 @@
     <Compile Include="ThreadLocalObjectList.cs" />
     <Compile Include="ThreadLocalPool.cs" />
     <Compile Include="PreciseTimeSpan.cs" />
+    <Compile Include="Utilities\AbstractConstant.cs" />
     <Compile Include="Utilities\AtomicReference.cs" />
+    <Compile Include="Utilities\DefaultAttributeMap.cs" />
+    <Compile Include="Utilities\IAttribute.cs" />
+    <Compile Include="Utilities\AttributeKey.cs" />
     <Compile Include="Utilities\BitOps.cs" />
     <Compile Include="Utilities\ArrayExtensions.cs" />
+    <Compile Include="Utilities\ConstantPool.cs" />
     <Compile Include="Utilities\DebugExtensions.cs" />
+    <Compile Include="Utilities\IAttributeMap.cs" />
+    <Compile Include="Utilities\IConstant.cs" />
     <Compile Include="Utilities\IntegerExtensions.cs" />
     <Compile Include="Utilities\MpscLinkedQueue.cs" />
     <Compile Include="Utilities\PriorityQueue.cs" />

--- a/src/DotNetty.Common/Utilities/AbstractConstant.cs
+++ b/src/DotNetty.Common/Utilities/AbstractConstant.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    using System;
+    using System.Threading;
+
+    public abstract class AbstractConstant : IConstant
+    {
+        static long nextUniquifier;
+
+        long volatileUniquifier;
+
+        protected AbstractConstant(int id, string name)
+        {
+            this.Id = id;
+            this.Name = name;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public sealed override string ToString() => this.Name;
+
+        protected long Uniquifier
+        {
+            get
+            {
+                long result;
+                if ((result = Volatile.Read(ref this.volatileUniquifier)) == 0)
+                {
+                    result = Interlocked.Increment(ref nextUniquifier);
+                    long previousUniquifier = Interlocked.CompareExchange(ref this.volatileUniquifier, result, 0);
+                    if (previousUniquifier != 0)
+                    {
+                        result = previousUniquifier;
+                    }
+                }
+
+                return result;
+            }
+        }
+    }
+
+    /// <summary>Base implementation of <see cref="IConstant" />.</summary>
+    public abstract class AbstractConstant<T> : AbstractConstant, IComparable<T>, IEquatable<T>
+        where T : AbstractConstant<T>
+    {
+        /// <summary>Creates a new instance.</summary>
+        protected AbstractConstant(int id, string name)
+            : base(id, name)
+        {
+        }
+
+        public sealed override int GetHashCode() => base.GetHashCode();
+
+        public sealed override bool Equals(object obj) => base.Equals(obj);
+
+        public bool Equals(T other) => ReferenceEquals(this, other);
+
+        public int CompareTo(T o)
+        {
+            if (ReferenceEquals(this, o))
+            {
+                return 0;
+            }
+
+            AbstractConstant<T> other = o;
+
+            int returnCode = this.GetHashCode() - other.GetHashCode();
+            if (returnCode != 0)
+            {
+                return returnCode;
+            }
+
+            long thisUV = this.Uniquifier;
+            long otherUV = other.Uniquifier;
+            if (thisUV < otherUV)
+            {
+                return -1;
+            }
+            if (thisUV > otherUV)
+            {
+                return 1;
+            }
+
+            throw new Exception("failed to compare two different constants");
+        }
+    }
+}

--- a/src/DotNetty.Common/Utilities/AtomicReference.cs
+++ b/src/DotNetty.Common/Utilities/AtomicReference.cs
@@ -43,7 +43,7 @@ namespace DotNetty.Common.Utilities
         ///     <see cref="newValue" />.
         ///     Returns true if <see cref="newValue" /> was set, false otherwise.
         /// </summary>
-        public T CompareAndSet(T expected, T newValue) => Interlocked.CompareExchange(ref this.atomicValue, expected, newValue);
+        public bool CompareAndSet(T expected, T newValue) => Interlocked.CompareExchange(ref this.atomicValue, newValue, expected) == expected;
 
         #region Conversion operators
 

--- a/src/DotNetty.Common/Utilities/AttributeKey.cs
+++ b/src/DotNetty.Common/Utilities/AttributeKey.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    using System;
+
+    /// <summary>
+    ///     Key which can be used to access <seealso cref="Attribute" /> out of the <see cref="IAttributeMap" />. Be aware that
+    ///     it is not be possible to have multiple keys with the same name.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     the type of the <see cref="Attribute" /> which can be accessed via this <see cref="AttributeKey{T}" />.
+    /// </typeparam>
+    public sealed class AttributeKey<T> : AbstractConstant<AttributeKey<T>>
+    {
+        public static readonly ConstantPool Pool = new AttributeConstantPool();
+
+        sealed class AttributeConstantPool : ConstantPool
+        {
+            protected override IConstant NewConstant<TValue>(int id, string name) => new AttributeKey<TValue>(id, name);
+        };
+
+        /// <summary>Returns the singleton instance of the {@link AttributeKey} which has the specified <c>name</c>.</summary>
+        public static AttributeKey<T> ValueOf(string name) => (AttributeKey<T>)Pool.ValueOf<T>(name);
+
+        /// <summary>Returns <c>true</c> if a <see cref="AttributeKey{T}" /> exists for the given <c>name</c>.</summary>
+        public static bool Exists(string name) => Pool.Exists(name);
+
+        /// <summary>
+        ///     Creates a new <see cref="AttributeKey{T}" /> for the given <c>name</c> or fail with an
+        ///     <see cref="ArgumentException" /> if a <see cref="AttributeKey{T}" /> for the given <c>name</c> exists.
+        /// </summary>
+        public static AttributeKey<T> NewInstance(string name) => (AttributeKey<T>)Pool.NewInstance<T>(name);
+
+        public static AttributeKey<T> ValueOf(Type firstNameComponent, string secondNameComponent)
+            => (AttributeKey<T>)Pool.ValueOf<T>(firstNameComponent, secondNameComponent);
+
+        internal AttributeKey(int id, string name)
+            : base(id, name)
+        {
+        }
+    }
+}

--- a/src/DotNetty.Common/Utilities/ConstantPool.cs
+++ b/src/DotNetty.Common/Utilities/ConstantPool.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Contracts;
+
+    /// <summary>
+    ///     A pool of <see cref="IConstant" />s.
+    /// </summary>
+    public abstract class ConstantPool
+    {
+        readonly Dictionary<string, IConstant> constants = new Dictionary<string, IConstant>();
+
+        int nextId = 1;
+
+        /// <summary>Shortcut of <c>this.ValueOf(firstNameComponent.Name + "#" + secondNameComponent)</c>.</summary>
+        public IConstant ValueOf<T>(Type firstNameComponent, string secondNameComponent)
+        {
+            Contract.Requires(firstNameComponent != null);
+            Contract.Requires(secondNameComponent != null);
+
+            return this.ValueOf<T>(firstNameComponent.Name + '#' + secondNameComponent);
+        }
+
+        /// <summary>
+        ///     Returns the <see cref="IConstant" /> which is assigned to the specified <c>name</c>.
+        ///     If there's no such <see cref="IConstant" />, a new one will be created and returned.
+        ///     Once created, the subsequent calls with the same <c>name</c> will always return the previously created one
+        ///     (i.e. singleton.)
+        /// </summary>
+        /// <param name="name">the name of the <see cref="IConstant" /></param>
+        public IConstant ValueOf<T>(string name)
+        {
+            IConstant c;
+
+            lock (this.constants)
+            {
+                if (this.constants.TryGetValue(name, out c))
+                {
+                    return c;
+                }
+                else
+                {
+                    c = this.NewInstance0<T>(name);
+                }
+            }
+
+            return c;
+        }
+
+        /// <summary>Returns <c>true</c> if a <see cref="AttributeKey{T}" /> exists for the given <c>name</c>.</summary>
+        public bool Exists(string name)
+        {
+            CheckNotNullAndNotEmpty(name);
+            lock (this.constants)
+            {
+                return this.constants.ContainsKey(name);
+            }
+        }
+
+        /// <summary>
+        ///     Creates a new <see cref="IConstant" /> for the given <c>name</c> or fail with an
+        ///     <see cref="ArgumentException" /> if a <see cref="IConstant" /> for the given <c>name</c> exists.
+        /// </summary>
+        public IConstant NewInstance<T>(string name)
+        {
+            if (this.Exists(name))
+            {
+                throw new ArgumentException($"'{name}' is already in use");
+            }
+
+            IConstant c = this.NewInstance0<T>(name);
+
+            return c;
+        }
+
+        // Be careful that this dose not check whether the argument is null or empty.
+        IConstant NewInstance0<T>(string name)
+        {
+            lock (this.constants)
+            {
+                IConstant c = this.NewConstant<T>(this.nextId, name);
+                this.constants[name] = c;
+                this.nextId++;
+                return c;
+            }
+        }
+
+        static void CheckNotNullAndNotEmpty(string name) => Contract.Requires(!string.IsNullOrEmpty(name));
+
+        protected abstract IConstant NewConstant<T>(int id, string name);
+
+        [Obsolete]
+        public int NextId()
+        {
+            lock (this.constants)
+            {
+                int id = this.nextId;
+                this.nextId++;
+                return id;
+            }
+        }
+    }
+}

--- a/src/DotNetty.Common/Utilities/DefaultAttributeMap.cs
+++ b/src/DotNetty.Common/Utilities/DefaultAttributeMap.cs
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    using System.Diagnostics.Contracts;
+    using System.Threading;
+
+    /// <summary>
+    ///     Default <see cref="IAttributeMap" /> implementation which use simple synchronization per bucket to keep the memory
+    ///     overhead
+    ///     as low as possible.
+    /// </summary>
+    public class DefaultAttributeMap : IAttributeMap
+    {
+        const int BucketSize = 4;
+        const int Mask = BucketSize - 1;
+
+        // Initialize lazily to reduce memory consumption; updated by AtomicReferenceFieldUpdater above.
+        volatile DefaultAttribute[] attributes;
+
+        public IAttribute<T> GetAttribute<T>(AttributeKey<T> key)
+            where T : class
+        {
+            Contract.Requires(key != null);
+
+            DefaultAttribute[] attrs = this.attributes;
+            if (attrs == null)
+            {
+                attrs = new DefaultAttribute[BucketSize];
+                // Not using ConcurrentHashMap due to high memory consumption.
+                attrs = Interlocked.CompareExchange(ref this.attributes, attrs, null) ?? attrs;
+            }
+
+            int i = Index(key);
+            DefaultAttribute head = Volatile.Read(ref attrs[i]);
+            if (head == null)
+            {
+                // No head exists yet which means we may be able to add the attribute without synchronization and just
+                // use compare and set. At worst we need to fallback to synchronization
+                head = new DefaultAttribute<T>(key);
+
+                if (Interlocked.CompareExchange(ref this.attributes[i], head, null) == null)
+                {
+                    // we were able to add it so return the head right away
+                    return (IAttribute<T>)head;
+                }
+
+                head = Volatile.Read(ref attrs[i]);
+            }
+
+            lock (head)
+            {
+                DefaultAttribute curr = head;
+                while (true)
+                {
+                    if (!curr.Removed && curr.GetKey() == key)
+                    {
+                        return (IAttribute<T>)curr;
+                    }
+
+                    DefaultAttribute next = curr.Next;
+                    if (next == null)
+                    {
+                        var attr = new DefaultAttribute<T>(head, key);
+                        curr.Next = attr;
+                        attr.Prev = curr;
+                        return attr;
+                    }
+                    else
+                    {
+                        curr = next;
+                    }
+                }
+            }
+        }
+
+        public bool HasAttribute<T>(AttributeKey<T> key)
+            where T : class
+        {
+            Contract.Requires(key != null);
+
+            DefaultAttribute[] attrs = this.attributes;
+            if (attrs == null)
+            {
+                // no attribute exists
+                return false;
+            }
+
+            int i = Index(key);
+            DefaultAttribute head = Volatile.Read(ref attrs[i]);
+            if (head == null)
+            {
+                // No attribute exists which point to the bucket in which the head should be located
+                return false;
+            }
+
+            // check on the head can be done without synchronization
+            if (head.GetKey() == key && !head.Removed)
+            {
+                return true;
+            }
+
+            lock (head)
+            {
+                // we need to synchronize on the head
+                DefaultAttribute curr = head.Next;
+                while (curr != null)
+                {
+                    if (!curr.Removed && curr.GetKey() == key)
+                    {
+                        return true;
+                    }
+                    curr = curr.Next;
+                }
+                return false;
+            }
+        }
+
+        static int Index<T>(AttributeKey<T> key) => key.Id & Mask;
+
+        abstract class DefaultAttribute
+        {
+            // The head of the linked-list this attribute belongs to, which may be itself
+            protected readonly DefaultAttribute Head;
+
+            // Double-linked list to prev and next node to allow fast removal
+            public DefaultAttribute Prev;
+            public DefaultAttribute Next;
+
+            // Will be set to true one the attribute is removed via GetAndRemove() or Remove()
+            public volatile bool Removed;
+
+            public abstract IConstant GetKey();
+
+            protected DefaultAttribute()
+            {
+                this.Head = this;
+            }
+
+            protected DefaultAttribute(DefaultAttribute head)
+            {
+                this.Head = head;
+            }
+        }
+
+        sealed class DefaultAttribute<T> : DefaultAttribute, IAttribute<T>
+            where T : class
+        {
+            readonly AttributeKey<T> key;
+            T value;
+
+            public DefaultAttribute(DefaultAttribute head, AttributeKey<T> key)
+                : base(head)
+            {
+                this.key = key;
+            }
+
+            public DefaultAttribute(AttributeKey<T> key)
+            {
+                this.key = key;
+            }
+
+            public AttributeKey<T> Key => this.key;
+
+            public T Get() => Volatile.Read(ref this.value);
+
+            public void Set(T value) => Volatile.Write(ref this.value, value);
+
+            public T GetAndSet(T value) => Interlocked.Exchange(ref this.value, value);
+
+            public T SetIfAbsent(T value)
+            {
+                while (!this.CompareAndSet(null, value))
+                {
+                    T old = this.Get();
+                    if (old != null)
+                    {
+                        return old;
+                    }
+                }
+                return default(T);
+            }
+
+            public T GetAndRemove()
+            {
+                this.Removed = true;
+                T oldValue = this.GetAndSet(null);
+                this.Remove0();
+                return oldValue;
+            }
+
+            public bool CompareAndSet(T oldValue, T newValue) => Interlocked.CompareExchange(ref this.value, newValue, oldValue) == oldValue;
+
+            public void Remove()
+            {
+                this.Removed = true;
+                this.Set(null);
+                this.Remove0();
+            }
+
+            void Remove0()
+            {
+                lock (this.Head)
+                {
+                    // We only update the linked-list structure if prev != null because if it is null this
+                    // DefaultAttribute acts also as head. The head must never be removed completely and just be
+                    // marked as removed as all synchronization is done on the head itself for each bucket.
+                    // The head itself will be GC'ed once the DefaultAttributeMap is GC'ed. So at most 5 heads will
+                    // be removed lazy as the array size is 5.
+                    if (this.Prev != null)
+                    {
+                        this.Prev.Next = this.Next;
+
+                        if (this.Next != null)
+                        {
+                            this.Next.Prev = this.Prev;
+                        }
+
+                        // Null out prev and next - this will guard against multiple remove0() calls which may corrupt
+                        // the linked list for the bucket.
+                        this.Prev = null;
+                        this.Next = null;
+                    }
+                }
+            }
+
+            public override IConstant GetKey() => this.key;
+        }
+    }
+}

--- a/src/DotNetty.Common/Utilities/IAttribute.cs
+++ b/src/DotNetty.Common/Utilities/IAttribute.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    /// <summary>An attribute which allows to store a value reference. It may be updated atomically and so is thread-safe.</summary>
+    /// <typeparam name="T">the type of the value it holds.</typeparam>
+    public interface IAttribute<T>
+    {
+        /// <summary>
+        ///     Returns the key of this attribute.
+        /// </summary>
+        AttributeKey<T> Key { get; }
+
+        /// <summary>
+        ///     Returns the current value, which may be <c>null</c>
+        /// </summary>
+        T Get();
+
+        /// <summary>
+        ///     Sets the value
+        /// </summary>
+        void Set(T value);
+
+        /// <summary>
+        ///     Atomically sets to the given value and returns the old value which may be <c>null</c> if non was set before.
+        /// </summary>
+        T GetAndSet(T value);
+
+        /// <summary>
+        ///     Atomically sets to the given value if this <see cref="IAttribute{T}" />'s value is <c>null</c>.
+        ///     If it was not possible to set the value as it contains a value it will just return the current value.
+        /// </summary>
+        T SetIfAbsent(T value);
+
+        /// <summary>
+        ///     Removes this attribute from the <see cref="IAttributeMap" /> and returns the old value. Subsequent
+        ///     <see cref="Get" />
+        ///     calls will return <c>null</c>.
+        ///     If you only want to return the old value and clear the <see cref="IAttribute{T}" /> while still keep it in
+        ///     <see cref="IAttributeMap" /> use <see cref="GetAndSet" /> with a value of <c>null</c>.
+        /// </summary>
+        T GetAndRemove();
+
+        /// <summary>
+        ///     Atomically sets the value to the given updated value if the current value == the expected value.
+        ///     If it the set was successful it returns <c>true</c> otherwise <c>false</c>.
+        /// </summary>
+        bool CompareAndSet(T oldValue, T newValue);
+
+        /// <summary>
+        ///     Removes this attribute from the <see cref="IAttributeMap" />. Subsequent <see cref="Get" /> calls will return
+        ///     <c>null</c>.
+        ///     If you only want to remove the value and clear the <see cref="IAttribute{T}" /> while still keep it in
+        ///     <see cref="IAttributeMap" /> use <see cref="Set" /> with a value of <c>null</c>.
+        /// </summary>
+        void Remove();
+    }
+}

--- a/src/DotNetty.Common/Utilities/IAttributeMap.cs
+++ b/src/DotNetty.Common/Utilities/IAttributeMap.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    /// <summary>Holds <see cref="IAttribute{T}" />s which can be accessed via <see cref="AttributeKey{T}" />.</summary>
+    /// <remarks>Implementations must be Thread-safe.</remarks>
+    public interface IAttributeMap
+    {
+        /// <summary>
+        ///     Get the <see cref="IAttribute{T}" /> for the given <see cref="AttributeKey{T}" />. This method will never return
+        ///     null, but may return an <see cref="IAttribute{T}" /> which does not have a value set yet.
+        /// </summary>
+        IAttribute<T> GetAttribute<T>(AttributeKey<T> key)
+            where T : class;
+
+        /// <summary>
+        ///     Returns <c>true</c> if and only if the given <see cref="IAttribute{T}" /> exists in this
+        ///     <see cref="IAttributeMap" />.
+        /// </summary>
+        bool HasAttribute<T>(AttributeKey<T> key)
+            where T : class;
+    }
+}

--- a/src/DotNetty.Common/Utilities/IConstant.cs
+++ b/src/DotNetty.Common/Utilities/IConstant.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    /// <summary>
+    ///     A singleton which is safe to compare via the <c>==</c> operator. Created and managed by
+    ///     <see cref="ConstantPool" />.
+    /// </summary>
+    public interface IConstant
+    {
+        /// <summary>Returns the unique number assigned to this <see cref="IConstant" />.</summary>
+        int Id { get; }
+
+        /// <summary>Returns the name of this <see cref="IConstant" />.</summary>
+        string Name { get; }
+    }
+}

--- a/src/DotNetty.Transport/Bootstrapping/Bootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/Bootstrap.cs
@@ -189,12 +189,12 @@ namespace DotNetty.Transport.Bootstrapping
             IChannelPipeline p = channel.Pipeline;
             p.AddLast(null, (string)null, this.Handler());
 
-            IDictionary<ChannelOption, object> options = this.Options();
-            foreach (KeyValuePair<ChannelOption, object> e in options)
+            ICollection<ChannelOptionValue> options = this.Options;
+            foreach (ChannelOptionValue e in options)
             {
                 try
                 {
-                    if (!channel.Configuration.SetOption(e.Key, e.Value))
+                    if (!e.Set(channel.Configuration))
                     {
                         Logger.Warn("Unknown channel option: " + e);
                     }
@@ -205,15 +205,11 @@ namespace DotNetty.Transport.Bootstrapping
                 }
             }
 
-            // todo: attrs
-            //var attrs = attrs();
-            //lock (attrs)
-            //{
-            //    foreach (var e in attrs)
-            //    {
-            //        channel.attr((AttributeKey<object>)e.getKey()).set(e.getValue());
-            //    }
-            //}
+            ICollection<AttributeValue> attrs = this.Attributes;
+            foreach (AttributeValue e in attrs)
+            {
+                e.Set(channel);
+            }
         }
 
         public override Bootstrap Validate()

--- a/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
@@ -5,11 +5,8 @@ namespace DotNetty.Transport.Bootstrapping
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
     using System.Diagnostics.Contracts;
     using System.Linq;
-    using System.Linq.Expressions;
-    using System.Reflection;
     using System.Text;
     using System.Threading.Tasks;
     using DotNetty.Common.Internal.Logging;
@@ -23,15 +20,15 @@ namespace DotNetty.Transport.Bootstrapping
     {
         static readonly IInternalLogger Logger = InternalLoggerFactory.GetInstance<ServerBootstrap>();
 
-        readonly ConcurrentDictionary<ChannelOption, object> childOptions;
-        // todo: attrs
-        //private final Map<AttributeKey<?>, Object> childAttrs = new LinkedHashMap<AttributeKey<?>, Object>();
+        readonly ConcurrentDictionary<ChannelOption, ChannelOptionValue> childOptions;
+        readonly ConcurrentDictionary<IConstant, AttributeValue> childAttrs;
         volatile IEventLoopGroup childGroup;
         volatile IChannelHandler childHandler;
 
         public ServerBootstrap()
         {
-            this.childOptions = new ConcurrentDictionary<ChannelOption, object>();
+            this.childOptions = new ConcurrentDictionary<ChannelOption, ChannelOptionValue>();
+            this.childAttrs = new ConcurrentDictionary<IConstant, AttributeValue>();
         }
 
         ServerBootstrap(ServerBootstrap bootstrap)
@@ -39,17 +36,14 @@ namespace DotNetty.Transport.Bootstrapping
         {
             this.childGroup = bootstrap.childGroup;
             this.childHandler = bootstrap.childHandler;
-            this.childOptions = new ConcurrentDictionary<ChannelOption, object>(bootstrap.childOptions);
-            // todo: attrs
-            //lock (bootstrap.childAttrs) {
-            //    childAttrs.putAll(bootstrap.childAttrs);
-            //}
+            this.childOptions = new ConcurrentDictionary<ChannelOption, ChannelOptionValue>(bootstrap.childOptions);
+            this.childAttrs = new ConcurrentDictionary<IConstant, AttributeValue>(bootstrap.childAttrs);
         }
 
         /// <summary>
         ///     Specify the {@link EventLoopGroup} which is used for the parent (acceptor) and the child (client).
         /// </summary>
-        public override ServerBootstrap Group(IEventLoopGroup group) => this.Group(@group, @group);
+        public override ServerBootstrap Group(IEventLoopGroup group) => this.Group(group, group);
 
         /// <summary>
         ///     Set the {@link EventLoopGroup} for the parent (acceptor) and the child (client). These
@@ -80,32 +74,37 @@ namespace DotNetty.Transport.Bootstrapping
 
             if (value == null)
             {
-                object removed;
+                ChannelOptionValue removed;
                 this.childOptions.TryRemove(childOption, out removed);
             }
             else
             {
-                this.childOptions[childOption] = value;
+                this.childOptions[childOption] = new ChannelOptionValue<T>(childOption, value);
             }
             return this;
         }
 
-        // todo: attrs
-        ///// <summary>
-        // /// Set the specific {@link AttributeKey} with the given value on every child {@link Channel}. If the value is
-        // /// {@code null} the {@link AttributeKey} is removed
-        // /// </summary>
-        //public <T> ServerBootstrap childAttr(AttributeKey<T> childKey, T value) {
-        //    if (childKey == null) {
-        //        throw new NullPointerException("childKey");
-        //    }
-        //    if (value == null) {
-        //        childAttrs.remove(childKey);
-        //    } else {
-        //        childAttrs.put(childKey, value);
-        //    }
-        //    return this;
-        //}
+        /// <summary>
+        ///     Set the specific {@link AttributeKey} with the given value on every child {@link Channel}. If the value is
+        ///     {@code null} the {@link AttributeKey} is removed
+        /// </summary>
+        public ServerBootstrap ChildAttribute<T>(AttributeKey<T> childKey, T value)
+            where T : class
+        {
+            Contract.Requires(childKey != null);
+
+            if (value == null)
+            {
+                AttributeValue removed;
+                this.childAttrs.TryRemove(childKey, out removed);
+            }
+            else
+            {
+                this.childAttrs[childKey] = new AttributeValue<T>(childKey, value);
+            }
+            return this;
+        }
+
         /// <summary>
         ///     Set the {@link ChannelHandler} which is used to serve the request for the {@link Channel}'s.
         /// </summary>
@@ -125,12 +124,11 @@ namespace DotNetty.Transport.Bootstrapping
 
         protected override void Init(IChannel channel)
         {
-            IDictionary<ChannelOption, object> options = this.Options();
-            foreach (KeyValuePair<ChannelOption, object> e in options)
+            foreach (ChannelOptionValue e in this.Options)
             {
                 try
                 {
-                    if (!channel.Configuration.SetOption(e.Key, e.Value))
+                    if (!e.Set(channel.Configuration))
                     {
                         Logger.Warn("Unknown channel option: " + e);
                     }
@@ -141,33 +139,27 @@ namespace DotNetty.Transport.Bootstrapping
                 }
             }
 
-            // todo: attrs
-            //Map<AttributeKey<?>, Object> attrs = attrs();
-            //lock (attrs) {
-            //    foreach (var e in attrs.entrySet()) {
-            //        AttributeKey<object> key = (AttributeKey<object>) e.getKey();
-            //        channel.attr(key).set(e.getValue());
-            //    }
-            //}
+            foreach (AttributeValue e in this.Attributes)
+            {
+                e.Set(channel);
+            }
 
             IChannelPipeline p = channel.Pipeline;
-            if (this.Handler() != null)
+            IChannelHandler channelHandler = this.Handler();
+            if (channelHandler != null)
             {
-                p.AddLast(this.Handler());
+                p.AddLast((string)null, channelHandler);
             }
 
             IEventLoopGroup currentChildGroup = this.childGroup;
             IChannelHandler currentChildHandler = this.childHandler;
-            KeyValuePair<ChannelOption, object>[] currentChildOptions = this.childOptions.ToArray();
-            // todo: attrs
-            //Entry<AttributeKey<?>, Object>[] currentChildAttrs = this.childAttrs.ToArray();
-
-            Func<IChannelConfiguration, bool> childConfigSetupFunc = CompileOptionsSetupFunc(this.childOptions);
+            ChannelOptionValue[] currentChildOptions = this.childOptions.Values.ToArray();
+            AttributeValue[] currentChildAttrs = this.childAttrs.Values.ToArray();
 
             p.AddLast(new ActionChannelInitializer<IChannel>(ch =>
             {
                 ch.Pipeline.AddLast(new ServerBootstrapAcceptor(currentChildGroup, currentChildHandler,
-                    childConfigSetupFunc /*, currentChildAttrs*/));
+                    currentChildOptions, currentChildAttrs));
             }));
         }
 
@@ -186,90 +178,55 @@ namespace DotNetty.Transport.Bootstrapping
             return this;
         }
 
-        static Func<IChannelConfiguration, bool> CompileOptionsSetupFunc(IDictionary<ChannelOption, object> templateOptions)
-        {
-            if (templateOptions.Count == 0)
-            {
-                return null;
-            }
-
-            ParameterExpression configParam = Expression.Parameter(typeof(IChannelConfiguration));
-            ParameterExpression resultVariable = Expression.Variable(typeof(bool));
-            var assignments = new List<Expression>
-            {
-                Expression.Assign(resultVariable, Expression.Constant(true))
-            };
-
-            MethodInfo setOptionMethodDefinition = typeof(IChannelConfiguration)
-                .FindMembers(MemberTypes.Method, BindingFlags.Instance | BindingFlags.Public, Type.FilterName, "SetOption")
-                .Cast<MethodInfo>()
-                .First(x => x.IsGenericMethodDefinition);
-
-            foreach (KeyValuePair<ChannelOption, object> p in templateOptions)
-            {
-                // todo: emit log if verbose is enabled && option is missing
-                Type optionType = p.Key.GetType();
-                if (!optionType.IsGenericType)
-                {
-                    throw new InvalidOperationException("Only options of type ChannelOption<T> are supported.");
-                }
-                if (optionType.GetGenericTypeDefinition() != typeof(ChannelOption<>))
-                {
-                    throw new NotSupportedException($"Channel option is of an unsupported type `{optionType}`. Only ChannelOption and ChannelOption<T> are supported.");
-                }
-                Type valueType = optionType.GetGenericArguments()[0];
-                MethodInfo setOptionMethod = setOptionMethodDefinition.MakeGenericMethod(valueType);
-                assignments.Add(Expression.Assign(
-                    resultVariable,
-                    Expression.AndAlso(
-                        resultVariable,
-                        Expression.Call(configParam, setOptionMethod, Expression.Constant(p.Key), Expression.Constant(p.Value, valueType)))));
-            }
-
-            return Expression.Lambda<Func<IChannelConfiguration, bool>>(Expression.Block(typeof(bool), new[] { resultVariable }, assignments), configParam).Compile();
-        }
-
         class ServerBootstrapAcceptor : ChannelHandlerAdapter
         {
             readonly IEventLoopGroup childGroup;
             readonly IChannelHandler childHandler;
-            readonly Func<IChannelConfiguration, bool> childOptionsSetupFunc;
-            // todo: attrs
-            //private readonly KeyValuePair<AttributeKey, object>[] childAttrs;
+            readonly ChannelOptionValue[] childOptions;
+            readonly AttributeValue[] childAttrs;
 
             public ServerBootstrapAcceptor(
                 IEventLoopGroup childGroup, IChannelHandler childHandler,
-                Func<IChannelConfiguration, bool> childOptionsSetupFunc /*, KeyValuePair<AttributeKey, object>[] childAttrs*/)
+                ChannelOptionValue[] childOptions, AttributeValue[] childAttrs)
             {
                 this.childGroup = childGroup;
                 this.childHandler = childHandler;
-                this.childOptionsSetupFunc = childOptionsSetupFunc;
-                //this.childAttrs = childAttrs;
+                this.childOptions = childOptions;
+                this.childAttrs = childAttrs;
             }
 
             public override void ChannelRead(IChannelHandlerContext ctx, object msg)
             {
                 var child = (IChannel)msg;
 
-                child.Pipeline.AddLast(this.childHandler);
+                child.Pipeline.AddLast((string)null, this.childHandler);
 
-                if (this.childOptionsSetupFunc != null)
+                foreach (ChannelOptionValue option in this.childOptions)
                 {
-                    if (!this.childOptionsSetupFunc(child.Configuration))
+                    try
                     {
-                        Logger.Warn("Not all configuration options could be set.");
+                        if (!option.Set(child.Configuration))
+                        {
+                            Logger.Warn("Unknown channel option: " + option);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn("Failed to set a channel option: " + child, ex);
                     }
                 }
 
-                // tood: attrs
-                //foreach (var e in this.childAttrs) {
-                //    child.attr((AttributeKey<Object>) e.getKey()).set(e.getValue());
-                //}
+                foreach (AttributeValue attr in this.childAttrs)
+                {
+                    attr.Set(child);
+                }
 
                 // todo: async/await instead?
                 try
                 {
-                    this.childGroup.GetNext().RegisterAsync(child).ContinueWith(future => ForceClose(child, future.Exception),
+                    this.childGroup.GetNext().RegisterAsync(child).ContinueWith(
+                        (future, state) => ForceClose((IChannel)state, future.Exception),
+                        child,
                         TaskContinuationOptions.NotOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
                 }
                 catch (Exception ex)
@@ -292,7 +249,7 @@ namespace DotNetty.Transport.Bootstrapping
                     // stop accept new connections for 1 second to allow the channel to recover
                     // See https://github.com/netty/netty/issues/1328
                     config.AutoRead = false;
-                    ctx.Channel.EventLoop.ScheduleAsync(() => { config.AutoRead = true; }, TimeSpan.FromSeconds(1));
+                    ctx.Channel.EventLoop.ScheduleAsync(c => { ((IChannelConfiguration)c).AutoRead = true; }, config, TimeSpan.FromSeconds(1));
                 }
                 // still let the ExceptionCaught event flow through the pipeline to give the user
                 // a chance to do something with it

--- a/src/DotNetty.Transport/Channels/AbstractChannel.cs
+++ b/src/DotNetty.Transport/Channels/AbstractChannel.cs
@@ -14,7 +14,7 @@ namespace DotNetty.Transport.Channels
     using DotNetty.Common.Internal.Logging;
     using DotNetty.Common.Utilities;
 
-    public abstract class AbstractChannel : /*DefaultAttributeMap, */ IChannel
+    public abstract class AbstractChannel : DefaultAttributeMap, IChannel
     {
         static readonly IInternalLogger Logger = InternalLoggerFactory.GetInstance<AbstractChannel>();
 
@@ -121,10 +121,7 @@ namespace DotNetty.Transport.Channels
 
         protected abstract EndPoint LocalAddressInternal { get; }
 
-        protected void InvalidateLocalAddress()
-        {
-            this.localAddress = null;
-        }
+        protected void InvalidateLocalAddress() => this.localAddress = null;
 
         protected EndPoint CacheLocalAddress()
         {
@@ -141,10 +138,7 @@ namespace DotNetty.Transport.Channels
 
         protected abstract EndPoint RemoteAddressInternal { get; }
 
-        protected void InvalidateRemoteAddress()
-        {
-            this.remoteAddress = null;
-        }
+        protected void InvalidateRemoteAddress() => this.remoteAddress = null;
 
         protected EndPoint CacheRemoteAddress()
         {

--- a/src/DotNetty.Transport/Channels/AbstractChannelHandlerContext.cs
+++ b/src/DotNetty.Transport/Channels/AbstractChannelHandlerContext.cs
@@ -12,6 +12,7 @@ namespace DotNetty.Transport.Channels
     using DotNetty.Buffers;
     using DotNetty.Common;
     using DotNetty.Common.Concurrency;
+    using DotNetty.Common.Utilities;
 
     abstract class AbstractChannelHandlerContext : IChannelHandlerContext, IResourceLeakHint
     {
@@ -191,6 +192,17 @@ namespace DotNetty.Transport.Channels
 
         public IChannelHandlerInvoker Invoker => this.invoker ?? this.Channel.EventLoop.Invoker;
 
+        public IAttribute<T> GetAttribute<T>(AttributeKey<T> key)
+            where T : class
+        {
+            return this.Channel.GetAttribute(key);
+        }
+
+        public bool HasAttribute<T>(AttributeKey<T> key)
+            where T : class
+        {
+            return this.Channel.HasAttribute(key);
+        }
         public IChannelHandlerContext FireChannelRegistered()
         {
             AbstractChannelHandlerContext next = this.FindContextInbound();

--- a/src/DotNetty.Transport/Channels/ChannelOption.cs
+++ b/src/DotNetty.Transport/Channels/ChannelOption.cs
@@ -6,40 +6,63 @@ namespace DotNetty.Transport.Channels
     using System;
     using System.Diagnostics.Contracts;
     using DotNetty.Buffers;
+    using DotNetty.Common.Utilities;
 
-    public abstract class ChannelOption
+    public abstract class ChannelOption : AbstractConstant<ChannelOption>
     {
-        public static readonly ChannelOption<IByteBufferAllocator> Allocator = new ChannelOption<IByteBufferAllocator>();
-        public static readonly ChannelOption<IRecvByteBufAllocator> RcvbufAllocator = new ChannelOption<IRecvByteBufAllocator>();
-        public static readonly ChannelOption<IMessageSizeEstimator> MessageSizeEstimator = new ChannelOption<IMessageSizeEstimator>();
+        class ChannelOptionPool : ConstantPool
+        {
+            protected override IConstant NewConstant<T>(int id, string name) => new ChannelOption<T>(id, name);
+        }
 
-        public static readonly ChannelOption<TimeSpan> ConnectTimeout = new ChannelOption<TimeSpan>();
-        public static readonly ChannelOption<int> MaxMessagesPerRead = new ChannelOption<int>();
-        public static readonly ChannelOption<int> WriteSpinCount = new ChannelOption<int>();
-        public static readonly ChannelOption<int> WriteBufferHighWaterMark = new ChannelOption<int>();
-        public static readonly ChannelOption<int> WriteBufferLowWaterMark = new ChannelOption<int>();
+        static readonly ChannelOptionPool Pool = new ChannelOptionPool();
 
-        public static readonly ChannelOption<bool> AllowHalfClosure = new ChannelOption<bool>();
-        public static readonly ChannelOption<bool> AutoRead = new ChannelOption<bool>();
+        /// <summary>Returns the {@link ChannelOption} of the specified name.</summary>
+        public static ChannelOption<T> ValueOf<T>(string name) => (ChannelOption<T>)Pool.ValueOf<T>(name);
 
-        public static readonly ChannelOption<bool> SoBroadcast = new ChannelOption<bool>();
-        public static readonly ChannelOption<bool> SoKeepalive = new ChannelOption<bool>();
-        public static readonly ChannelOption<int> SoSndbuf = new ChannelOption<int>();
-        public static readonly ChannelOption<int> SoRcvbuf = new ChannelOption<int>();
-        public static readonly ChannelOption<bool> SoReuseaddr = new ChannelOption<bool>();
-        public static readonly ChannelOption<int> SoLinger = new ChannelOption<int>();
-        public static readonly ChannelOption<int> SoBacklog = new ChannelOption<int>();
-        public static readonly ChannelOption<int> SoTimeout = new ChannelOption<int>();
+        /// <summary>Shortcut of {@link #valueOf(String) valueOf(firstNameComponent.getName() + "#" + secondNameComponent)}.</summary>
+        public static ChannelOption<T> ValueOf<T>(Type firstNameComponent, string secondNameComponent) => (ChannelOption<T>)Pool.ValueOf<T>(firstNameComponent, secondNameComponent);
 
-        //public static readonly ChannelOption<int> IP_TOS = new ChannelOption<int>();
-        //public static readonly ChannelOption<InetAddress> IP_MULTICAST_ADDR = new ChannelOption<int>("IP_MULTICAST_ADDR");
-        //public static readonly ChannelOption<NetworkInterface> IP_MULTICAST_IF = new ChannelOption<int>("IP_MULTICAST_IF");
-        public static readonly ChannelOption<int> IpMulticastTtl = new ChannelOption<int>();
-        public static readonly ChannelOption<bool> IpMulticastLoopDisabled = new ChannelOption<bool>();
+        /// <summary>Returns {@code true} if a {@link ChannelOption} exists for the given {@code name}.</summary>
+        public static bool Exists(string name) => Pool.Exists(name);
 
-        public static readonly ChannelOption<bool> TcpNodelay = new ChannelOption<bool>();
+        /// <summary>Creates a new {@link ChannelOption} for the given {@code name} or fail with an
+        /// {@link IllegalArgumentException} if a {@link ChannelOption} for the given {@code name} exists.
+        /// </summary>
+        public static  ChannelOption<T> NewInstance<T>(string name) => (ChannelOption<T>)Pool.NewInstance<T>(name);
 
-        internal ChannelOption()
+        public static readonly ChannelOption<IByteBufferAllocator> Allocator = ValueOf<IByteBufferAllocator>("ALLOCATOR");
+        public static readonly ChannelOption<IRecvByteBufAllocator> RcvbufAllocator = ValueOf<IRecvByteBufAllocator>("RCVBUF_ALLOCATOR");
+        public static readonly ChannelOption<IMessageSizeEstimator> MessageSizeEstimator = ValueOf<IMessageSizeEstimator>("MESSAGE_SIZE_ESTIMATOR");
+
+        public static readonly ChannelOption<TimeSpan> ConnectTimeout = ValueOf<TimeSpan>("CONNECT_TIMEOUT");
+        public static readonly ChannelOption<int> MaxMessagesPerRead = ValueOf<int>("MAX_MESSAGES_PER_READ");
+        public static readonly ChannelOption<int> WriteSpinCount = ValueOf<int>("WRITE_SPIN_COUNT");
+        public static readonly ChannelOption<int> WriteBufferHighWaterMark = ValueOf<int>("WRITE_BUFFER_HIGH_WATER_MARK");
+        public static readonly ChannelOption<int> WriteBufferLowWaterMark = ValueOf<int>("WRITE_BUFFER_LOW_WATER_MARK");
+
+        public static readonly ChannelOption<bool> AllowHalfClosure = ValueOf<bool>("ALLOW_HALF_CLOSURE");
+        public static readonly ChannelOption<bool> AutoRead = ValueOf<bool>("AUTO_READ");
+
+        public static readonly ChannelOption<bool> SoBroadcast = ValueOf<bool>("SO_BROADCAST");
+        public static readonly ChannelOption<bool> SoKeepalive = ValueOf<bool>("SO_KEEPALIVE");
+        public static readonly ChannelOption<int> SoSndbuf = ValueOf<int>("SO_SNDBUF");
+        public static readonly ChannelOption<int> SoRcvbuf = ValueOf<int>("SO_RCVBUF");
+        public static readonly ChannelOption<bool> SoReuseaddr = ValueOf<bool>("SO_REUSEADDR");
+        public static readonly ChannelOption<int> SoLinger = ValueOf<int>("SO_LINGER");
+        public static readonly ChannelOption<int> SoBacklog = ValueOf<int>("SO_BACKLOG");
+        public static readonly ChannelOption<int> SoTimeout = ValueOf<int>("SO_TIMEOUT");
+
+        //public static readonly ChannelOption<int> IP_TOS = ValueOf<int>("IP_TOS");
+        //public static readonly ChannelOption<InetAddress> IP_MULTICAST_ADDR = ValueOf<int>("IP_MULTICAST_ADDR");
+        //public static readonly ChannelOption<NetworkInterface> IP_MULTICAST_IF = ValueOf<int>("IP_MULTICAST_IF");
+        public static readonly ChannelOption<int> IpMulticastTtl = ValueOf<int>("IP_MULTICAST_TTL");
+        public static readonly ChannelOption<bool> IpMulticastLoopDisabled = ValueOf<bool>("IP_MULTICAST_LOOP_DISABLED");
+
+        public static readonly ChannelOption<bool> TcpNodelay = ValueOf<bool>("TCP_NODELAY");
+
+        internal ChannelOption(int id, string name)
+            : base(id, name)
         {
         }
 
@@ -48,6 +71,11 @@ namespace DotNetty.Transport.Channels
 
     public sealed class ChannelOption<T> : ChannelOption
     {
+        internal ChannelOption(int id, string name)
+            : base(id, name)
+        {
+        }
+
         public void Validate(T value) => Contract.Requires(value != null);
 
         public override bool Set(IChannelConfiguration configuration, object value) => configuration.SetOption(this, (T)value);

--- a/src/DotNetty.Transport/Channels/IChannel.cs
+++ b/src/DotNetty.Transport/Channels/IChannel.cs
@@ -7,8 +7,9 @@ namespace DotNetty.Transport.Channels
     using System.Net;
     using System.Threading.Tasks;
     using DotNetty.Buffers;
+    using DotNetty.Common.Utilities;
 
-    public interface IChannel : IComparable<IChannel>
+    public interface IChannel : IAttributeMap, IComparable<IChannel>
     {
         IChannelId Id { get; }
 

--- a/src/DotNetty.Transport/Channels/IChannelHandlerContext.cs
+++ b/src/DotNetty.Transport/Channels/IChannelHandlerContext.cs
@@ -8,8 +8,9 @@ namespace DotNetty.Transport.Channels
     using System.Threading.Tasks;
     using DotNetty.Buffers;
     using DotNetty.Common.Concurrency;
+    using DotNetty.Common.Utilities;
 
-    public interface IChannelHandlerContext
+    public interface IChannelHandlerContext : IAttributeMap
     {
         IChannel Channel { get; }
 

--- a/src/DotNetty.Transport/Channels/IEventLoopGroup.cs
+++ b/src/DotNetty.Transport/Channels/IEventLoopGroup.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Transport.Channels
 {
+    using System;
     using System.Threading.Tasks;
 
     public interface IEventLoopGroup
@@ -12,5 +13,7 @@ namespace DotNetty.Transport.Channels
         IEventLoop GetNext();
 
         Task ShutdownGracefullyAsync();
+
+        Task ShutdownGracefullyAsync(TimeSpan quietPeriod, TimeSpan timeout);
     }
 }

--- a/src/DotNetty.Transport/Channels/MultithreadEventLoopGroup.cs
+++ b/src/DotNetty.Transport/Channels/MultithreadEventLoopGroup.cs
@@ -81,5 +81,14 @@ namespace DotNetty.Transport.Channels
             }
             return this.TerminationCompletion;
         }
+
+        public Task ShutdownGracefullyAsync(TimeSpan quietPeriod, TimeSpan timeout)
+        {
+            foreach (IEventLoop eventLoop in this.eventLoops)
+            {
+                eventLoop.ShutdownGracefullyAsync(quietPeriod, timeout);
+            }
+            return this.TerminationCompletion;
+        }
     }
 }

--- a/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelPerfSpec.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelPerfSpec.cs
@@ -161,7 +161,10 @@ namespace DotNetty.Transport.Tests.Performance.Sockets
         {
             CloseChannel(this.clientChannel);
             CloseChannel(this.serverChannel);
-            Task.WaitAll(this.ClientGroup.ShutdownGracefullyAsync(), this.ServerGroup.ShutdownGracefullyAsync(), this.WorkerGroup.ShutdownGracefullyAsync());
+            Task.WaitAll(
+                this.ClientGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)),
+                this.ServerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)),
+                this.WorkerGroup.ShutdownGracefullyAsync(TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1)));
         }
 
         static void CloseChannel(IChannel cc) => cc?.CloseAsync().Wait();


### PR DESCRIPTION
Motivation:
Increasing feature parity and dev convenience through addition of arbitrary data assignment on Channel and related API on Bootstrap classes.

Modifications
- Introduced `IAttributeMap`, `IAttribute<T>`, `IConstant` and related impl artifacts.
- Moved `ChannelOption` to common constant codebase
- `AbstractChannel` now inherits from `DefaultChannelMap`
- Reflection-less child optoins config in `ServerBootstrap`
- Extra: minor closure allocation fixes, internal API fixes.

Result:
Attributes can be set on Channels, better code portability in Bootstrap.