### PR TITLE
Fixes TlsHandler from operation, perf and compat POVs.

### DIFF
--- a/DotNetty.sln
+++ b/DotNetty.sln
@@ -57,6 +57,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Tests.Common", "te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Transport.Tests.Performance", "test\DotNetty.Transport.Tests.Performance\DotNetty.Transport.Tests.Performance.csproj", "{F2C39894-476D-441D-878F-23A03B848E06}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetty.Handlers.Tests", "test\DotNetty.Handlers.Tests\DotNetty.Handlers.Tests.csproj", "{0F5AC479-520B-476F-8E2B-1849F5B63A91}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +160,12 @@ Global
 		{F2C39894-476D-441D-878F-23A03B848E06}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F2C39894-476D-441D-878F-23A03B848E06}.Signed|Any CPU.ActiveCfg = Release|Any CPU
 		{F2C39894-476D-441D-878F-23A03B848E06}.Signed|Any CPU.Build.0 = Release|Any CPU
+		{0F5AC479-520B-476F-8E2B-1849F5B63A91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F5AC479-520B-476F-8E2B-1849F5B63A91}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F5AC479-520B-476F-8E2B-1849F5B63A91}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F5AC479-520B-476F-8E2B-1849F5B63A91}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F5AC479-520B-476F-8E2B-1849F5B63A91}.Signed|Any CPU.ActiveCfg = Release|Any CPU
+		{0F5AC479-520B-476F-8E2B-1849F5B63A91}.Signed|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -181,5 +189,6 @@ Global
 		{D0D45DCD-EF82-43FA-8B95-D85D50378806} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 		{EDF30087-8B53-4432-84B8-D21BD9F49E95} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 		{F2C39894-476D-441D-878F-23A03B848E06} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
+		{0F5AC479-520B-476F-8E2B-1849F5B63A91} = {6A0821D4-8A5D-42AD-8E3F-F519100F4AD8}
 	EndGlobalSection
 EndGlobal

--- a/DotNetty.sln.DotSettings
+++ b/DotNetty.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantIfElseBlock/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantThisQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantToStringCallForValueType/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SimplifyConditionalTernaryExpression/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StyleCop_002ESA1208/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestUseVarKeywordEvident/@EntryIndexedValue">HINT</s:String>

--- a/build.cmd
+++ b/build.cmd
@@ -22,7 +22,7 @@ copy %CACHED_NUGET% .nuget\nuget.exe > nul
 .nuget\NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -Version 4.25.4
 
 .nuget\NuGet.exe install xunit.runner.console -OutputDirectory packages\FAKE -ExcludeVersion -Version 2.1.0
-.nuget\NuGet.exe install NBench.Runner -OutputDirectory packages -ExcludeVersion -Version 0.2.1
+.nuget\NuGet.exe install NBench.Runner -OutputDirectory packages -ExcludeVersion -Version 0.2.2
 
 if not exist packages\SourceLink.Fake\tools\SourceLink.fsx ( 
   .nuget\nuget.exe install SourceLink.Fake -OutputDirectory packages -ExcludeVersion

--- a/build.fsx
+++ b/build.fsx
@@ -440,6 +440,7 @@ Target "All" DoNothing
 "CleanTests" ==> "RunTests"
 
 // NBench dependencies
+"BuildRelease" ==> "NBench"
 "CleanPerf" ==> "NBench"
 
 // nuget dependencies

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ mono $SCRIPT_PATH/.nuget/nuget.exe update -self
 mono $SCRIPT_PATH/.nuget/nuget.exe install FAKE -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion -Version 4.25.4
 
 mono $SCRIPT_PATH/.nuget/nuget.exe install xunit.runners -OutputDirectory $SCRIPT_PATH/packages/FAKE -ExcludeVersion -Version 2.1.0
-mono $SCRIPT_PATH/.nuget/nuget.exe install NBench.Runner -OutputDirectory packages -ExcludeVersion -Version 0.2.1
+mono $SCRIPT_PATH/.nuget/nuget.exe install NBench.Runner -OutputDirectory packages -ExcludeVersion -Version 0.2.2
 
 if ! [ -e $SCRIPT_PATH/packages/SourceLink.Fake/tools/SourceLink.fsx ] ; then
 	mono $SCRIPT_PATH/.nuget/nuget.exe install SourceLink.Fake -OutputDirectory $SCRIPT_PATH/packages -ExcludeVersion

--- a/src/DotNetty.Common/ResourceLeakDetector.cs
+++ b/src/DotNetty.Common/ResourceLeakDetector.cs
@@ -298,13 +298,13 @@ namespace DotNetty.Common
                             .Append(StringUtil.Newline)
                             .Append(array[i]);
                     }
+                    buf.Append(StringUtil.Newline);
                 }
 
                 buf.Append("Created at:")
                     .Append(StringUtil.Newline)
                     .Append(this.creationRecord);
 
-                buf.Length -= StringUtil.Newline.Length;
                 return buf.ToString();
             }
         }

--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\LogLevelExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tls\NotSslRecordException.cs" />
     <Compile Include="Tls\TlsHandshakeCompletionEvent.cs" />
     <Compile Include="Tls\TlsHandler.cs" />
     <Compile Include="Timeout\IdleState.cs" />
@@ -56,6 +57,7 @@
     <Compile Include="Timeout\WriteTimeoutException.cs" />
     <Compile Include="Timeout\ReadTimeoutHandler.cs" />
     <Compile Include="Timeout\WriteTimeoutHandler.cs" />
+    <Compile Include="Tls\TlsUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotNetty.Buffers\DotNetty.Buffers.csproj">
@@ -86,7 +88,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Folder Include="Timeout\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/src/DotNetty.Handlers/Tls/NotSslRecordException.cs
+++ b/src/DotNetty.Handlers/Tls/NotSslRecordException.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tls
+{
+    using System;
+
+    /// <summary>
+    ///     Special exception which will get thrown if a packet is
+    ///     received that not looks like a TLS/SSL record. A user can check for
+    ///     this <see cref="NotSslRecordException" /> and so detect if one peer tries to
+    ///     use secure and the other plain connection.
+    /// </summary>
+    public class NotSslRecordException : Exception
+    {
+        public NotSslRecordException()
+            : base(string.Empty)
+        {
+        }
+
+        public NotSslRecordException(string message)
+            : base(message)
+        {
+        }
+
+        public NotSslRecordException(Exception cause)
+            : base(string.Empty, cause)
+        {
+        }
+
+        public NotSslRecordException(string message, Exception cause)
+            : base(message, cause)
+        {
+        }
+    }
+}

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -21,23 +21,26 @@ namespace DotNetty.Handlers.Tls
 
     public sealed class TlsHandler : ByteToMessageDecoder
     {
-        const int ReadBufferSize = 4 * 1024; // todo: research perfect size
+        const int FallbackReadBufferSize = 256;
+        const int UnencryptedWriteBatchSize = 14 * 1024;
 
         static readonly Exception ChannelClosedException = new IOException("Channel is closed");
-        static readonly Action<Task, object> AuthenticationCompletionCallback = new Action<Task, object>(HandleAuthenticationCompleted);
-        static readonly AsyncCallback SslStreamReadCallback = new AsyncCallback(HandleSslStreamRead);
+        static readonly Action<Task, object> HandshakeCompletionCallback = new Action<Task, object>(HandleHandshakeCompleted);
 
         readonly SslStream sslStream;
-        State state;
+        TlsHandlerState state;
+        int packetLength;
         readonly MediationStream mediationStream;
-        IByteBuffer sslStreamReadBuffer;
         volatile IChannelHandlerContext capturedContext;
-        PendingWriteQueue pendingUnencryptedWrites;
+        BatchingPendingWriteQueue pendingUnencryptedWrites;
         Task lastContextWriteTask;
         readonly TaskCompletionSource closeFuture;
         readonly bool isServer;
         readonly X509Certificate2 certificate;
         readonly string targetHost;
+        bool firedChannelRead;
+        IByteBuffer pendingSslStreamReadBuffer;
+        Task<int> pendingSslStreamReadFuture;
 
         TlsHandler(bool isServer, X509Certificate2 certificate, string targetHost, RemoteCertificateValidationCallback certificateValidationCallback)
         {
@@ -112,46 +115,42 @@ namespace DotNetty.Handlers.Tls
             return false;
         }
 
-        static void HandleAuthenticationCompleted(Task task, object state)
+        static void HandleHandshakeCompleted(Task task, object state)
         {
             var self = (TlsHandler)state;
             switch (task.Status)
             {
                 case TaskStatus.RanToCompletion:
-                {
-                    State oldState = self.state;
-                    if ((oldState & State.AuthenticationCompleted) == 0)
                     {
-                        self.state = (oldState | State.Authenticated) & ~(State.Authenticating | State.FlushedBeforeHandshake);
+                        TlsHandlerState oldState = self.state;
+
+                        Contract.Assert(!oldState.HasAny(TlsHandlerState.AuthenticationCompleted));
+                        self.state = (oldState | TlsHandlerState.Authenticated) & ~(TlsHandlerState.Authenticating | TlsHandlerState.FlushedBeforeHandshake);
 
                         self.capturedContext.FireUserEventTriggered(TlsHandshakeCompletionEvent.Success);
 
-                        if ((oldState & State.ReadRequestedBeforeAuthenticated) == State.ReadRequestedBeforeAuthenticated
-                            && !self.capturedContext.Channel.Configuration.AutoRead)
+                        if (oldState.Has(TlsHandlerState.ReadRequestedBeforeAuthenticated) && !self.capturedContext.Channel.Configuration.AutoRead)
                         {
                             self.capturedContext.Read();
                         }
 
-                        if ((oldState & State.FlushedBeforeHandshake) != 0)
+                        if (oldState.Has(TlsHandlerState.FlushedBeforeHandshake))
                         {
                             self.Wrap(self.capturedContext);
                             self.capturedContext.Flush();
                         }
+                        break;
                     }
-                    break;
-                }
                 case TaskStatus.Canceled:
                 case TaskStatus.Faulted:
-                {
-                    // ReSharper disable once AssignNullToNotNullAttribute -- task.Exception will be present as task is faulted
-                    State oldState = self.state;
-                    if ((oldState & State.AuthenticationCompleted) == 0)
                     {
-                        self.state = (oldState | State.FailedAuthentication) & ~State.Authenticating;
+                        // ReSharper disable once AssignNullToNotNullAttribute -- task.Exception will be present as task is faulted
+                        TlsHandlerState oldState = self.state;
+                        Contract.Assert(!oldState.HasAny(TlsHandlerState.AuthenticationCompleted));
+                        self.state = (oldState | TlsHandlerState.FailedAuthentication) & ~TlsHandlerState.Authenticating;
+                        self.HandleFailure(task.Exception);
+                        break;
                     }
-                    self.HandleFailure(task.Exception);
-                    break;
-                }
                 default:
                     throw new ArgumentOutOfRangeException(nameof(task), "Unexpected task status: " + task.Status);
             }
@@ -161,7 +160,7 @@ namespace DotNetty.Handlers.Tls
         {
             base.HandlerAdded(context);
             this.capturedContext = context;
-            this.pendingUnencryptedWrites = new PendingWriteQueue(context);
+            this.pendingUnencryptedWrites = new BatchingPendingWriteQueue(context, UnencryptedWriteBatchSize);
             if (context.Channel.Active && !this.isServer)
             {
                 // todo: support delayed initialization on an existing/active channel if in client mode
@@ -180,36 +179,298 @@ namespace DotNetty.Handlers.Tls
 
         protected override void Decode(IChannelHandlerContext context, IByteBuffer input, List<object> output)
         {
-            // pass bytes to SslStream through input -> trigger HandleSslStreamRead. After this call sslStreamReadBuffer may or may not have bytes to read
-            this.mediationStream.AcceptBytes(input);
+            int startOffset = input.ReaderIndex;
+            int endOffset = input.WriterIndex;
+            int offset = startOffset;
+            int totalLength = 0;
 
-            if (!this.EnsureAuthenticated())
+            List<int> packetLengths;
+            // if we calculated the length of the current SSL record before, use that information.
+            if (this.packetLength > 0)
             {
-                return;
+                if (endOffset - startOffset < this.packetLength)
+                {
+                    // input does not contain a single complete SSL record
+                    return;
+                }
+                else
+                {
+                    packetLengths = new List<int>(4);
+                    packetLengths.Add(this.packetLength);
+                    offset += this.packetLength;
+                    totalLength = this.packetLength;
+                    this.packetLength = 0;
+                }
+            }
+            else
+            {
+                packetLengths = new List<int>(4);
             }
 
-            IByteBuffer readBuffer = this.sslStreamReadBuffer;
-            if (readBuffer == null)
+            bool nonSslRecord = false;
+
+            while (totalLength < TlsUtils.MAX_ENCRYPTED_PACKET_LENGTH)
             {
-                this.sslStreamReadBuffer = readBuffer = context.Channel.Allocator.Buffer(ReadBufferSize);
-                this.ScheduleSslStreamRead();
+                int readableBytes = endOffset - offset;
+                if (readableBytes < TlsUtils.SSL_RECORD_HEADER_LENGTH)
+                {
+                    break;
+                }
+
+                int packetLength = TlsUtils.GetEncryptedPacketLength(input, offset);
+                if (packetLength == -1)
+                {
+                    nonSslRecord = true;
+                    break;
+                }
+
+                Contract.Assert(packetLength > 0);
+
+                if (packetLength > readableBytes)
+                {
+                    // wait until the whole packet can be read
+                    this.packetLength = packetLength;
+                    break;
+                }
+
+                int newTotalLength = totalLength + packetLength;
+                if (newTotalLength > TlsUtils.MAX_ENCRYPTED_PACKET_LENGTH)
+                {
+                    // Don't read too much.
+                    break;
+                }
+
+                // 1. call unwrap with packet boundaries - call SslStream.ReadAsync only once.
+                // 2. once we're through all the whole packets, switch to reading out using fallback sized buffer
+
+                // We have a whole packet.
+                // Increment the offset to handle the next packet.
+                packetLengths.Add(packetLength);
+                offset += packetLength;
+                totalLength = newTotalLength;
             }
 
-            if (readBuffer.IsReadable())
+            if (totalLength > 0)
             {
-                // SslStream parsed at least one full frame and completed read request
-                // Pass the buffer to a next handler in pipeline
-                output.Add(readBuffer);
-                this.sslStreamReadBuffer = null;
+                // The buffer contains one or more full SSL records.
+                // Slice out the whole packet so unwrap will only be called with complete packets.
+                // Also directly reset the packetLength. This is needed as unwrap(..) may trigger
+                // decode(...) again via:
+                // 1) unwrap(..) is called
+                // 2) wrap(...) is called from within unwrap(...)
+                // 3) wrap(...) calls unwrapLater(...)
+                // 4) unwrapLater(...) calls decode(...)
+                //
+                // See https://github.com/netty/netty/issues/1534
+
+                input.SkipBytes(totalLength);
+                this.Unwrap(context, input, startOffset, totalLength, packetLengths, output);
+
+                if (!this.firedChannelRead)
+                {
+                    // Check first if firedChannelRead is not set yet as it may have been set in a
+                    // previous decode(...) call.
+                    this.firedChannelRead = output.Count > 0;
+                }
             }
+
+            if (nonSslRecord)
+            {
+                // Not an SSL/TLS packet
+                var ex = new NotSslRecordException(
+                    "not an SSL/TLS record: " + ByteBufferUtil.HexDump(input));
+                input.SkipBytes(input.ReadableBytes);
+                context.FireExceptionCaught(ex);
+                this.HandleFailure(ex);
+            }
+        }
+
+        public override void ChannelReadComplete(IChannelHandlerContext ctx)
+        {
+            // Discard bytes of the cumulation buffer if needed.
+            this.DiscardSomeReadBytes();
+
+            this.ReadIfNeeded(ctx);
+
+            this.firedChannelRead = false;
+            ctx.FireChannelReadComplete();
+        }
+
+        void ReadIfNeeded(IChannelHandlerContext ctx)
+        {
+            // if handshake is not finished yet, we need more data
+            if (!ctx.Channel.Configuration.AutoRead && (!this.firedChannelRead || !this.state.HasAny(TlsHandlerState.AuthenticationCompleted)))
+            {
+                // No auto-read used and no message was passed through the ChannelPipeline or the handshake was not completed
+                // yet, which means we need to trigger the read to ensure we will not stall
+                ctx.Read();
+            }
+        }
+
+        /// <summary>Unwraps inbound SSL records.</summary>
+        void Unwrap(IChannelHandlerContext ctx, IByteBuffer packet, int offset, int length, List<int> packetLengths, List<object> output)
+        {
+            Contract.Requires(packetLengths.Count > 0);
+
+            //bool notifyClosure = false; // todo: netty/issues/137
+            bool pending = false;
+
+            IByteBuffer outputBuffer = null;
+
+            try
+            {
+                ArraySegment<byte> inputIoBuffer = packet.GetIoBuffer(offset, length);
+                this.mediationStream.SetSource(inputIoBuffer.Array, inputIoBuffer.Offset);
+
+                int packetIndex = 0;
+
+                while (!this.EnsureAuthenticated())
+                {
+                    this.mediationStream.ExpandSource(packetLengths[packetIndex]);
+                    if (++packetIndex == packetLengths.Count)
+                    {
+                        return;
+                    }
+                }
+
+                Task<int> currentReadFuture = this.pendingSslStreamReadFuture;
+
+                int outputBufferLength;
+
+                if (currentReadFuture != null)
+                {
+                    // restoring context from previous read
+                    Contract.Assert(this.pendingSslStreamReadBuffer != null);
+
+                    outputBuffer = this.pendingSslStreamReadBuffer;
+                    outputBufferLength = outputBuffer.WritableBytes;
+                }
+                else
+                {
+                    outputBufferLength = 0;
+                }
+
+                // go through packets one by one (because SslStream does not consume more than 1 packet at a time)
+                for (; packetIndex < packetLengths.Count; packetIndex++)
+                {
+                    int currentPacketLength = packetLengths[packetIndex];
+                    this.mediationStream.ExpandSource(currentPacketLength);
+
+                    if (currentReadFuture != null)
+                    {
+                        // there was a read pending already, so we make sure we completed that first
+
+                        if (!currentReadFuture.IsCompleted)
+                        {
+                            // we did feed the whole current packet to SslStream yet it did not produce any result -> move to the next packet in input
+                            Contract.Assert(this.mediationStream.SourceReadableBytes == 0);
+
+                            continue;
+                        }
+
+                        int read = currentReadFuture.Result;
+
+                        // Now output the result of previous read and decide whether to do an extra read on the same source or move forward
+                        AddBufferToOutput(outputBuffer, read, output);
+
+                        currentReadFuture = null;
+                        if (this.mediationStream.SourceReadableBytes == 0)
+                        {
+                            // we just made a frame available for reading but there was already pending read so SslStream read it out to make further progress there
+
+                            if (read < outputBufferLength)
+                            {
+                                // SslStream returned non-full buffer and there's no more input to go through ->
+                                // typically it means SslStream is done reading current frame so we skip
+                                continue;
+                            }
+
+                            // we've read out `read` bytes out of current packet to fulfil previously outstanding read
+                            outputBufferLength = currentPacketLength - read;
+                            if (outputBufferLength <= 0)
+                            {
+                                // after feeding to SslStream current frame it read out more bytes than current packet size
+                                outputBufferLength = FallbackReadBufferSize;
+                            }
+                        }
+                        else
+                        {
+                            // SslStream did not get to reading current frame so it completed previous read sync
+                            // and the next read will likely read out the new frame
+                            outputBufferLength = currentPacketLength;
+                        }
+                    }
+                    else
+                    {
+                        // there was no pending read before so we estimate buffer of `currentPacketLength` bytes to be sufficient
+                        outputBufferLength = currentPacketLength;
+                    }
+
+                    outputBuffer = ctx.Allocator.Buffer(outputBufferLength);
+                    currentReadFuture = this.ReadFromSslStreamAsync(outputBuffer, outputBufferLength);
+                }
+
+                // read out the rest of SslStream's output (if any) at risk of going async
+                // using FallbackReadBufferSize - buffer size we're ok to have pinned with the SslStream until it's done reading
+                while (true)
+                {
+                    if (currentReadFuture != null)
+                    {
+                        if (!currentReadFuture.IsCompleted)
+                        {
+                            break;
+                        }
+                        int read = currentReadFuture.Result;
+                        AddBufferToOutput(outputBuffer, read, output);
+                    }
+                    outputBuffer = ctx.Allocator.Buffer(FallbackReadBufferSize);
+                    currentReadFuture = this.ReadFromSslStreamAsync(outputBuffer, FallbackReadBufferSize);
+                }
+
+                pending = true;
+                this.pendingSslStreamReadBuffer = outputBuffer;
+                this.pendingSslStreamReadFuture = currentReadFuture;
+            }
+            catch (Exception ex)
+            {
+                this.HandleFailure(ex);
+                throw;
+            }
+            finally
+            {
+                this.mediationStream.ResetSource();
+                if (!pending && outputBuffer != null)
+                {
+                    if (outputBuffer.IsReadable())
+                    {
+                        output.Add(outputBuffer);
+                    }
+                    else
+                    {
+                        outputBuffer.Release();
+                    }
+                }
+            }
+        }
+
+        static void AddBufferToOutput(IByteBuffer outputBuffer, int length, List<object> output)
+        {
+            Contract.Assert(length > 0);
+            output.Add(outputBuffer.SetWriterIndex(outputBuffer.WriterIndex + length));
+        }
+
+        Task<int> ReadFromSslStreamAsync(IByteBuffer outputBuffer, int outputBufferLength)
+        {
+            ArraySegment<byte> outlet = outputBuffer.GetIoBuffer(outputBuffer.WriterIndex, outputBufferLength);
+            return this.sslStream.ReadAsync(outlet.Array, outlet.Offset, outlet.Count);
         }
 
         public override void Read(IChannelHandlerContext context)
         {
-            State oldState = this.state;
-            if ((oldState & State.AuthenticationCompleted) == 0)
+            TlsHandlerState oldState = this.state;
+            if (!oldState.HasAny(TlsHandlerState.AuthenticationCompleted))
             {
-                this.state = oldState | State.ReadRequestedBeforeAuthenticated;
+                this.state = oldState | TlsHandlerState.ReadRequestedBeforeAuthenticated;
             }
 
             context.Read();
@@ -217,14 +478,14 @@ namespace DotNetty.Handlers.Tls
 
         bool EnsureAuthenticated()
         {
-            State oldState = this.state;
-            if ((oldState & State.AuthenticationStarted) == 0)
+            TlsHandlerState oldState = this.state;
+            if (!oldState.HasAny(TlsHandlerState.AuthenticationStarted))
             {
-                this.state = oldState | State.Authenticating;
+                this.state = oldState | TlsHandlerState.Authenticating;
                 if (this.isServer)
                 {
                     this.sslStream.AuthenticateAsServerAsync(this.certificate, false, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false) // todo: change to begin/end
-                        .ContinueWith(AuthenticationCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);
+                        .ContinueWith(HandshakeCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);
                 }
                 else
                 {
@@ -234,32 +495,12 @@ namespace DotNetty.Handlers.Tls
                         certificateCollection.Add(this.certificate);
                     }
                     this.sslStream.AuthenticateAsClientAsync(this.targetHost, certificateCollection, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, false) // todo: change to begin/end
-                        .ContinueWith(AuthenticationCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);
+                        .ContinueWith(HandshakeCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);
                 }
                 return false;
             }
-            return (oldState & State.Authenticated) == State.Authenticated;
-        }
 
-        void ScheduleSslStreamRead()
-        {
-            try
-            {
-                IByteBuffer buf = this.sslStreamReadBuffer;
-                this.sslStream.BeginRead(buf.Array, buf.ArrayOffset + buf.WriterIndex, buf.WritableBytes, SslStreamReadCallback, this);
-            }
-            catch (Exception ex)
-            {
-                this.HandleFailure(ex);
-                throw;
-            }
-        }
-
-        static void HandleSslStreamRead(IAsyncResult ar)
-        {
-            var self = (TlsHandler)ar.AsyncState;
-            int length = self.sslStream.EndRead(ar);
-            self.sslStreamReadBuffer.SetWriterIndex(self.sslStreamReadBuffer.ReaderIndex + length); // adjust byte buffer's writer index to reflect read progress
+            return oldState.Has(TlsHandlerState.Authenticated);
         }
 
         public override Task WriteAsync(IChannelHandlerContext context, object message)
@@ -280,52 +521,84 @@ namespace DotNetty.Handlers.Tls
 
             if (!this.EnsureAuthenticated())
             {
-                this.state |= State.FlushedBeforeHandshake;
+                this.state |= TlsHandlerState.FlushedBeforeHandshake;
                 return;
             }
 
-            this.Wrap(context);
-            context.Flush();
+            try
+            {
+                this.Wrap(context);
+            }
+            finally
+            {
+                // We may have written some parts of data before an exception was thrown so ensure we always flush.
+                context.Flush();
+            }
         }
 
         void Wrap(IChannelHandlerContext context)
         {
             Contract.Assert(context == this.capturedContext);
 
-            while (true)
+            IByteBuffer buf = null;
+            try
             {
-                object msg = this.pendingUnencryptedWrites.Current;
-                if (msg == null)
+                while (true)
                 {
-                    break;
-                }
+                    List<object> messages = this.pendingUnencryptedWrites.Current;
+                    if (messages == null || messages.Count == 0)
+                    {
+                        break;
+                    }
 
-                var buf = (IByteBuffer)msg;
-                buf.ReadBytes(this.sslStream, buf.ReadableBytes); // this leads to FinishWrap being called 0+ times
+                    if (messages.Count == 1)
+                    {
+                        buf = (IByteBuffer)messages[0];
+                    }
+                    else
+                    {
+                        buf = context.Allocator.Buffer((int)this.pendingUnencryptedWrites.CurrentSize);
+                        foreach (IByteBuffer buffer in messages)
+                        {
+                            buffer.ReadBytes(buf, buffer.ReadableBytes);
+                            buffer.Release();
+                        }
+                    }
+                    buf.ReadBytes(this.sslStream, buf.ReadableBytes); // this leads to FinishWrap being called 0+ times
+                    buf.Release();
 
-                TaskCompletionSource promise = this.pendingUnencryptedWrites.Remove();
-                Task task = this.lastContextWriteTask;
-                if (task != null)
-                {
-                    task.LinkOutcome(promise);
-                    this.lastContextWriteTask = null;
+                    TaskCompletionSource promise = this.pendingUnencryptedWrites.Remove();
+                    Task task = this.lastContextWriteTask;
+                    if (task != null)
+                    {
+                        task.LinkOutcome(promise);
+                        this.lastContextWriteTask = null;
+                    }
+                    else
+                    {
+                        promise.TryComplete();
+                    }
                 }
-                else
-                {
-                    promise.TryComplete();
-                }
+            }
+            catch (Exception ex)
+            {
+                ReferenceCountUtil.SafeRelease(buf);
+                this.HandleFailure(ex);
+                throw;
             }
         }
 
         void FinishWrap(byte[] buffer, int offset, int count)
         {
-            IByteBuffer output = this.capturedContext.Allocator.Buffer(count);
-            output.WriteBytes(buffer, offset, count);
-
-            if (!output.IsReadable())
+            IByteBuffer output;
+            if (count == 0)
             {
-                output.Release();
                 output = Unpooled.Empty;
+            }
+            else
+            {
+                output = this.capturedContext.Allocator.Buffer(count);
+                output.WriteBytes(buffer, offset, count);
             }
 
             this.lastContextWriteTask = this.capturedContext.WriteAsync(output);
@@ -333,8 +606,8 @@ namespace DotNetty.Handlers.Tls
 
         public override Task CloseAsync(IChannelHandlerContext context)
         {
-            this.sslStream.Close();
             this.closeFuture.TryComplete();
+            this.sslStream.Dispose();
             return base.CloseAsync(context);
         }
 
@@ -345,7 +618,7 @@ namespace DotNetty.Handlers.Tls
 
             try
             {
-                this.sslStream.Close();
+                this.sslStream.Dispose();
             }
             catch (Exception ex)
             {
@@ -357,7 +630,7 @@ namespace DotNetty.Handlers.Tls
                 //string msg = ex.Message;
                 //if (msg == null || !msg.contains("possible truncation attack"))
                 //{
-                //    logger.Debug("{} SSLEngine.closeInbound() raised an exception.", ctx.channel(), e);
+                //    //Logger.Debug("{} SSLEngine.closeInbound() raised an exception.", ctx.channel(), e);
                 //}
             }
             this.NotifyHandshakeFailure(cause);
@@ -366,25 +639,13 @@ namespace DotNetty.Handlers.Tls
 
         void NotifyHandshakeFailure(Exception cause)
         {
-            if ((this.state & State.AuthenticationCompleted) == 0)
+            if (!this.state.HasAny(TlsHandlerState.AuthenticationCompleted))
             {
                 // handshake was not completed yet => TlsHandler react to failure by closing the channel
-                this.state = (this.state | State.FailedAuthentication) & ~State.Authenticating;
+                this.state = (this.state | TlsHandlerState.FailedAuthentication) & ~TlsHandlerState.Authenticating;
                 this.capturedContext.FireUserEventTriggered(new TlsHandshakeCompletionEvent(cause));
-                this.capturedContext.CloseAsync();
+                this.CloseAsync(this.capturedContext);
             }
-        }
-
-        [Flags]
-        enum State
-        {
-            Authenticating = 1,
-            Authenticated = 1 << 1,
-            FailedAuthentication = 1 << 2,
-            ReadRequestedBeforeAuthenticated = 1 << 3,
-            FlushedBeforeHandshake = 1 << 4,
-            AuthenticationStarted = Authenticating | Authenticated | FailedAuthentication,
-            AuthenticationCompleted = Authenticated | FailedAuthentication
         }
 
         sealed class MediationStream : Stream
@@ -392,8 +653,11 @@ namespace DotNetty.Handlers.Tls
             static readonly Action<Task, object> WriteCompleteCallback = HandleChannelWriteComplete;
 
             readonly TlsHandler owner;
-            IByteBuffer pendingReadBuffer;
-            readonly SynchronousAsyncResult<int> syncReadResult;
+            byte[] input;
+            int inputStartOffset;
+            int inputOffset;
+            int inputLength;
+            SynchronousAsyncResult<int> syncReadResult;
             TaskCompletionSource<int> readCompletionSource;
             AsyncCallback readCallback;
             ArraySegment<byte> sslOwnedBuffer;
@@ -402,55 +666,71 @@ namespace DotNetty.Handlers.Tls
 
             public MediationStream(TlsHandler owner)
             {
-                this.syncReadResult = new SynchronousAsyncResult<int>();
                 this.owner = owner;
             }
 
-            public void AcceptBytes(IByteBuffer input)
+            public int SourceReadableBytes => this.inputLength - this.inputOffset;
+
+            public void SetSource(byte[] source, int offset)
             {
-                TaskCompletionSource<int> tcs = this.readCompletionSource;
-                if (tcs == null)
+                this.input = source;
+                this.inputStartOffset = offset;
+                this.inputOffset = 0;
+                this.inputLength = 0;
+            }
+
+            public void ResetSource()
+            {
+                this.input = null;
+                this.inputLength = 0;
+            }
+
+            public void ExpandSource(int count)
+            {
+                Contract.Assert(this.input != null);
+
+                this.inputLength += count;
+
+                TaskCompletionSource<int> promise = this.readCompletionSource;
+                if (promise == null)
                 {
                     // there is no pending read operation - keep for future
-                    this.pendingReadBuffer = input;
                     return;
                 }
 
                 ArraySegment<byte> sslBuffer = this.sslOwnedBuffer;
 
-                Contract.Assert(sslBuffer.Array != null);
+                int read = this.ReadFromInput(sslBuffer.Array, sslBuffer.Offset, sslBuffer.Count);
+                promise.TrySetResult(read);
 
-                int readableBytes = input.ReadableBytes;
-                int length = Math.Min(sslBuffer.Count, readableBytes);
-                input.ReadBytes(sslBuffer.Array, sslBuffer.Offset, length);
-                tcs.TrySetResult(length);
-                if (length < readableBytes)
+                this.readCallback?.Invoke(promise.Task);
+            }
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                if (this.inputLength - this.inputOffset > 0)
                 {
-                    // set buffer for consecutive read to use
-                    this.pendingReadBuffer = input;
+                    // we have the bytes available upfront - write out synchronously
+                    int read = this.ReadFromInput(buffer, offset, count);
+                    return Task.FromResult(read);
                 }
 
-                this.readCallback?.Invoke(tcs.Task);
+                // take note of buffer - we will pass bytes there once available
+                this.sslOwnedBuffer = new ArraySegment<byte>(buffer, offset, count);
+                this.readCompletionSource = new TaskCompletionSource<int>();
+                return this.readCompletionSource.Task;
             }
 
             public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
             {
-                IByteBuffer pendingBuf = this.pendingReadBuffer;
-                if (pendingBuf != null)
+                if (this.inputLength - this.inputOffset > 0)
                 {
                     // we have the bytes available upfront - write out synchronously
-                    int readableBytes = pendingBuf.ReadableBytes;
-                    int length = Math.Min(count, readableBytes);
-                    pendingBuf.ReadBytes(buffer, offset, length);
-                    if (length == readableBytes)
-                    {
-                        // buffer has been read out to the end
-                        this.pendingReadBuffer = null;
-                    }
-                    return this.PrepareSyncReadResult(length, state);
+                    int read = this.ReadFromInput(buffer, offset, count);
+                    return this.PrepareSyncReadResult(read, state);
                 }
 
-                // take note of buffer - we will pass bytes in here
+                // take note of buffer - we will pass bytes there once available
                 this.sslOwnedBuffer = new ArraySegment<byte>(buffer, offset, count);
                 this.readCompletionSource = new TaskCompletionSource<int>(state);
                 this.readCallback = callback;
@@ -485,6 +765,9 @@ namespace DotNetty.Handlers.Tls
             }
 
             public override void Write(byte[] buffer, int offset, int count) => this.owner.FinishWrap(buffer, offset, count);
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                => this.owner.capturedContext.WriteAndFlushAsync(Unpooled.WrappedBuffer(buffer, offset, count));
 
             public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
             {
@@ -548,10 +831,22 @@ namespace DotNetty.Handlers.Tls
                 }
             }
 
+            int ReadFromInput(byte[] destination, int destinationOffset, int destinationCapacity)
+            {
+                Contract.Assert(destination != null);
+
+                byte[] source = this.input;
+                int readableBytes = this.inputLength - this.inputOffset;
+                int length = Math.Min(readableBytes, destinationCapacity);
+                Buffer.BlockCopy(source, this.inputStartOffset + this.inputOffset, destination, destinationOffset, length);
+                this.inputOffset += length;
+                return length;
+            }
+
             IAsyncResult PrepareSyncReadResult(int readBytes, object state)
             {
                 // it is safe to reuse sync result object as it can't lead to leak (no way to attach to it via handle)
-                SynchronousAsyncResult<int> result = this.syncReadResult;
+                SynchronousAsyncResult<int> result = this.syncReadResult ?? (this.syncReadResult = new SynchronousAsyncResult<int>());
                 result.Result = readBytes;
                 result.AsyncState = state;
                 return result;
@@ -618,5 +913,24 @@ namespace DotNetty.Handlers.Tls
 
             #endregion
         }
+    }
+
+    [Flags]
+    enum TlsHandlerState
+    {
+        Authenticating = 1,
+        Authenticated = 1 << 1,
+        FailedAuthentication = 1 << 2,
+        ReadRequestedBeforeAuthenticated = 1 << 3,
+        FlushedBeforeHandshake = 1 << 4,
+        AuthenticationStarted = Authenticating | Authenticated | FailedAuthentication,
+        AuthenticationCompleted = Authenticated | FailedAuthentication
+    }
+
+    static class TlsHandlerStateExtensions
+    {
+        public static bool Has(this TlsHandlerState value, TlsHandlerState testValue) => (value & testValue) == testValue;
+
+        public static bool HasAny(this TlsHandlerState value, TlsHandlerState testValue) => (value & testValue) != 0;
     }
 }

--- a/src/DotNetty.Handlers/Tls/TlsHandshakeCompletionEvent.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandshakeCompletionEvent.cs
@@ -41,5 +41,11 @@ namespace DotNetty.Handlers.Tls
         ///     and so the handshake failed.
         /// </summary>
         public Exception Exception => this.exception;
+
+        public override string ToString()
+        {
+            Exception ex = this.Exception;
+            return ex == null ? "TlsHandshakeCompletionEvent(SUCCESS)" : $"TlsHandshakeCompletionEvent({ex})";
+        }
     }
 }

--- a/src/DotNetty.Handlers/Tls/TlsUtils.cs
+++ b/src/DotNetty.Handlers/Tls/TlsUtils.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tls
+{
+    using System;
+    using DotNetty.Buffers;
+    using DotNetty.Transport.Channels;
+
+    /// Utilities for TLS packets.
+    static class TlsUtils
+    {
+        const int MAX_PLAINTEXT_LENGTH = 16 * 1024; // 2^14
+        const int MAX_COMPRESSED_LENGTH = MAX_PLAINTEXT_LENGTH + 1024;
+        const int MAX_CIPHERTEXT_LENGTH = MAX_COMPRESSED_LENGTH + 1024;
+
+        // Header (5) + Data (2^14) + Compression (1024) + Encryption (1024) + MAC (20) + Padding (256)
+        public const int MAX_ENCRYPTED_PACKET_LENGTH = MAX_CIPHERTEXT_LENGTH + 5 + 20 + 256;
+
+
+        /// change cipher spec
+        public const int SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC = 20;
+
+        /// alert
+        public const int SSL_CONTENT_TYPE_ALERT = 21;
+
+        /// handshake
+        public const int SSL_CONTENT_TYPE_HANDSHAKE = 22;
+
+        /// application data
+        public const int SSL_CONTENT_TYPE_APPLICATION_DATA = 23;
+
+        /// the length of the ssl record header (in bytes)
+        public const int SSL_RECORD_HEADER_LENGTH = 5;
+
+        /// <summary>
+        ///     Return how much bytes can be read out of the encrypted data. Be aware that this method will not increase
+        ///     the readerIndex of the given <see cref="IByteBuffer"/>.
+        /// </summary>
+        /// <param name="buffer">
+        ///     The <see cref="IByteBuffer"/> to read from. Be aware that it must have at least
+        ///     <see cref="SSL_RECORD_HEADER_LENGTH"/> bytes to read,
+        ///     otherwise it will throw an <see cref="ArgumentException"/>.
+        /// </param>
+        /// <param name="offset">Offset to record start.</param>
+        /// <returns>
+        ///     The length of the encrypted packet that is included in the buffer. This will
+        ///     return <c>-1</c> if the given <see cref="IByteBuffer"/> is not encrypted at all.
+        /// </returns>
+        public static int GetEncryptedPacketLength(IByteBuffer buffer, int offset)
+        {
+            int packetLength = 0;
+
+            // SSLv3 or TLS - Check ContentType
+            switch (buffer.GetByte(offset))
+            {
+                case SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC:
+                case SSL_CONTENT_TYPE_ALERT:
+                case SSL_CONTENT_TYPE_HANDSHAKE:
+                case SSL_CONTENT_TYPE_APPLICATION_DATA:
+                    break;
+                default:
+                    // SSLv2 or bad data
+                    return -1;
+            }
+            // SSLv3 or TLS - Check ProtocolVersion
+            int majorVersion = buffer.GetByte(offset + 1);
+            if (majorVersion == 3)
+            {
+                // SSLv3 or TLS
+                packetLength = buffer.GetUnsignedShort(offset + 3) + SSL_RECORD_HEADER_LENGTH;
+                if (packetLength <= SSL_RECORD_HEADER_LENGTH)
+                {
+                    // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
+                    return -1;
+                }
+            }
+            else
+            {
+                // Neither SSLv3 or TLSv1 (i.e. SSLv2 or bad data)
+                return -1;
+            }
+
+            return packetLength;
+        }
+
+        public static void NotifyHandshakeFailure(IChannelHandlerContext ctx, Exception cause)
+        {
+            // We have may haven written some parts of data before an exception was thrown so ensure we always flush.
+            // See https://github.com/netty/netty/issues/3900#issuecomment-172481830
+            ctx.Flush();
+            ctx.FireUserEventTriggered(new TlsHandshakeCompletionEvent(cause));
+            ctx.CloseAsync();
+        }
+    }
+}

--- a/src/DotNetty.Transport/Bootstrapping/AbstractBootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/AbstractBootstrap.cs
@@ -22,7 +22,7 @@ namespace DotNetty.Transport.Bootstrapping
     ///         transports such as datagram (UDP).
     ///     </p>
     /// </summary>
-    public abstract class AbstractBootstrap<TBootstrap, TChannel> : ICloneable
+    public abstract class AbstractBootstrap<TBootstrap, TChannel>
         where TBootstrap : AbstractBootstrap<TBootstrap, TChannel>
         where TChannel : IChannel
     {
@@ -172,7 +172,7 @@ namespace DotNetty.Transport.Bootstrapping
         ///     multiple {@link Channel}s with similar settings.  Please note that this method does not clone the
         ///     {@link EventLoopGroup} deeply but shallowly, making the group a shared resource.
         /// </summary>
-        public abstract object Clone();
+        public abstract TBootstrap Clone();
 
         /// <summary>
         ///     Create a new {@link Channel} and register it with an {@link EventLoop}.
@@ -418,6 +418,8 @@ namespace DotNetty.Transport.Bootstrapping
             }
 
             public override bool Set(IChannelConfiguration config) => config.SetOption(this.option, this.value);
+
+            public override string ToString() => this.value.ToString();
         }
 
         protected abstract class AttributeValue

--- a/src/DotNetty.Transport/Bootstrapping/Bootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/Bootstrap.cs
@@ -222,7 +222,7 @@ namespace DotNetty.Transport.Bootstrapping
             return this;
         }
 
-        public override object Clone() => new Bootstrap(this);
+        public override Bootstrap Clone() => new Bootstrap(this);
 
         /// <summary>
         ///     Returns a deep clone of this bootstrap which has the identical configuration except that it uses

--- a/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
@@ -257,7 +257,7 @@ namespace DotNetty.Transport.Bootstrapping
             }
         }
 
-        public override object Clone() => new ServerBootstrap(this);
+        public override ServerBootstrap Clone() => new ServerBootstrap(this);
 
         public override string ToString()
         {

--- a/src/DotNetty.Transport/Channels/ActionChannelInitializer.cs
+++ b/src/DotNetty.Transport/Channels/ActionChannelInitializer.cs
@@ -5,6 +5,7 @@ namespace DotNetty.Transport.Channels
 {
     using System;
     using System.Diagnostics.Contracts;
+    using DotNetty.Common.Utilities;
 
     public sealed class ActionChannelInitializer<T> : ChannelInitializer<T>
         where T : IChannel
@@ -19,5 +20,7 @@ namespace DotNetty.Transport.Channels
         }
 
         protected override void InitChannel(T channel) => this.initializationAction(channel);
+
+        public override string ToString() => nameof(ActionChannelInitializer<T>) + "[" + StringUtil.SimpleClassName(typeof(T)) + "]";
     }
 }

--- a/src/DotNetty.Transport/Channels/Embedded/EmbeddedChannel.cs
+++ b/src/DotNetty.Transport/Channels/Embedded/EmbeddedChannel.cs
@@ -125,8 +125,14 @@ namespace DotNetty.Transport.Channels.Embedded
         /// </summary>
         public Queue<object> OutboundMessages => this.outboundMessages ?? (this.outboundMessages = new Queue<object>());
 
+        /// <summary>
+        /// Return received data from this <see cref="IChannel"/>.
+        /// </summary>
         public T ReadInbound<T>() => (T)Poll(this.inboundMessages);
 
+        /// <summary>
+        /// Read data from the outbound. This may return <c>null</c> if nothing is readable.
+        /// </summary>
         public T ReadOutbound<T>() => (T)Poll(this.outboundMessages);
 
         protected override EndPoint LocalAddressInternal => this.Active ? LOCAL_ADDRESS : null;

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
@@ -56,7 +56,7 @@ namespace DotNetty.Transport.Channels.Sockets
             {
                 try
                 {
-                    socket.Close();
+                    socket.Dispose();
                 }
                 catch (SocketException ex2)
                 {

--- a/src/DotNetty.Transport/Channels/Sockets/TcpServerSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpServerSocketChannel.cs
@@ -75,7 +75,7 @@ namespace DotNetty.Transport.Channels.Sockets
         {
             if (this.ResetState(StateFlags.Open))
             {
-                this.Socket.Close(0);
+                this.Socket.Dispose();
             }
         }
 
@@ -185,7 +185,7 @@ namespace DotNetty.Transport.Channels.Sockets
                             {
                                 try
                                 {
-                                    connectedSocket.Close();
+                                    connectedSocket.Dispose();
                                 }
                                 catch (Exception ex2)
                                 {

--- a/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
@@ -168,7 +168,7 @@ namespace DotNetty.Transport.Channels.Sockets
             if (this.ResetState(StateFlags.Open | StateFlags.Active))
             {
                 this.Socket.Shutdown(SocketShutdown.Both);
-                this.Socket.Close(0);
+                this.Socket.Dispose();
             }
         }
 

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Bootstrapping\INameResolver.cs" />
     <Compile Include="Bootstrapping\ServerBootstrap.cs" />
     <Compile Include="Channels\AdaptiveRecvByteBufAllocator.cs" />
+    <Compile Include="Channels\BatchingPendingWriteQueue.cs" />
     <Compile Include="Channels\ChannelMetadata.cs" />
     <Compile Include="Channels\ChannelOutboundBuffer.cs" />
     <Compile Include="Channels\AbstractChannel.cs" />

--- a/test/DotNetty.Buffers.Tests/packages.config
+++ b/test/DotNetty.Buffers.Tests/packages.config
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net45" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
+++ b/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,7 +17,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>cacc9365</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
@@ -40,8 +40,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -49,12 +49,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -71,7 +75,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
@@ -119,10 +125,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
-  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/DotNetty.Codecs.Mqtt.Tests/packages.config
+++ b/test/DotNetty.Codecs.Mqtt.Tests/packages.config
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
+++ b/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -17,7 +16,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>48e5db24</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
@@ -43,11 +43,17 @@
     <Reference Include="xunit.abstractions">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -105,12 +111,6 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/DotNetty.Codecs.Tests/packages.config
+++ b/test/DotNetty.Codecs.Tests/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/DotNetty.Common.Tests/Concurrency/SingleThreadEventExecutorTests.cs
+++ b/test/DotNetty.Common.Tests/Concurrency/SingleThreadEventExecutorTests.cs
@@ -114,7 +114,7 @@ namespace DotNetty.Common.Tests.Concurrency
 
             scheduler.Execute(selfQueueAction);
             Task task = scheduler.ScheduleAsync(() => promise.Complete(), TimeSpan.FromMilliseconds(100));
-            await Task.WhenAny(task, Task.Delay(TimeSpan.FromMilliseconds(300)));
+            await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(1)));
             Assert.True(task.IsCompleted);
         }
 

--- a/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
+++ b/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,7 +17,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>09c245da</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
@@ -40,8 +40,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -61,12 +61,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -96,7 +100,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -125,8 +131,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/DotNetty.Common.Tests/packages.config
+++ b/test/DotNetty.Common.Tests/packages.config
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/DotNetty.Handlers.Tests/AsIsWriteStrategy.cs
+++ b/test/DotNetty.Handlers.Tests/AsIsWriteStrategy.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using DotNetty.Buffers;
+    using DotNetty.Common.Utilities;
+    using DotNetty.Transport.Channels.Embedded;
+
+    class AsIsWriteStrategy : IWriteStrategy
+    {
+        public Task WriteToChannelAsync(EmbeddedChannel channel, ArraySegment<byte> input)
+        {
+            channel.WriteInbound(Unpooled.WrappedBuffer(input.Array, input.Offset, input.Count));
+            return TaskEx.Completed;
+        }
+
+        public override string ToString() => "as-is";
+    }
+}

--- a/test/DotNetty.Handlers.Tests/BatchingWriteStrategy.cs
+++ b/test/DotNetty.Handlers.Tests/BatchingWriteStrategy.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using DotNetty.Buffers;
+    using DotNetty.Transport.Channels.Embedded;
+
+    class BatchingWriteStrategy : IWriteStrategy
+    {
+        readonly int maxBatchSize;
+        readonly TimeSpan timeWindow;
+        readonly bool forceSizing;
+        IByteBuffer pendingBuffer;
+        EmbeddedChannel channel;
+
+        public BatchingWriteStrategy(int maxBatchSize, TimeSpan timeWindow, bool forceSizing)
+        {
+            this.maxBatchSize = maxBatchSize;
+            this.timeWindow = timeWindow;
+            this.forceSizing = forceSizing;
+        }
+
+        public async Task WriteToChannelAsync(EmbeddedChannel ch, ArraySegment<byte> input)
+        {
+            this.channel = ch;
+
+            if (input.Count == 0)
+            {
+                if (this.pendingBuffer != null)
+                {
+                    this.FlushPendingBuffer();
+                }
+                ch.WriteInbound(Unpooled.Empty);
+            }
+
+            if (this.pendingBuffer == null)
+            {
+                await this.SetupPendingBufferAsync(input);
+                return;
+            }
+
+            if (input.Count + this.pendingBuffer.ReadableBytes >= this.maxBatchSize)
+            {
+                if (this.forceSizing)
+                {
+                    int appendLength = this.maxBatchSize - this.pendingBuffer.ReadableBytes;
+                    this.pendingBuffer.WriteBytes(input.Array, input.Offset, appendLength);
+                    this.FlushPendingBuffer();
+                    if (input.Count - appendLength > 0)
+                    {
+                        await this.SetupPendingBufferAsync(new ArraySegment<byte>(input.Array, input.Offset + appendLength, input.Count - appendLength));
+                    }
+                }
+                else
+                {
+                    this.FlushPendingBuffer();
+                    await this.SetupPendingBufferAsync(input);
+                }
+            }
+            else
+            {
+                this.pendingBuffer.WriteBytes(input.Array, input.Offset, input.Count);
+            }
+        }
+
+        async Task SetupPendingBufferAsync(ArraySegment<byte> input)
+        {
+            this.pendingBuffer = Unpooled.Buffer(Math.Max(this.maxBatchSize, input.Count));
+            this.pendingBuffer.WriteBytes(input.Array, input.Offset, input.Count);
+
+            if (this.pendingBuffer.ReadableBytes >= this.maxBatchSize)
+            {
+                if (this.forceSizing)
+                {
+                    do
+                    {
+                        this.channel.WriteInbound(this.pendingBuffer.ReadBytes(this.maxBatchSize));
+                    }
+                    while (this.pendingBuffer.ReadableBytes > this.maxBatchSize);
+                    if (!this.pendingBuffer.IsReadable())
+                    {
+                        this.pendingBuffer = null;
+                    }
+                    else
+                    {
+                        await this.ScheduleFlushByTimeoutAsync();
+                    }
+                }
+                else
+                {
+                    this.FlushPendingBuffer();
+                }
+            }
+            else
+            {
+                await this.ScheduleFlushByTimeoutAsync();
+            }
+        }
+
+        void FlushPendingBuffer()
+        {
+            this.channel.WriteInbound(this.pendingBuffer);
+            this.pendingBuffer = null;
+        }
+
+        async Task ScheduleFlushByTimeoutAsync()
+        {
+            IByteBuffer buffer = this.pendingBuffer;
+            await Task.Delay(this.timeWindow);
+            if (ReferenceEquals(this.pendingBuffer, buffer))
+            {
+                this.FlushPendingBuffer();
+            }
+        }
+
+        public override string ToString() => $"batch({this.maxBatchSize}, {this.timeWindow})";
+    }
+}

--- a/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
+++ b/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
@@ -1,15 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{94E10283-E26E-441A-A2A7-D9671A6E9818}</ProjectGuid>
+    <ProjectGuid>{0F5AC479-520B-476F-8E2B-1849F5B63A91}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DotNetty.Buffers.Tests</RootNamespace>
-    <AssemblyName>DotNetty.Buffers.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>DotNetty.Handlers.Tests</RootNamespace>
+    <AssemblyName>DotNetty.Handlers.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -17,10 +16,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,16 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.2.0.1406.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -78,34 +65,49 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
-          <Private>False</Private>
-        </Reference>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
       </ItemGroup>
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Compile Include="AbstractPooledByteBufTest.cs" />
-    <Compile Include="ByteBufferDerivationTests.cs" />
-    <Compile Include="LeakDetectionTest.cs" />
-    <Compile Include="PooledBigEndianHeapByteBufTest.cs" />
-    <Compile Include="PortionedMemoryStream.cs" />
-    <Compile Include="AbstractByteBufferTests.cs" />
+    <Compile Include="AsIsWriteStrategy.cs" />
+    <Compile Include="BatchingWriteStrategy.cs" />
+    <Compile Include="IWriteStrategy.cs" />
+    <Compile Include="MediationStream.cs" />
+    <Compile Include="TlsHandlerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="PooledBufferAllocatorTests.cs" />
-    <Compile Include="AbstractByteBufTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="..\..\shared\dotnetty.com.pfx">
+      <Link>dotnetty.com.pfx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj">
-      <Project>{5DE3C557-48BF-4CDB-9F47-474D343DD841}</Project>
+      <Project>{5de3c557-48bf-4cdb-9f47-474d343dd841}</Project>
       <Name>DotNetty.Buffers</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Codecs\DotNetty.Codecs.csproj">
+      <Project>{2abd244e-ef8f-460d-9c30-39116499e6e4}</Project>
+      <Name>DotNetty.Codecs</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj">
-      <Project>{DE58FE41-5E99-44E5-86BC-FC9ED8761DAF}</Project>
+      <Project>{de58fe41-5e99-44e5-86bc-fc9ed8761daf}</Project>
       <Name>DotNetty.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Handlers\DotNetty.Handlers.csproj">
+      <Project>{09628314-f44e-445e-9f0d-cbe33b736ac3}</Project>
+      <Name>DotNetty.Handlers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\DotNetty.Transport\DotNetty.Transport.csproj">
+      <Project>{8218c9ee-0a4a-432f-a12a-b54202f97b05}</Project>
+      <Name>DotNetty.Transport</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\DotNetty.Tests.Common\DotNetty.Tests.Common.csproj">
+      <Project>{edf30087-8b53-4432-84b8-d21bd9f49e95}</Project>
+      <Name>DotNetty.Tests.Common</Name>
     </ProjectReference>
   </ItemGroup>
   <Choose>
@@ -128,12 +130,6 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/DotNetty.Handlers.Tests/IWriteStrategy.cs
+++ b/test/DotNetty.Handlers.Tests/IWriteStrategy.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using DotNetty.Transport.Channels.Embedded;
+
+    public interface IWriteStrategy
+    {
+        Task WriteToChannelAsync(EmbeddedChannel channel, ArraySegment<byte> input);
+    }
+}

--- a/test/DotNetty.Handlers.Tests/MediationStream.cs
+++ b/test/DotNetty.Handlers.Tests/MediationStream.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tests
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    class MediationStream : Stream
+    {
+        readonly Func<ArraySegment<byte>, Task<int>> readDataFunc;
+        readonly Action<ArraySegment<byte>> writeDataFunc;
+
+        public MediationStream(Func<ArraySegment<byte>, Task<int>> readDataFunc, Action<ArraySegment<byte>> writeDataFunc)
+        {
+            this.readDataFunc = readDataFunc;
+            this.writeDataFunc = writeDataFunc;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => this.readDataFunc(new ArraySegment<byte>(buffer, offset, count)).Result;
+
+        public override void Write(byte[] buffer, int offset, int count) => this.writeDataFunc(new ArraySegment<byte>(buffer, offset, count));
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+    }
+}

--- a/test/DotNetty.Handlers.Tests/Properties/AssemblyInfo.cs
+++ b/test/DotNetty.Handlers.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DotNetty.Handlers.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DotNetty.Handlers.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0f5ac479-520b-476f-8e2b-1849f5b63a91")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Security;
+    using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Threading.Tasks;
+    using DotNetty.Buffers;
+    using DotNetty.Handlers.Tls;
+    using DotNetty.Tests.Common;
+    using DotNetty.Transport.Channels.Embedded;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class TlsHandlerTest : TestBase
+    {
+        static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
+        public TlsHandlerTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        public static IEnumerable<object[]> GetTlsReadTestData()
+        {
+            var random = new Random(Environment.TickCount);
+            var lengthVariations =
+                new[]
+                {
+                    new[] { 1 },
+                    new[] { 2, 8000, 300 },
+                    new[] { 100, 0, 1000 },
+                    new[] { 4 * 1024 - 10, 1, 0, 1 },
+                    new[] { 0, 24000, 0, 1000 },
+                    new[] { 0, 4000, 0 },
+                    new[] { 16 * 1024 - 100 },
+                    Enumerable.Repeat(0, 30).Select(_ => random.Next(0, 17000)).ToArray()
+                };
+            var boolToggle = new[] { false, true };
+            var protocols = new[] { SslProtocols.Tls, SslProtocols.Tls11, SslProtocols.Tls12 };
+            var writeStrategyFactories = new Func<IWriteStrategy>[]
+            {
+                () => new AsIsWriteStrategy(),
+                () => new BatchingWriteStrategy(1, TimeSpan.FromMilliseconds(20), true),
+                () => new BatchingWriteStrategy(4096, TimeSpan.FromMilliseconds(20), true),
+                () => new BatchingWriteStrategy(32 * 1024, TimeSpan.FromMilliseconds(20), false)
+            };
+
+            return
+                from frameLengths in lengthVariations
+                from isClient in boolToggle
+                from writeStrategyFactory in writeStrategyFactories
+                from protocol in protocols
+                select new object[] { frameLengths, isClient, writeStrategyFactory(), protocol };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTlsReadTestData))]
+        public async Task TlsRead(int[] frameLengths, bool isClient, IWriteStrategy writeStrategy, SslProtocols protocol)
+        {
+            this.Output.WriteLine("frameLengths: " + string.Join(", ", frameLengths));
+
+            var writeTasks = new List<Task>();
+            var pair = await SetupStreamAndChannelAsync(isClient, writeStrategy, protocol, writeTasks);
+            EmbeddedChannel ch = pair.Item1;
+            SslStream driverStream = pair.Item2;
+
+            int randomSeed = Environment.TickCount;
+            var random = new Random(randomSeed);
+            IByteBuffer expectedBuffer = Unpooled.Buffer(16 * 1024);
+            foreach (int len in frameLengths)
+            {
+                var data = new byte[len];
+                random.NextBytes(data);
+                expectedBuffer.WriteBytes(data);
+                await Task.Run(() => driverStream.Write(data)).WithTimeout(TimeSpan.FromSeconds(5));
+            }
+            await Task.WhenAll(writeTasks).WithTimeout(TimeSpan.FromSeconds(5));
+            IByteBuffer finalReadBuffer = Unpooled.Buffer(16 * 1024);
+            await ReadOutboundAsync(() => ch.ReadInbound<IByteBuffer>(), expectedBuffer.ReadableBytes, finalReadBuffer, TestTimeout);
+            Assert.True(ByteBufferUtil.Equals(expectedBuffer, finalReadBuffer), $"---Expected:\n{ByteBufferUtil.PrettyHexDump(expectedBuffer)}\n---Actual:\n{ByteBufferUtil.PrettyHexDump(finalReadBuffer)}");
+        }
+
+        public static IEnumerable<object[]> GetTlsWriteTestData()
+        {
+            var random = new Random(Environment.TickCount);
+            var lengthVariations =
+                new[]
+                {
+                    new[] { 1 },
+                    new[] { 2, 8000, 300 },
+                    new[] { 100, 0, 1000 },
+                    new[] { 4 * 1024 - 10, 1, -1, 0, -1, 1 },
+                    new[] { 0, 24000, 0, -1, 1000 },
+                    new[] { 0, 4000, 0 },
+                    new[] { 16 * 1024 - 100 },
+                    Enumerable.Repeat(0, 30).Select(_ => random.Next(0, 10) < 2 ? -1 : random.Next(0, 17000)).ToArray()
+                };
+            var boolToggle = new[] { false, true };
+            var protocols = new[] { SslProtocols.Tls, SslProtocols.Tls11, SslProtocols.Tls12 };
+
+            return
+                from frameLengths in lengthVariations
+                from isClient in boolToggle
+                from protocol in protocols
+                select new object[] { frameLengths, isClient, protocol };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTlsWriteTestData))]
+        public async Task TlsWrite(int[] frameLengths, bool isClient, SslProtocols protocol)
+        {
+            this.Output.WriteLine("frameLengths: " + string.Join(", ", frameLengths));
+
+            var writeStrategy = new AsIsWriteStrategy();
+
+            var writeTasks = new List<Task>();
+            var pair = await SetupStreamAndChannelAsync(isClient, writeStrategy, protocol, writeTasks);
+            EmbeddedChannel ch = pair.Item1;
+            SslStream driverStream = pair.Item2;
+
+            int randomSeed = Environment.TickCount;
+            var random = new Random(randomSeed);
+            IByteBuffer expectedBuffer = Unpooled.Buffer(16 * 1024);
+            foreach (IEnumerable<int> lengths in frameLengths.Split(x => x < 0))
+            {
+                ch.WriteOutbound(lengths.Select(len =>
+                {
+                    var data = new byte[len];
+                    random.NextBytes(data);
+                    expectedBuffer.WriteBytes(data);
+                    return (object)Unpooled.WrappedBuffer(data);
+                }).ToArray());
+            }
+
+            IByteBuffer finalReadBuffer = Unpooled.Buffer(16 * 1024);
+            var readBuffer = new byte[16 * 1024 * 10];
+            await ReadOutboundAsync(
+                () =>
+                {
+                    int read = driverStream.Read(readBuffer, 0, readBuffer.Length);
+                    return Unpooled.WrappedBuffer(readBuffer, 0, read);
+                },
+                expectedBuffer.ReadableBytes, finalReadBuffer, TestTimeout);
+            Assert.True(ByteBufferUtil.Equals(expectedBuffer, finalReadBuffer), $"---Expected:\n{ByteBufferUtil.PrettyHexDump(expectedBuffer)}\n---Actual:\n{ByteBufferUtil.PrettyHexDump(finalReadBuffer)}");
+        }
+
+        static async Task<Tuple<EmbeddedChannel, SslStream>> SetupStreamAndChannelAsync(bool isClient, IWriteStrategy writeStrategy, SslProtocols protocol, List<Task> writeTasks)
+        {
+            var tlsCertificate = new X509Certificate2("dotnetty.com.pfx", "password");
+            string targetHost = tlsCertificate.GetNameInfo(X509NameType.DnsName, false);
+            TlsHandler tlsHandler = isClient ? TlsHandler.Client(targetHost, null, (_1, _2, _3, _4) => true) : TlsHandler.Server(tlsCertificate);
+            //var ch = new EmbeddedChannel(new LoggingHandler("BEFORE"), tlsHandler, new LoggingHandler("AFTER"));
+            var ch = new EmbeddedChannel(tlsHandler);
+
+            IByteBuffer readResultBuffer = Unpooled.Buffer(4 * 1024);
+            Func<ArraySegment<byte>, Task<int>> readDataFunc = async output =>
+            {
+                if (writeTasks.Count > 0)
+                {
+                    await Task.WhenAll(writeTasks).WithTimeout(TestTimeout);
+                    writeTasks.Clear();
+                }
+
+                if (readResultBuffer.ReadableBytes < output.Count)
+                {
+                    await ReadOutboundAsync(() =>
+                    {
+                        var a = ch.ReadOutbound<IByteBuffer>();
+                        return a;
+                    }, output.Count - readResultBuffer.ReadableBytes, readResultBuffer, TestTimeout);
+                }
+                Assert.NotEqual(0, readResultBuffer.ReadableBytes);
+                int read = Math.Min(output.Count, readResultBuffer.ReadableBytes);
+                readResultBuffer.ReadBytes(output.Array, output.Offset, read);
+                return read;
+            };
+            var mediationStream = new MediationStream(readDataFunc, input => writeTasks.Add(writeStrategy.WriteToChannelAsync(ch, input)));
+
+            var driverStream = new SslStream(mediationStream, true, (_1, _2, _3, _4) => true);
+            if (isClient)
+            {
+                await Task.Run(() => driverStream.AuthenticateAsServer(tlsCertificate)).WithTimeout(TimeSpan.FromSeconds(5));
+            }
+            else
+            {
+                await Task.Run(() => driverStream.AuthenticateAsClient(targetHost, null, protocol, false)).WithTimeout(TimeSpan.FromSeconds(5));
+            }
+            writeTasks.Clear();
+
+            return Tuple.Create(ch, driverStream);
+        }
+
+        static Task ReadOutboundAsync(Func<IByteBuffer> readFunc, int expectedBytes, IByteBuffer result, TimeSpan timeout)
+        {
+            int remaining = expectedBytes;
+            return AssertEx.EventuallyAsync(
+                () =>
+                {
+                    IByteBuffer output = readFunc();//inbound ? ch.ReadInbound<IByteBuffer>() : ch.ReadOutbound<IByteBuffer>();
+                    if (output != null)
+                    {
+                        remaining -= output.ReadableBytes;
+                        result.WriteBytes(output);
+                    }
+                    return remaining <= 0;
+                },
+                TimeSpan.FromMilliseconds(10),
+                timeout);
+        }
+    }
+}

--- a/test/DotNetty.Handlers.Tests/packages.config
+++ b/test/DotNetty.Handlers.Tests/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net452" />
+  <package id="xunit" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+</packages>

--- a/test/DotNetty.Microbench/DotNetty.Microbench.csproj
+++ b/test/DotNetty.Microbench/DotNetty.Microbench.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -46,12 +45,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -98,12 +101,6 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/DotNetty.Microbench/packages.config
+++ b/test/DotNetty.Microbench/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0" targetFramework="net46" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/DotNetty.Tests.Common/AssertEx.cs
+++ b/test/DotNetty.Tests.Common/AssertEx.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Tests.Common
+{
+    using System;
+    using System.Threading.Tasks;
+    using DotNetty.Common;
+    using Xunit;
+
+    public static class AssertEx
+    {
+        public static Task EventuallyAsync(Func<bool> testFunc, TimeSpan interval, TimeSpan timeout) => EventuallyAsync(() => Task.FromResult(testFunc()), interval, timeout);
+
+        public static async Task EventuallyAsync(Func<Task<bool>> testFunc, TimeSpan interval, TimeSpan timeout)
+        {
+            PreciseTimeSpan deadline = PreciseTimeSpan.Deadline(timeout);
+            while (true)
+            {
+                if (await testFunc())
+                {
+                    return;
+                }
+                if (PreciseTimeSpan.FromStart - deadline > PreciseTimeSpan.Zero)
+                {
+                    Assert.True(false, "Did not reach expected state in time.");
+                }
+                await Task.Delay(interval);
+            }
+        }
+    }
+}

--- a/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
+++ b/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -52,12 +51,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -74,7 +77,10 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="AssertEx.cs" />
+    <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TaskExtensions.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="TestScenarioRunner.cs" />
     <Compile Include="TestScenarioStep.cs" />
@@ -114,12 +120,6 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/DotNetty.Tests.Common/EnumerableExtensions.cs
+++ b/test/DotNetty.Tests.Common/EnumerableExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Tests.Common
+{
+    using System;
+    using System.Collections.Generic;
+
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<IEnumerable<T>> Split<T>(this IEnumerable<T> src, Func<T, bool> splitFunc)
+        {
+            var group = new List<T>();
+            foreach (T elem in src)
+            {
+                if (splitFunc(elem))
+                {
+                    yield return group;
+                    group = new List<T>();
+                }
+                else
+                {
+                    group.Add(elem);
+                }
+            }
+            yield return group;
+        }
+    }
+}

--- a/test/DotNetty.Tests.Common/TaskExtensions.cs
+++ b/test/DotNetty.Tests.Common/TaskExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Tests.Common
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public static class TaskExtensions
+    {
+        public static Task WithTimeout(this Task task, TimeSpan timeout)
+        {
+            if (task.IsCompleted || (timeout == Timeout.InfiniteTimeSpan))
+            {
+                return task;
+            }
+
+            return WithTimeoutInternal(task, timeout);
+        }
+
+        static async Task WithTimeoutInternal(Task task, TimeSpan timeout)
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+                {
+                    cts.Cancel();
+                    await task;
+                    return;
+                }
+            }
+
+            throw new TimeoutException();
+        }
+    }
+}

--- a/test/DotNetty.Tests.Common/TestScenarioRunner.cs
+++ b/test/DotNetty.Tests.Common/TestScenarioRunner.cs
@@ -8,6 +8,7 @@ namespace DotNetty.Tests.Common
     using System.Diagnostics.Contracts;
     using System.Threading.Tasks;
     using DotNetty.Common.Concurrency;
+    using DotNetty.Common.Utilities;
     using DotNetty.Transport.Channels;
 
     public class TestScenarioRunner : ChannelHandlerAdapter
@@ -33,7 +34,15 @@ namespace DotNetty.Tests.Common
         public override void ChannelRead(IChannelHandlerContext context, object message)
         {
             this.lastReceivedMessage = message;
-            this.ContinueScenarioExecution(context);
+            try
+            {
+                this.ContinueScenarioExecution(context);
+
+            }
+            finally
+            {
+                ReferenceCountUtil.SafeRelease(message);
+            }
         }
 
         public override void ChannelReadComplete(IChannelHandlerContext context)

--- a/test/DotNetty.Tests.Common/packages.config
+++ b/test/DotNetty.Tests.Common/packages.config
@@ -2,9 +2,10 @@
 <packages>
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -18,7 +17,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>8624fbb3</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
@@ -49,8 +49,8 @@
       <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.2.0.1406.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1507.118, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.2.1507.0118\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -62,12 +62,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -121,7 +125,9 @@
       <Link>dotnetty.com.pfx</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -150,8 +156,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/DotNetty.Tests.End2End/End2EndTests.cs
+++ b/test/DotNetty.Tests.End2End/End2EndTests.cs
@@ -15,6 +15,7 @@ namespace DotNetty.Tests.End2End
     using DotNetty.Codecs.Mqtt;
     using DotNetty.Codecs.Mqtt.Packets;
     using DotNetty.Common.Concurrency;
+    using DotNetty.Handlers.Logging;
     using DotNetty.Handlers.Tls;
     using DotNetty.Tests.Common;
     using DotNetty.Transport.Bootstrapping;
@@ -50,7 +51,9 @@ namespace DotNetty.Tests.End2End
             var tlsCertificate = new X509Certificate2("dotnetty.com.pfx", "password");
             Func<Task> closeServerFunc = await this.StartServerAsync(true, ch =>
             {
+                ch.Pipeline.AddLast("server logger", new LoggingHandler("SERVER"));
                 ch.Pipeline.AddLast("server tls", TlsHandler.Server(tlsCertificate));
+                    ch.Pipeline.AddLast("server logger2", new LoggingHandler("SER***"));
                 ch.Pipeline.AddLast("server prepender", new LengthFieldPrepender(2));
                 ch.Pipeline.AddLast("server decoder", new LengthFieldBasedFrameDecoder(ushort.MaxValue, 0, 2, 0, 2));
                 ch.Pipeline.AddLast(new EchoChannelHandler());
@@ -64,7 +67,9 @@ namespace DotNetty.Tests.End2End
                 .Handler(new ActionChannelInitializer<ISocketChannel>(ch =>
                 {
                     string targetHost = tlsCertificate.GetNameInfo(X509NameType.DnsName, false);
+                    ch.Pipeline.AddLast("client logger", new LoggingHandler("CLIENT"));
                     ch.Pipeline.AddLast("client tls", TlsHandler.Client(targetHost, null, (sender, certificate, chain, errors) => true));
+                    ch.Pipeline.AddLast("client logger2", new LoggingHandler("CLI***"));
                     ch.Pipeline.AddLast("client prepender", new LengthFieldPrepender(2));
                     ch.Pipeline.AddLast("client decoder", new LengthFieldBasedFrameDecoder(ushort.MaxValue, 0, 2, 0, 2));
                     ch.Pipeline.AddLast(new TestScenarioRunner(this.GetEchoClientScenario, testPromise));
@@ -103,7 +108,9 @@ namespace DotNetty.Tests.End2End
             var tlsCertificate = new X509Certificate2("dotnetty.com.pfx", "password");
             Func<Task> closeServerFunc = await this.StartServerAsync(true, ch =>
             {
-                ch.Pipeline.AddLast(TlsHandler.Server(tlsCertificate));
+                ch.Pipeline.AddLast("server logger", new LoggingHandler("SERVER"));
+                ch.Pipeline.AddLast("client tls", TlsHandler.Server(tlsCertificate));
+                ch.Pipeline.AddLast("server logger2", new LoggingHandler("SER***"));
                 ch.Pipeline.AddLast(
                     MqttEncoder.Instance,
                     new MqttDecoder(true, 256 * 1024),
@@ -117,8 +124,10 @@ namespace DotNetty.Tests.End2End
                 .Option(ChannelOption.TcpNodelay, true)
                 .Handler(new ActionChannelInitializer<ISocketChannel>(ch =>
                 {
+                    ch.Pipeline.AddLast("client logger", new LoggingHandler("CLIENT"));
                     string targetHost = tlsCertificate.GetNameInfo(X509NameType.DnsName, false);
-                    ch.Pipeline.AddLast(TlsHandler.Client(targetHost, null, (sender, certificate, chain, errors) => true));
+                    ch.Pipeline.AddLast("client tls", TlsHandler.Client(targetHost, null, (sender, certificate, chain, errors) => true));
+                    ch.Pipeline.AddLast("client logger2", new LoggingHandler("CLI***"));
                     ch.Pipeline.AddLast(
                         MqttEncoder.Instance,
                         new MqttDecoder(false, 256 * 1024),
@@ -134,7 +143,7 @@ namespace DotNetty.Tests.End2End
 
                 this.Output.WriteLine("Connected channel: {0}", clientChannel);
 
-                await Task.WhenAny(testPromise.Task, Task.Delay(TimeSpan.FromMinutes(1)));
+                await Task.WhenAny(testPromise.Task, Task.Delay(TimeSpan.FromSeconds(30)));
                 Assert.True(testPromise.Task.IsCompleted);
             }
             finally

--- a/test/DotNetty.Tests.End2End/packages.config
+++ b/test/DotNetty.Tests.End2End/packages.config
@@ -2,12 +2,13 @@
 <packages>
   <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging.EventSourceAnalyzer" version="2.0.1406.1" targetFramework="net45" />
-  <package id="Moq" version="4.2.1507.0118" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
+++ b/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
@@ -36,8 +36,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NBench, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NBench.0.2.1\lib\net45\NBench.dll</HintPath>
+    <Reference Include="NBench, Version=0.2.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NBench.0.2.2\lib\net45\NBench.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/DotNetty.Transport.Tests.Performance/packages.config
+++ b/test/DotNetty.Transport.Tests.Performance/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
-  <package id="NBench" version="0.2.1" targetFramework="net452" />
+  <package id="NBench" version="0.2.2" targetFramework="net452" />
 </packages>

--- a/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
+++ b/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -43,12 +42,16 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -103,12 +106,6 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/DotNetty.Transport.Tests/packages.config
+++ b/test/DotNetty.Transport.Tests/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Motivation:
Fix `TlsHandler`, optimize encryption / decryption wrt Write vs Flush semantics, optimize memory retention for sparse communication, adopt `IByteBuffer.GetIoBuffers()` in `TlsHandler`.

Modifications:
- `TlsHandler` is rewritten to use batch->copy->write approach instead of writing directly to `SslStream` in order to reduce overhead of framing / writing out everything separately.
- `TlsHandler` uses `IByteBuffer.GetIoBuffers()` instead of direct array access increasing compatibility for non-array-backed buffers.
- `TlsHandler` and `TlsHandler.MediationStream` use Task semantics now when reading through `SslStream`.
- Extra: upgraded to NBench 2.2, xUnit 2.1.0.
- Extra: better portability for .NET Core support.

Result:
`TlsHandler` provides better framing and much better (x2+) performance (depends on application control of flushing).
`TlsHandler` operates properly in edge cases when more than one frame is accepted at once and if decrypted frame size is more than 4 KB.
`TlsHandler` holds only 256 byte buffer while waiting for more data to arrive off the wire.
Extra: DotNetty is almost .NET Core compatible.