### PR TITLE
Exposes SSL Stream and adds more TLS settings

### DIFF
--- a/examples/Echo.Server/Program.cs
+++ b/examples/Echo.Server/Program.cs
@@ -5,6 +5,7 @@ namespace Echo.Server
 {
     using System;
     using System.Diagnostics.Tracing;
+    using System.Net.Security;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using DotNetty.Codecs;
@@ -26,6 +27,11 @@ namespace Echo.Server
 
             var bossGroup = new MultithreadEventLoopGroup(1);
             var workerGroup = new MultithreadEventLoopGroup();
+            X509Certificate2 tlsCertificate = null;
+            if (EchoServerSettings.IsSsl)
+            {
+                tlsCertificate = new X509Certificate2("dotnetty.com.pfx", "password");
+            }
             try
             {
                 var bootstrap = new ServerBootstrap();
@@ -37,10 +43,9 @@ namespace Echo.Server
                     .ChildHandler(new ActionChannelInitializer<ISocketChannel>(channel =>
                     {
                         IChannelPipeline pipeline = channel.Pipeline;
-
-                        if (EchoServerSettings.IsSsl)
+                        if (tlsCertificate != null)
                         {
-                            pipeline.AddLast(TlsHandler.Server(new X509Certificate2("dotnetty.com.pfx", "password")));
+                            pipeline.AddLast(TlsHandler.Server(tlsCertificate));
                         }
                         pipeline.AddLast(new LengthFieldPrepender(2));
                         pipeline.AddLast(new LengthFieldBasedFrameDecoder(ushort.MaxValue, 0, 2, 0, 2));

--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -47,7 +47,9 @@
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\LogLevelExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tls\ClientTlsSettings.cs" />
     <Compile Include="Tls\NotSslRecordException.cs" />
+    <Compile Include="Tls\ServerTlsSettings.cs" />
     <Compile Include="Tls\TlsHandshakeCompletionEvent.cs" />
     <Compile Include="Tls\TlsHandler.cs" />
     <Compile Include="Timeout\IdleState.cs" />
@@ -58,6 +60,7 @@
     <Compile Include="Timeout\WriteTimeoutException.cs" />
     <Compile Include="Timeout\ReadTimeoutHandler.cs" />
     <Compile Include="Timeout\WriteTimeoutHandler.cs" />
+    <Compile Include="Tls\TlsSettings.cs" />
     <Compile Include="Tls\TlsUtils.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DotNetty.Handlers/Tls/ClientTlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/ClientTlsSettings.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tls
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
+
+    public sealed class ClientTlsSettings : TlsSettings
+    {
+        IReadOnlyCollection<X509Certificate2> certificates;
+
+        public ClientTlsSettings(string targetHost)
+            : this(targetHost, new List<X509Certificate>())
+        {
+        }
+
+        public ClientTlsSettings(string targetHost, List<X509Certificate> certificates)
+            : this(false, certificates, targetHost)
+        {
+        }
+
+        public ClientTlsSettings(bool checkCertificateRevocation, List<X509Certificate> certificates, string targetHost)
+            : this(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, checkCertificateRevocation, certificates, targetHost)
+        {
+        }
+
+        public ClientTlsSettings(SslProtocols enabledProtocols, bool checkCertificateRevocation, List<X509Certificate> certificates, string targetHost)
+            :base(enabledProtocols, checkCertificateRevocation)
+        {
+            this.X509CertificateCollection = new X509CertificateCollection(certificates.ToArray());
+            this.TargetHost = targetHost;
+            this.Certificates = certificates.AsReadOnly();
+        }
+
+        internal X509CertificateCollection X509CertificateCollection { get; set; }
+
+        public IReadOnlyCollection<X509Certificate> Certificates { get; }
+
+        public string TargetHost { get; }
+    }
+}

--- a/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tls
+{
+    using System.Security.Authentication;
+    using System.Security.Cryptography.X509Certificates;
+
+    public sealed class ServerTlsSettings : TlsSettings
+    {
+        public ServerTlsSettings(X509Certificate certificate)
+            : this(false, certificate)
+        {
+        }
+
+        public ServerTlsSettings(bool checkCertificateRevocation, X509Certificate certificate)
+            : this(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, checkCertificateRevocation, certificate)
+        {
+        }
+
+        public ServerTlsSettings(SslProtocols enabledProtocols, bool checkCertificateRevocation, X509Certificate certificate)
+            : base(enabledProtocols, checkCertificateRevocation)
+        {
+            this.Certificate = certificate;
+        }
+
+        public X509Certificate Certificate { get; }
+    }
+}

--- a/src/DotNetty.Handlers/Tls/TlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/TlsSettings.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tls
+{
+    using System.Security.Authentication;
+
+    public abstract class TlsSettings
+    {
+        protected TlsSettings(SslProtocols enabledProtocols, bool checkCertificateRevocation)
+        {
+            this.EnabledProtocols = enabledProtocols;
+            this.CheckCertificateRevocation = checkCertificateRevocation;
+        }
+
+        public SslProtocols EnabledProtocols { get; }
+
+        public bool CheckCertificateRevocation { get; }
+    }
+}

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -154,7 +154,9 @@ namespace DotNetty.Handlers.Tests
         {
             var tlsCertificate = new X509Certificate2("dotnetty.com.pfx", "password");
             string targetHost = tlsCertificate.GetNameInfo(X509NameType.DnsName, false);
-            TlsHandler tlsHandler = isClient ? TlsHandler.Client(targetHost, null, (_1, _2, _3, _4) => true) : TlsHandler.Server(tlsCertificate);
+            TlsHandler tlsHandler = isClient ? 
+                new TlsHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), new ClientTlsSettings(targetHost)) : 
+                TlsHandler.Server(tlsCertificate);
             //var ch = new EmbeddedChannel(new LoggingHandler("BEFORE"), tlsHandler, new LoggingHandler("AFTER"));
             var ch = new EmbeddedChannel(tlsHandler);
 


### PR DESCRIPTION
Motivation:

Some important SSL Stream settings are hidden in the TlsHandler class

Modifications:
SSLStream is provided by user now via factory method;
TLS settings extended

Results:
More advanced scenarios, like X509 client authentication, are possible to do now