### PR TITLE
Negotiage client certificate

### DIFF
--- a/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
@@ -9,21 +9,29 @@ namespace DotNetty.Handlers.Tls
     public sealed class ServerTlsSettings : TlsSettings
     {
         public ServerTlsSettings(X509Certificate certificate)
-            : this(false, certificate)
+            : this(certificate, false)
         {
         }
 
-        public ServerTlsSettings(bool checkCertificateRevocation, X509Certificate certificate)
-            : this(SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12, checkCertificateRevocation, certificate)
+        public ServerTlsSettings(X509Certificate certificate, bool negotiateClientCertificate)
+            : this(certificate, negotiateClientCertificate, false)
         {
         }
 
-        public ServerTlsSettings(SslProtocols enabledProtocols, bool checkCertificateRevocation, X509Certificate certificate)
+        public ServerTlsSettings(X509Certificate certificate, bool negotiateClientCertificate, bool checkCertificateRevocation)
+            : this(certificate, negotiateClientCertificate, checkCertificateRevocation, SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12)
+        {
+        }
+
+        public ServerTlsSettings(X509Certificate certificate, bool negotiateClientCertificate, bool checkCertificateRevocation, SslProtocols enabledProtocols)
             : base(enabledProtocols, checkCertificateRevocation)
         {
             this.Certificate = certificate;
+            this.NegotiateClientCertificate = negotiateClientCertificate;
         }
 
         public X509Certificate Certificate { get; }
+
+        public bool NegotiateClientCertificate { get; }
     }
 }

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -483,7 +483,7 @@ namespace DotNetty.Handlers.Tls
                 var serverSettings = settings as ServerTlsSettings;
                 if (serverSettings != null)
                 {
-                    this.sslStream.AuthenticateAsServerAsync(serverSettings.Certificate, false, serverSettings.EnabledProtocols, serverSettings.CheckCertificateRevocation)
+                    this.sslStream.AuthenticateAsServerAsync(serverSettings.Certificate, serverSettings.NegotiateClientCertificate, serverSettings.EnabledProtocols, serverSettings.CheckCertificateRevocation)
                         .ContinueWith(HandshakeCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);
                 }
                 else


### PR DESCRIPTION
Motivation:
SslStream's paramter required client certificate is misleading. In fact in suggests to client to provide the certificate and client may or may not provide it.
If client has not provided the client certificate - it assumes that client is not authenticated from TLS prospective and continues the handshake

Modification:
Expose this setting as a parameter, so that users could set it if needed.

Results:
Allows users to do a client certificate authentication on server.