### PR TITLE
Bug: StringDecoder not marked as Sharable

### DIFF
--- a/src/DotNetty.Codecs/Strings/StringDecoder.cs
+++ b/src/DotNetty.Codecs/Strings/StringDecoder.cs
@@ -62,6 +62,8 @@ namespace DotNetty.Codecs
             this.encoding = encoding;
         }
 
+        public override bool IsSharable => true;
+
         protected override void Decode(IChannelHandlerContext context, IByteBuffer input, List<object> output)
         {
             string decoded = this.Decode(context, input);


### PR DESCRIPTION
Marked StringDecoder as Sharable

Motivation:

Can use StringDecoder in a server where you have more than 1 connect to the server. 
This is a bug, since StringEncoder is marked Sharable and there is nothing that stands out as different.

Modifications:

Marked StringDecoder as Sharable


Result:
Sample project like EchoServer and TelnetServer will now be able to receive more than 1 connections.
So will all other code using the StringDecoder