### PR TITLE
Allow looking up current executor

### DIFF
--- a/src/DotNetty.Common/Concurrency/AbstractEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/AbstractEventExecutor.cs
@@ -110,6 +110,8 @@ namespace DotNetty.Common.Concurrency
 
         public abstract Task ShutdownGracefullyAsync(TimeSpan quietPeriod, TimeSpan timeout);
 
+        protected void SetCurrentExecutor(IEventExecutor executor) => ExecutionEnvironment.SetCurrentExecutor(executor);
+
         #region Queuing data structures
 
         protected abstract class RunnableQueueNode : MpscLinkedQueueNode<IRunnable>, IRunnable

--- a/src/DotNetty.Common/Concurrency/ExecutionEnvironment.cs
+++ b/src/DotNetty.Common/Concurrency/ExecutionEnvironment.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Concurrency
+{
+    using System;
+
+    public static class ExecutionEnvironment
+    {
+        [ThreadStatic]
+        static IEventExecutor currentExecutor;
+
+        public static bool TryGetCurrentExecutor(out IEventExecutor executor)
+        {
+            executor = currentExecutor;
+            return executor != null;
+        }
+
+        internal static void SetCurrentExecutor(IEventExecutor executor) => currentExecutor = executor;
+    }
+}

--- a/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
@@ -65,6 +65,8 @@ namespace DotNetty.Common.Concurrency
 
         void Loop()
         {
+            this.SetCurrentExecutor(this);
+
             Task.Factory.StartNew(
                 () =>
                 {

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -153,6 +153,7 @@
     </Compile>
     <Compile Include="Concurrency\ActionScheduledAsyncTask.cs" />
     <Compile Include="Concurrency\ActionScheduledTask.cs" />
+    <Compile Include="Concurrency\ExecutionEnvironment.cs" />
     <Compile Include="Concurrency\ICallable`T.cs" />
     <Compile Include="Concurrency\IEventExecutorGroup.cs" />
     <Compile Include="Concurrency\IScheduledRunnable.cs" />


### PR DESCRIPTION
Motivation:
In many instances routines may be optimized in a presence of IEventExecutor but it is hard to carry it around everywhere.

Modifications:
- introduced ExecutionEnvironment.TryGetCurrentExecutor which looks up current executor if any.
- modified SingleThreadEventExecutor to set itself as current on its worker thread.

Result:
Executor may be looked up ambiently for optional executor-specific optimizations.