### PR TITLE
Add ability to limit buffer pool memory capacity

### DIFF
--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -875,6 +875,15 @@ namespace DotNetty.Buffers
             }
         }
 
+        protected void CheckNewCapacity(int newCapacity)
+        {
+            this.EnsureAccessible();
+            if (newCapacity < 0 || newCapacity > this.MaxCapacity)
+            {
+                throw new ArgumentOutOfRangeException(nameof(newCapacity), $"newCapacity: {newCapacity} (expected: 0-{this.MaxCapacity}{')'}");
+            }
+        }
+
         protected void EnsureAccessible()
         {
             if (this.ReferenceCount == 0)

--- a/src/DotNetty.Buffers/CompositeByteBuffer.cs
+++ b/src/DotNetty.Buffers/CompositeByteBuffer.cs
@@ -555,8 +555,7 @@ namespace DotNetty.Buffers
 
         public override IByteBuffer AdjustCapacity(int newCapacity)
         {
-            this.EnsureAccessible();
-            Contract.Requires(newCapacity >= 0 && newCapacity <= this.MaxCapacity);
+            this.CheckNewCapacity(newCapacity);
 
             int oldCapacity = this.Capacity;
             if (newCapacity > oldCapacity)

--- a/src/DotNetty.Buffers/PoolArena.cs
+++ b/src/DotNetty.Buffers/PoolArena.cs
@@ -25,6 +25,7 @@ namespace DotNetty.Buffers
         internal readonly PooledByteBufferAllocator Parent;
 
         readonly int maxOrder;
+        readonly int maxChunkCount;
         internal readonly int PageSize;
         internal readonly int PageShifts;
         internal readonly int ChunkSize;
@@ -41,6 +42,8 @@ namespace DotNetty.Buffers
         readonly PoolChunkList<T> q100;
 
         readonly List<IPoolChunkListMetric> chunkListMetrics;
+
+        int chunkCount;
 
         // Metrics for allocations and deallocations
         long allocationsTiny;
@@ -62,13 +65,14 @@ namespace DotNetty.Buffers
         // TODO: Test if adding padding helps under contention
         //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
 
-        protected PoolArena(PooledByteBufferAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize)
+        protected PoolArena(PooledByteBufferAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize, int maxChunkCount)
         {
             this.Parent = parent;
             this.PageSize = pageSize;
             this.maxOrder = maxOrder;
             this.PageShifts = pageShifts;
             this.ChunkSize = chunkSize;
+            this.maxChunkCount = maxChunkCount;
             this.SubpageOverflowMask = ~(pageSize - 1);
             this.tinySubpagePools = this.NewSubpagePoolArray(NumTinySubpagePools);
             for (int i = 0; i < this.tinySubpagePools.Length; i++)
@@ -238,18 +242,28 @@ namespace DotNetty.Buffers
                 return;
             }
 
-            // Add a new chunk.
-            PoolChunk<T> c = this.NewChunk(this.PageSize, this.maxOrder, this.PageShifts, this.ChunkSize);
-            long handle = c.Allocate(normCapacity);
-            ++this.allocationsNormal;
-            Contract.Assert(handle > 0);
-            c.InitBuf(buf, handle, reqCapacity);
-            this.qInit.Add(c);
+            if (this.chunkCount < this.maxChunkCount)
+            {
+                // Add a new chunk.
+                PoolChunk<T> c = this.NewChunk(this.PageSize, this.maxOrder, this.PageShifts, this.ChunkSize);
+                this.chunkCount++;
+                long handle = c.Allocate(normCapacity);
+                ++this.allocationsNormal;
+                Contract.Assert(handle > 0);
+                c.InitBuf(buf, handle, reqCapacity);
+                this.qInit.Add(c);
+            }
+            else
+            {
+                PoolChunk<T> chunk = this.NewUnpooledChunk(reqCapacity, false);
+                buf.InitUnpooled(chunk, reqCapacity);
+                Interlocked.Increment(ref this.allocationsNormal);
+            }
         }
 
         void AllocateHuge(PooledByteBuffer<T> buf, int reqCapacity)
         {
-            PoolChunk<T> chunk = this.NewUnpooledChunk(reqCapacity);
+            PoolChunk<T> chunk = this.NewUnpooledChunk(reqCapacity, true);
             Interlocked.Add(ref this.activeBytesHuge, chunk.ChunkSize);
             buf.InitUnpooled(chunk, reqCapacity);
             Interlocked.Increment(ref this.allocationsHuge);
@@ -261,8 +275,18 @@ namespace DotNetty.Buffers
             {
                 int size = chunk.ChunkSize;
                 this.DestroyChunk(chunk);
-                Interlocked.Add(ref this.activeBytesHuge, -size);
-                Interlocked.Decrement(ref this.deallocationsHuge);
+                switch (chunk.Origin)
+                {
+                    case PoolChunk<T>.PoolChunkOrigin.UnpooledNormal:
+                        Interlocked.Decrement(ref this.deallocationsNormal);
+                        break;
+                    case PoolChunk<T>.PoolChunkOrigin.UnpooledHuge:
+                        Interlocked.Add(ref this.activeBytesHuge, -size);
+                        Interlocked.Decrement(ref this.deallocationsHuge);
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unsupported PoolChunk.Origin: " + chunk.Origin);
+                }
             }
             else
             {
@@ -474,7 +498,7 @@ namespace DotNetty.Buffers
 
         public long NumNormalAllocations => this.allocationsNormal;
 
-        public long NumDeallocations => this.deallocationsTiny + this.deallocationsSmall + this.allocationsNormal + this.NumHugeDeallocations;
+        public long NumDeallocations => this.deallocationsTiny + this.deallocationsSmall + this.deallocationsNormal + this.NumHugeDeallocations;
 
         public long NumTinyDeallocations => this.deallocationsTiny;
 
@@ -528,7 +552,7 @@ namespace DotNetty.Buffers
 
         protected abstract PoolChunk<T> NewChunk(int pageSize, int maxOrder, int pageShifts, int chunkSize);
 
-        protected abstract PoolChunk<T> NewUnpooledChunk(int capacity);
+        protected abstract PoolChunk<T> NewUnpooledChunk(int capacity, bool huge);
 
         protected abstract PooledByteBuffer<T> NewByteBuf(int maxCapacity);
 
@@ -619,14 +643,14 @@ namespace DotNetty.Buffers
 
     sealed class HeapArena : PoolArena<byte[]>
     {
-        public HeapArena(PooledByteBufferAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize)
-            : base(parent, pageSize, maxOrder, pageShifts, chunkSize)
+        public HeapArena(PooledByteBufferAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize, int maxChunkCount)
+            : base(parent, pageSize, maxOrder, pageShifts, chunkSize, maxChunkCount)
         {
         }
 
         protected override PoolChunk<byte[]> NewChunk(int pageSize, int maxOrder, int pageShifts, int chunkSize) => new PoolChunk<byte[]>(this, new byte[chunkSize], pageSize, maxOrder, pageShifts, chunkSize);
 
-        protected override PoolChunk<byte[]> NewUnpooledChunk(int capacity) => new PoolChunk<byte[]>(this, new byte[capacity], capacity);
+        protected override PoolChunk<byte[]> NewUnpooledChunk(int capacity, bool huge) => new PoolChunk<byte[]>(this, new byte[capacity], capacity, huge);
 
         protected override void DestroyChunk(PoolChunk<byte[]> chunk)
         {

--- a/src/DotNetty.Buffers/PooledByteBufferAllocator.cs
+++ b/src/DotNetty.Buffers/PooledByteBufferAllocator.cs
@@ -56,7 +56,7 @@ namespace DotNetty.Buffers
             }
             DEFAULT_MAX_ORDER = defaultMaxOrder;
 
-            // Determine reasonable default for nHeapArena and nDirectArena.
+            // todo: Determine reasonable default for heapArenaCount
             // Assuming each arena has 3 chunks, the pool should not consume more than 50% of max memory.
 
             // Use 2 * cores by default to reduce contention as we use 2 * cores for the number of EventLoops
@@ -124,18 +124,31 @@ namespace DotNetty.Buffers
         {
         }
 
-        public PooledByteBufferAllocator(int nHeapArena, int pageSize, int maxOrder)
-            : this(nHeapArena, pageSize, maxOrder,
+        public PooledByteBufferAllocator(int heapArenaCount, int pageSize, int maxOrder)
+            : this(heapArenaCount, pageSize, maxOrder,
                 DEFAULT_TINY_CACHE_SIZE, DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE)
         {
         }
 
-        public PooledByteBufferAllocator(int nHeapArena, int pageSize, int maxOrder,
+        public PooledByteBufferAllocator(int heapArenaCount, int pageSize, int maxOrder,
             int tinyCacheSize, int smallCacheSize, int normalCacheSize)
+            : this(heapArenaCount, pageSize, maxOrder,
+                tinyCacheSize, smallCacheSize, normalCacheSize, int.MaxValue)
         {
-            Contract.Requires(nHeapArena >= 0);
+        }
 
-            //super(preferDirect);
+        public PooledByteBufferAllocator(int maxArenaSize)
+            : this(DEFAULT_NUM_HEAP_ARENA, DEFAULT_PAGE_SIZE, DEFAULT_MAX_ORDER, DEFAULT_TINY_CACHE_SIZE,
+                  DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE,
+                  Math.Max(1, maxArenaSize / (DEFAULT_PAGE_SIZE << DEFAULT_MAX_ORDER)))
+        {
+        }
+
+        public PooledByteBufferAllocator(int heapArenaCount, int pageSize, int maxOrder,
+            int tinyCacheSize, int smallCacheSize, int normalCacheSize, int maxChunkCountPerArena)
+        {
+            Contract.Requires(heapArenaCount >= 0);
+
             this.threadCache = new PoolThreadLocalCache(this);
             this.tinyCacheSize = tinyCacheSize;
             this.smallCacheSize = smallCacheSize;
@@ -144,13 +157,13 @@ namespace DotNetty.Buffers
 
             int pageShifts = ValidateAndCalculatePageShifts(pageSize);
 
-            if (nHeapArena > 0)
+            if (heapArenaCount > 0)
             {
-                this.heapArenas = NewArenaArray<byte[]>(nHeapArena);
+                this.heapArenas = NewArenaArray<byte[]>(heapArenaCount);
                 var metrics = new List<IPoolArenaMetric>(this.heapArenas.Length);
                 for (int i = 0; i < this.heapArenas.Length; i++)
                 {
-                    var arena = new HeapArena(this, pageSize, maxOrder, pageShifts, chunkSize);
+                    var arena = new HeapArena(this, pageSize, maxOrder, pageShifts, chunkSize, maxChunkCountPerArena);
                     this.heapArenas[i] = arena;
                     metrics.Add(arena);
                 }

--- a/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
@@ -64,8 +64,7 @@ namespace DotNetty.Buffers
 
         public override IByteBuffer AdjustCapacity(int newCapacity)
         {
-            this.EnsureAccessible();
-            Contract.Requires(newCapacity >= 0 && newCapacity <= this.MaxCapacity);
+            this.CheckNewCapacity(newCapacity);
 
             int oldCapacity = this.array.Length;
             if (newCapacity > oldCapacity)

--- a/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
@@ -76,12 +76,19 @@ namespace DotNetty.Common.Concurrency
             Task.Factory.StartNew(
                 () =>
                 {
-                    Interlocked.CompareExchange(ref this.executionState, ST_STARTED, ST_NOT_STARTED);
-                    while (!this.ConfirmShutdown())
+                    try
                     {
-                        this.RunAllTasks(this.preciseBreakoutInterval);
+                        Interlocked.CompareExchange(ref this.executionState, ST_STARTED, ST_NOT_STARTED);
+                        while (!this.ConfirmShutdown())
+                        {
+                            this.RunAllTasks(this.preciseBreakoutInterval);
+                        }
+                        this.CleanupAndTerminate(true);
                     }
-                    this.CleanupAndTerminate(true);
+                    catch (Exception ex)
+                    {
+                        Logger.Error("{}: execution loop failed", this.thread.Name, ex);
+                    }
                 },
                 CancellationToken.None,
                 TaskCreationOptions.None,

--- a/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelPerfSpec.cs
+++ b/test/DotNetty.Transport.Tests.Performance/Sockets/TcpSocketChannelPerfSpec.cs
@@ -73,8 +73,7 @@ namespace DotNetty.Transport.Tests.Performance.Sockets
             this.ServerGroup = new MultithreadEventLoopGroup(1);
             this.WorkerGroup = new MultithreadEventLoopGroup();
 
-            Encoding iso = Encoding.GetEncoding("ISO-8859-1");
-            this.message = iso.GetBytes("ABC");
+            this.message = Encoding.UTF8.GetBytes("ABC");
 
             this.inboundThroughputCounter = context.GetCounter(InboundThroughputCounterName);
             this.outboundThroughputCounter = context.GetCounter(OutboundThroughputCounterName);
@@ -107,7 +106,6 @@ namespace DotNetty.Transport.Tests.Performance.Sockets
                         .AddLast(this.GetEncoder())
                         .AddLast(this.GetDecoder())
                         .AddLast(counterHandler)
-                        .AddLast(new CounterHandlerOutbound(this.outboundThroughputCounter))
                         .AddLast(new ReadFinishedHandler(this.signal, WriteCount));
                 }));
 
@@ -122,7 +120,6 @@ namespace DotNetty.Transport.Tests.Performance.Sockets
                             //.AddLast(TlsHandler.Client(targetHost, null, (sender, certificate, chain, errors) => true))
                             .AddLast(this.GetEncoder())
                             .AddLast(this.GetDecoder())
-                            .AddLast(counterHandler)
                             .AddLast(new CounterHandlerOutbound(this.outboundThroughputCounter));
                     }));
 


### PR DESCRIPTION
Motivation:
If pool grows too fast OOM exception may happen.

Modifications:
- add limit on max memory capacity allocated per heap arena, after which allocations are unpooled.
- extra: log exceptions terminating executor loop

Result:
Users have option to limit size of buffer pool.