### PR TITLE
Add Float and Zero api for IByteBuffer

### DIFF
--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -468,7 +468,32 @@ namespace DotNetty.Buffers
 
         public abstract Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken);
 
-        public abstract IByteBuffer SetZero(int index, int length);
+        public virtual IByteBuffer SetZero(int index, int length)
+        {
+            if (length == 0)
+            {
+                return this;
+            }
+
+            this.CheckIndex(index, length);
+
+            int longCount = length.RightUShift(3);
+            int byteCount = length & 7;
+
+            for (int i = longCount; i > 0; i--)
+            {
+                this._SetLong(index, 0);
+                index += 8;
+            }
+
+            for (int i = byteCount; i > 0; i--)
+            {
+                this._SetByte(index, 0);
+                index++;
+            }
+
+            return this;
+        }
 
         public virtual bool ReadBoolean() => this.ReadByte() != 0;
 

--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -468,6 +468,8 @@ namespace DotNetty.Buffers
 
         public abstract Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken);
 
+        public abstract IByteBuffer SetZero(int index, int length);
+
         public virtual bool ReadBoolean() => this.ReadByte() != 0;
 
         public virtual byte ReadByte()
@@ -771,6 +773,15 @@ namespace DotNetty.Buffers
 
         public Task WriteBytesAsync(Stream stream, int length) => this.WriteBytesAsync(stream, length, CancellationToken.None);
 
+        public virtual IByteBuffer WriteZero(int length)
+        {
+            this.EnsureAccessible();
+            this.EnsureWritable(length);
+            this.SetZero(this.WriterIndex, length);
+            this.WriterIndex += length;
+            return this;
+        }
+
         public abstract bool HasArray { get; }
 
         public abstract byte[] Array { get; }
@@ -933,7 +944,7 @@ namespace DotNetty.Buffers
 
         /// <summary>
         ///     Throws a <see cref="IndexOutOfRangeException" /> if the current <see cref="ReadableBytes" /> of this buffer
-        ///     is less than <see cref="minimumReadableBytes" />.
+        ///     is less than <paramref name="minimumReadableBytes" />.
         /// </summary>
         protected void CheckReadableBytes(int minimumReadableBytes)
         {

--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -11,6 +11,7 @@ namespace DotNetty.Buffers
     using System.Threading.Tasks;
     using DotNetty.Common;
     using DotNetty.Common.Utilities;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     ///     Abstract base class implementation of a <see cref="IByteBuffer" />
@@ -316,6 +317,12 @@ namespace DotNetty.Buffers
 
         public virtual char GetChar(int index) => Convert.ToChar(this.GetShort(index));
 
+        public virtual float GetFloat(int index)
+        {
+            int raw = this.GetInt(index);
+            return Unsafe.As<int, float>(ref raw);
+        }
+
         public virtual double GetDouble(int index) => BitConverter.Int64BitsToDouble(this.GetLong(index));
 
         public virtual IByteBuffer GetBytes(int index, IByteBuffer destination)
@@ -412,6 +419,12 @@ namespace DotNetty.Buffers
         public virtual IByteBuffer SetChar(int index, char value)
         {
             this.SetShort(index, value);
+            return this;
+        }
+
+        public virtual IByteBuffer SetFloat(int index, float value)
+        {
+            this.SetInt(index, Unsafe.As<float, int>(ref value));
             return this;
         }
 
@@ -518,6 +531,12 @@ namespace DotNetty.Buffers
         }
 
         public virtual char ReadChar() => (char)this.ReadShort();
+
+        public virtual float ReadFloat()
+        {
+            int raw = this.ReadInt();
+            return Unsafe.As<int, float>(ref raw);
+        }
 
         public virtual double ReadDouble() => BitConverter.Int64BitsToDouble(this.ReadLong());
 
@@ -667,6 +686,12 @@ namespace DotNetty.Buffers
         public virtual IByteBuffer WriteChar(char value)
         {
             this.WriteShort(value);
+            return this;
+        }
+
+        public virtual IByteBuffer WriteFloat(float value)
+        {
+            this.WriteInt(Unsafe.As<float, int>(ref value));
             return this;
         }
 

--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -317,11 +317,7 @@ namespace DotNetty.Buffers
 
         public virtual char GetChar(int index) => Convert.ToChar(this.GetShort(index));
 
-        public virtual float GetFloat(int index)
-        {
-            int raw = this.GetInt(index);
-            return Unsafe.As<int, float>(ref raw);
-        }
+        public virtual float GetFloat(int index) => ByteBufferUtil.Int32BitsToSingle(this.GetInt(index));
 
         public virtual double GetDouble(int index) => BitConverter.Int64BitsToDouble(this.GetLong(index));
 
@@ -424,7 +420,7 @@ namespace DotNetty.Buffers
 
         public virtual IByteBuffer SetFloat(int index, float value)
         {
-            this.SetInt(index, Unsafe.As<float, int>(ref value));
+            this.SetInt(index, ByteBufferUtil.SingleToInt32Bits(value));
             return this;
         }
 
@@ -559,11 +555,7 @@ namespace DotNetty.Buffers
 
         public virtual char ReadChar() => (char)this.ReadShort();
 
-        public virtual float ReadFloat()
-        {
-            int raw = this.ReadInt();
-            return Unsafe.As<int, float>(ref raw);
-        }
+        public virtual float ReadFloat() => ByteBufferUtil.Int32BitsToSingle(this.ReadInt());
 
         public virtual double ReadDouble() => BitConverter.Int64BitsToDouble(this.ReadLong());
 
@@ -718,7 +710,7 @@ namespace DotNetty.Buffers
 
         public virtual IByteBuffer WriteFloat(float value)
         {
-            this.WriteInt(Unsafe.As<float, int>(ref value));
+            this.WriteInt(ByteBufferUtil.SingleToInt32Bits(value));
             return this;
         }
 

--- a/src/DotNetty.Buffers/AdvancedLeakAwareByteBuffer.cs
+++ b/src/DotNetty.Buffers/AdvancedLeakAwareByteBuffer.cs
@@ -303,12 +303,11 @@ namespace DotNetty.Buffers
             return base.SetBytesAsync(index, input, length, cancellationToken);
         }
 
-        // todo: port: complete
-        //        public override IByteBuffer SetZero(int index, int length)
-        //{
-        //    this.RecordLeakNonRefCountingOperation();
-        //    return base.SetZero(index, length);
-        //}
+        public override IByteBuffer SetZero(int index, int length)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.SetZero(index, length);
+        }
 
         public override bool ReadBoolean()
         {
@@ -520,12 +519,11 @@ namespace DotNetty.Buffers
             return base.WriteBytesAsync(input, length, cancellationToken);
         }
 
-        // todo: port: complete
-        //public override IByteBuffer WriteZero(int length)
-        //{
-        //    this.RecordLeakNonRefCountingOperation();
-        //    return base.WriteZero(length);
-        //}
+        public override IByteBuffer WriteZero(int length)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.WriteZero(length);
+        }
 
         //public override int indexOf(int fromIndex, int toIndex, byte value)
         //{

--- a/src/DotNetty.Buffers/AdvancedLeakAwareByteBuffer.cs
+++ b/src/DotNetty.Buffers/AdvancedLeakAwareByteBuffer.cs
@@ -165,12 +165,11 @@ namespace DotNetty.Buffers
             return base.GetChar(index);
         }
 
-        // todo: port: complete
-        //    public override float GetFloat(int index)
-        //{
-        //    this.RecordLeakNonRefCountingOperation();
-        //    return base.GetFloat(index);
-        //}
+        public override float GetFloat(int index)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.GetFloat(index);
+        }
 
         public override double GetDouble(int index)
         {
@@ -256,12 +255,11 @@ namespace DotNetty.Buffers
             return base.SetChar(index, value);
         }
 
-        // todo: port: complete
-        //    public override IByteBuffer SetFloat(int index, float value)
-        //{
-        //    this.RecordLeakNonRefCountingOperation();
-        //    return base.SetFloat(index, value);
-        //}
+        public override IByteBuffer SetFloat(int index, float value)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.SetFloat(index, value);
+        }
 
         public override IByteBuffer SetDouble(int index, double value)
         {
@@ -372,12 +370,11 @@ namespace DotNetty.Buffers
             return base.ReadChar();
         }
 
-        // todo: port: complete
-        //    public override float ReadFloat()
-        //{
-        //    this.RecordLeakNonRefCountingOperation();
-        //    return base.ReadFloat();
-        //}
+        public override float ReadFloat()
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.ReadFloat();
+        }
 
         public override double ReadDouble()
         {
@@ -475,12 +472,11 @@ namespace DotNetty.Buffers
             return base.WriteChar(value);
         }
 
-        // todo: port: complete
-        //        public override IByteBuffer WriteFloat(float value)
-        //{
-        //    this.RecordLeakNonRefCountingOperation();
-        //    return base.WriteFloat(value);
-        //}
+        public override IByteBuffer WriteFloat(float value)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.WriteFloat(value);
+        }
 
         public override IByteBuffer WriteDouble(double value)
         {

--- a/src/DotNetty.Buffers/ByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/ByteBufferUtil.cs
@@ -648,5 +648,15 @@ namespace DotNetty.Buffers
                 }
             }
         }
+
+        public static unsafe int SingleToInt32Bits(float value)
+        {
+            return *(int*)(&value);
+        }
+
+        public static unsafe float Int32BitsToSingle(int value)
+        {
+            return *(float*)(&value);
+        }
     }
 }

--- a/src/DotNetty.Buffers/CompositeByteBuffer.cs
+++ b/src/DotNetty.Buffers/CompositeByteBuffer.cs
@@ -990,6 +990,29 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public override IByteBuffer SetZero(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            if (length == 0)
+            {
+                return this;
+            }
+
+            int i = this.ToComponentIndex(index);
+            while (length > 0)
+            {
+                ComponentEntry c = this.components[i];
+                IByteBuffer s = c.Buffer;
+                int adjustment = c.Offset;
+                int localLength = Math.Min(length, s.Capacity - (index - adjustment));
+                s.SetZero(index - adjustment, localLength);
+                index += localLength;
+                length -= localLength;
+                i++;
+            }
+            return this;
+        }
+
         public override IByteBuffer Copy(int index, int length)
         {
             this.CheckIndex(index, length);

--- a/src/DotNetty.Buffers/DotNetty.Buffers.csproj
+++ b/src/DotNetty.Buffers/DotNetty.Buffers.csproj
@@ -23,6 +23,9 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DotNetty.Buffers/DotNetty.Buffers.csproj
+++ b/src/DotNetty.Buffers/DotNetty.Buffers.csproj
@@ -9,6 +9,7 @@
     <VersionPrefix>0.4.4</VersionPrefix>
     <Authors>Microsoft Azure</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>DotNetty.Buffers</AssemblyName>
@@ -22,9 +23,6 @@
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>

--- a/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
+++ b/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
@@ -127,6 +127,12 @@ namespace DotNetty.Buffers
 
         public override Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken) => this.buffer.SetBytesAsync(index, src, length, cancellationToken);
 
+        public override IByteBuffer SetZero(int index, int length)
+        {
+            this.buffer.SetZero(index, length);
+            return this;
+        }
+
         public override int IoBufferCount => this.Unwrap().IoBufferCount;
 
         public override ArraySegment<byte>[] GetIoBuffers(int index, int length) => this.Unwrap().GetIoBuffers(index, length);

--- a/src/DotNetty.Buffers/EmptyByteBuffer.cs
+++ b/src/DotNetty.Buffers/EmptyByteBuffer.cs
@@ -260,6 +260,8 @@ namespace DotNetty.Buffers
             return TaskEx.Zero;
         }
 
+        public IByteBuffer SetZero(int index, int length) => this.CheckIndex(index, length);
+
         public bool ReadBoolean()
         {
             throw new IndexOutOfRangeException();
@@ -479,6 +481,8 @@ namespace DotNetty.Buffers
             this.CheckLength(length);
             return TaskEx.Completed;
         }
+
+        public IByteBuffer WriteZero(int length) => this.CheckLength(length);
 
         public IByteBuffer Unwrap() => null;
 

--- a/src/DotNetty.Buffers/EmptyByteBuffer.cs
+++ b/src/DotNetty.Buffers/EmptyByteBuffer.cs
@@ -153,6 +153,11 @@ namespace DotNetty.Buffers
             throw new IndexOutOfRangeException();
         }
 
+        public float GetFloat(int index)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
         public double GetDouble(int index)
         {
             throw new IndexOutOfRangeException();
@@ -222,6 +227,11 @@ namespace DotNetty.Buffers
         }
 
         public IByteBuffer SetChar(int index, char value)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public IByteBuffer SetFloat(int index, float value)
         {
             throw new IndexOutOfRangeException();
         }
@@ -300,6 +310,11 @@ namespace DotNetty.Buffers
             throw new IndexOutOfRangeException();
         }
 
+        public float ReadFloat()
+        {
+            throw new IndexOutOfRangeException();
+        }
+
         public double ReadDouble()
         {
             throw new IndexOutOfRangeException();
@@ -367,6 +382,11 @@ namespace DotNetty.Buffers
         }
 
         public IByteBuffer WriteChar(char value)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public IByteBuffer WriteFloat(float value)
         {
             throw new IndexOutOfRangeException();
         }

--- a/src/DotNetty.Buffers/IByteBuffer.cs
+++ b/src/DotNetty.Buffers/IByteBuffer.cs
@@ -567,6 +567,8 @@ namespace DotNetty.Buffers
         /// </exception>
         Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken);
 
+        IByteBuffer SetZero(int index, int length);
+
         /// <summary>
         ///     Gets a boolean at the current <see cref="ReaderIndex" /> and increases the <see cref="ReaderIndex" />
         ///     by <c>1</c> in this buffer.
@@ -848,6 +850,8 @@ namespace DotNetty.Buffers
         Task WriteBytesAsync(Stream stream, int length);
 
         Task WriteBytesAsync(Stream stream, int length, CancellationToken cancellationToken);
+
+        IByteBuffer WriteZero(int length);
 
         string ToString(Encoding encoding);
 

--- a/src/DotNetty.Buffers/IByteBuffer.cs
+++ b/src/DotNetty.Buffers/IByteBuffer.cs
@@ -293,6 +293,17 @@ namespace DotNetty.Buffers
         char GetChar(int index);
 
         /// <summary>
+        ///     Gets a float at the specified absolute <paramref name="index"/> in this buffer.
+        ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
+        ///     of this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">
+        ///     if the specified <paramref name="index"/> is less than <c>0</c> or
+        ///     <c>index + 3</c> greater than <see cref="Capacity" />
+        /// </exception>
+        float GetFloat(int index);
+
+        /// <summary>
         ///     Gets a double at the specified absolute <see cref="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
@@ -473,6 +484,16 @@ namespace DotNetty.Buffers
         IByteBuffer SetDouble(int index, double value);
 
         /// <summary>
+        ///     Sets the specified float at the specified absolute <see cref="index" /> in this buffer.
+        ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">
+        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        /// </exception>
+        IByteBuffer SetFloat(int index, float value);
+
+        /// <summary>
         ///     Transfers the <see cref="src" /> byte buffer's contents starting at the specified absolute <see cref="index" />.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
@@ -614,6 +635,14 @@ namespace DotNetty.Buffers
         double ReadDouble();
 
         /// <summary>
+        ///     Gets an 4-byte Decimaling integer at the current <see cref="ReaderIndex" /> and increases the
+        ///     <see cref="ReaderIndex" />
+        ///     by <c>4</c> in this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">if <see cref="ReadableBytes" /> is less than <c>8</c></exception>
+        float ReadFloat();
+
+        /// <summary>
         ///     Reads <see cref="length" /> bytes from this buffer into a new destination buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
@@ -665,6 +694,8 @@ namespace DotNetty.Buffers
         IByteBuffer WriteChar(char value);
 
         IByteBuffer WriteDouble(double value);
+
+        IByteBuffer WriteFloat(float value);
 
         IByteBuffer WriteUnsignedMedium(int value);
 

--- a/src/DotNetty.Buffers/IByteBuffer.cs
+++ b/src/DotNetty.Buffers/IByteBuffer.cs
@@ -86,7 +86,7 @@ namespace DotNetty.Buffers
         bool IsWritable();
 
         /// <summary>
-        ///     Returns true if and only if the buffer has enough <see cref="Capacity" /> to accomodate <see cref="size" />
+        ///     Returns true if and only if the buffer has enough <see cref="Capacity" /> to accomodate <paramref name="size" />
         ///     additional bytes.
         /// </summary>
         /// <param name="size">The number of additional elements we would like to write.</param>
@@ -151,12 +151,12 @@ namespace DotNetty.Buffers
 
         /// <summary>
         ///     Makes sure the number of <see cref="WritableBytes" /> is equal to or greater than
-        ///     the specified value (<see cref="minWritableBytes" />.) If there is enough writable bytes in this buffer,
+        ///     the specified value (<paramref name="minWritableBytes" />.) If there is enough writable bytes in this buffer,
         ///     the method returns with no side effect. Otherwise, it raises an <see cref="ArgumentOutOfRangeException" />.
         /// </summary>
         /// <param name="minWritableBytes">The expected number of minimum writable bytes</param>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if <see cref="WriterIndex" /> + <see cref="minWritableBytes" /> >
+        ///     if <see cref="WriterIndex" /> + <paramref name="minWritableBytes" /> >
         ///     <see cref="MaxCapacity" />.
         /// </exception>
         IByteBuffer EnsureWritable(int minWritableBytes);
@@ -183,79 +183,79 @@ namespace DotNetty.Buffers
         int EnsureWritable(int minWritableBytes, bool force);
 
         /// <summary>
-        ///     Gets a boolean at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets a boolean at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         bool GetBoolean(int index);
 
         /// <summary>
-        ///     Gets a byte at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets a byte at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         byte GetByte(int index);
 
         /// <summary>
-        ///     Gets a short at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets a short at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 2</c> greater than <see cref="Capacity" />
         /// </exception>
         short GetShort(int index);
 
         /// <summary>
-        ///     Gets an ushort at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets an ushort at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 2</c> greater than <see cref="Capacity" />
         /// </exception>
         ushort GetUnsignedShort(int index);
 
         /// <summary>
-        ///     Gets an integer at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets an integer at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 4</c> greater than <see cref="Capacity" />
         /// </exception>
         int GetInt(int index);
 
         /// <summary>
-        ///     Gets an unsigned integer at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets an unsigned integer at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 4</c> greater than <see cref="Capacity" />
         /// </exception>
         uint GetUnsignedInt(int index);
 
         /// <summary>
-        ///     Gets a long integer at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets a long integer at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 8</c> greater than <see cref="Capacity" />
         /// </exception>
         long GetLong(int index);
 
@@ -282,13 +282,13 @@ namespace DotNetty.Buffers
         int GetUnsignedMedium(int index);
 
         /// <summary>
-        ///     Gets a char at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets a char at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 2</c> greater than <see cref="Capacity" />
         /// </exception>
         char GetChar(int index);
 
@@ -299,67 +299,67 @@ namespace DotNetty.Buffers
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
         ///     if the specified <paramref name="index"/> is less than <c>0</c> or
-        ///     <c>index + 3</c> greater than <see cref="Capacity" />
+        ///     <c>index + 4</c> greater than <see cref="Capacity" />
         /// </exception>
         float GetFloat(int index);
 
         /// <summary>
-        ///     Gets a double at the specified absolute <see cref="index" /> in this buffer.
+        ///     Gets a double at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 8</c> greater than <see cref="Capacity" />
         /// </exception>
         double GetDouble(int index);
 
         /// <summary>
-        ///     Transfers this buffers data to the specified <see cref="destination" /> buffer starting at the specified
-        ///     absolute <see cref="index" /> until the destination becomes non-writable.
+        ///     Transfers this buffers data to the specified <paramref name="destination" /> buffer starting at the specified
+        ///     absolute <paramref name="index" /> until the destination becomes non-writable.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer GetBytes(int index, IByteBuffer destination);
 
         /// <summary>
-        ///     Transfers this buffers data to the specified <see cref="destination" /> buffer starting at the specified
-        ///     absolute <see cref="index" /> until the destination becomes non-writable.
+        ///     Transfers this buffers data to the specified <paramref name="destination" /> buffer starting at the specified
+        ///     absolute <paramref name="index" /> until the destination becomes non-writable.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer GetBytes(int index, IByteBuffer destination, int length);
 
         /// <summary>
-        ///     Transfers this buffers data to the specified <see cref="destination" /> buffer starting at the specified
-        ///     absolute <see cref="index" /> until the destination becomes non-writable.
+        ///     Transfers this buffers data to the specified <paramref name="destination" /> buffer starting at the specified
+        ///     absolute <paramref name="index" /> until the destination becomes non-writable.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer GetBytes(int index, IByteBuffer destination, int dstIndex, int length);
 
         /// <summary>
-        ///     Transfers this buffers data to the specified <see cref="destination" /> buffer starting at the specified
-        ///     absolute <see cref="index" /> until the destination becomes non-writable.
+        ///     Transfers this buffers data to the specified <paramref name="destination" /> buffer starting at the specified
+        ///     absolute <paramref name="index" /> until the destination becomes non-writable.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer GetBytes(int index, byte[] destination);
 
         /// <summary>
-        ///     Transfers this buffers data to the specified <see cref="destination" /> buffer starting at the specified
-        ///     absolute <see cref="index" /> until the destination becomes non-writable.
+        ///     Transfers this buffers data to the specified <paramref name="destination" /> buffer starting at the specified
+        ///     absolute <paramref name="index" /> until the destination becomes non-writable.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer GetBytes(int index, byte[] destination, int dstIndex, int length);
@@ -383,62 +383,62 @@ namespace DotNetty.Buffers
         IByteBuffer GetBytes(int index, Stream destination, int length);
 
         /// <summary>
-        ///     Sets the specified boolean at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified boolean at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetBoolean(int index, bool value);
 
         /// <summary>
-        ///     Sets the specified byte at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified byte at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
         ///     <c>index + 1</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetByte(int index, int value);
 
         /// <summary>
-        ///     Sets the specified short at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified short at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 2</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetShort(int index, int value);
 
         /// <summary>
-        ///     Sets the specified unsigned short at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified unsigned short at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 2</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetUnsignedShort(int index, ushort value);
 
         /// <summary>
-        ///     Sets the specified integer at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified integer at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 4</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetInt(int index, int value);
 
         /// <summary>
-        ///     Sets the specified unsigned integer at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified unsigned integer at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 4</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetUnsignedInt(int index, uint value);
 
@@ -454,99 +454,106 @@ namespace DotNetty.Buffers
         IByteBuffer SetMedium(int index, int value);
 
         /// <summary>
-        ///     Sets the specified long integer at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified long integer at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 8</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetLong(int index, long value);
 
         /// <summary>
-        ///     Sets the specified UTF-16 char at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified UTF-16 char at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 2</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetChar(int index, char value);
 
         /// <summary>
-        ///     Sets the specified double at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified double at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 8</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetDouble(int index, double value);
 
         /// <summary>
-        ///     Sets the specified float at the specified absolute <see cref="index" /> in this buffer.
+        ///     Sets the specified float at the specified absolute <paramref name="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c>index + 4</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetFloat(int index, float value);
 
         /// <summary>
-        ///     Transfers the <see cref="src" /> byte buffer's contents starting at the specified absolute <see cref="index" />.
+        ///     Transfers the <paramref name="src" /> byte buffer's contents starting at the specified absolute <paramref name="index" />.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c><paramref name="index"/> + <paramref name="src"/>.ReadableBytes</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetBytes(int index, IByteBuffer src);
 
         /// <summary>
-        ///     Transfers the <see cref="src" /> byte buffer's contents starting at the specified absolute <see cref="index" />.
+        ///     Transfers the <paramref name="src" /> byte buffer's contents starting at the specified absolute <paramref name="index" />.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index"/> is less than <c>0</c> or
+        ///     <paramref name="length"/> is less than <c>0</c> or
+        ///     <c><paramref name="index"/> + <paramref name="length"/></c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetBytes(int index, IByteBuffer src, int length);
 
         /// <summary>
-        ///     Transfers the <see cref="src" /> byte buffer's contents starting at the specified absolute <see cref="index" />.
+        ///     Transfers the <paramref name="src" /> byte buffer's contents starting at the specified absolute <paramref name="index" />.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index"/> is less than <c>0</c> or
+        ///     <paramref name="srcIndex"/> is less than <c>0</c> or
+        ///     <paramref name="length"/> is less than <c>0</c> or
+        ///     <c><paramref name="index"/> + <paramref name="length"/></c> greater than <see cref="Capacity" /> or
+        ///     <c><paramref name="srcIndex"/> + <paramref name="length"/></c> greater than <c><paramref name="src" />.Capacity</c>
         /// </exception>
         IByteBuffer SetBytes(int index, IByteBuffer src, int srcIndex, int length);
 
         /// <summary>
-        ///     Transfers the <see cref="src" /> byte buffer's contents starting at the specified absolute <see cref="index" />.
+        ///     Transfers the <paramref name="src" /> byte buffer's contents starting at the specified absolute <paramref name="index" />.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index" /> is less than <c>0</c> or
+        ///     <c><paramref name="index"/> + <paramref name="src"/>.Length</c> greater than <see cref="Capacity" />
         /// </exception>
         IByteBuffer SetBytes(int index, byte[] src);
 
         /// <summary>
-        ///     Transfers the <see cref="src" /> byte buffer's contents starting at the specified absolute <see cref="index" />.
+        ///     Transfers the <paramref name="src" /> byte buffer's contents starting at the specified absolute <paramref name="index" />.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <see cref="index" /> is less than <c>0</c> or
-        ///     <c>index + 1</c> greater than <see cref="Capacity" />
+        ///     if the specified <paramref name="index"/> is less than <c>0</c> or
+        ///     <paramref name="srcIndex"/> is less than <c>0</c> or
+        ///     <paramref name="length"/> is less than <c>0</c> or
+        ///     <c><paramref name="index"/> + <paramref name="length"/></c> greater than <see cref="Capacity" /> or
+        ///     <c><paramref name="srcIndex"/> + <paramref name="length"/></c> greater than <c><paramref name="src" />.Length</c>
         /// </exception>
         IByteBuffer SetBytes(int index, byte[] src, int srcIndex, int length);
 
         /// <summary>
         ///     Transfers the content of the specified source stream to this buffer
-        ///     starting at the specified absolute {@code index}.
-        ///     This method does not modify {@code readerIndex} or {@code writerIndex} of
+        ///     starting at the specified absolute <paramref name="index"/>.
+        ///     This method does not modify <see cref="ReaderIndex"/> or <see cref="WriterIndex"/> of
         ///     this buffer.
         /// </summary>
         /// <param name="index">absolute index in this byte buffer to start writing to</param>
@@ -555,7 +562,7 @@ namespace DotNetty.Buffers
         /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the actual number of bytes read in from the specified channel.</returns>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if the specified <c>index</c> is less than {@code 0} or
+        ///     if the specified <c>index</c> is less than <c>0</c> or
         ///     if <c>index + length</c> is greater than <c>this.capacity</c>
         /// </exception>
         Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken);
@@ -639,14 +646,14 @@ namespace DotNetty.Buffers
         ///     <see cref="ReaderIndex" />
         ///     by <c>4</c> in this buffer.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException">if <see cref="ReadableBytes" /> is less than <c>8</c></exception>
+        /// <exception cref="IndexOutOfRangeException">if <see cref="ReadableBytes" /> is less than <c>4</c></exception>
         float ReadFloat();
 
         /// <summary>
-        ///     Reads <see cref="length" /> bytes from this buffer into a new destination buffer.
+        ///     Reads <paramref name="length" /> bytes from this buffer into a new destination buffer.
         /// </summary>
         /// <exception cref="IndexOutOfRangeException">
-        ///     if <see cref="ReadableBytes" /> is less than <see cref="length" />
+        ///     if <see cref="ReadableBytes" /> is less than <paramref name="length" />
         /// </exception>
         IByteBuffer ReadBytes(int length);
 
@@ -672,9 +679,9 @@ namespace DotNetty.Buffers
         IByteBuffer ReadBytes(Stream destination, int length);
 
         /// <summary>
-        ///     Increases the current <see cref="ReaderIndex" /> by the specified <see cref="length" /> in this buffer.
+        ///     Increases the current <see cref="ReaderIndex" /> by the specified <paramref name="length" /> in this buffer.
         /// </summary>
-        /// <exception cref="IndexOutOfRangeException"> if <see cref="length" /> is greater than <see cref="ReadableBytes" />.</exception>
+        /// <exception cref="IndexOutOfRangeException"> if <paramref name="length" /> is greater than <see cref="ReadableBytes" />.</exception>
         IByteBuffer SkipBytes(int length);
 
         IByteBuffer WriteBoolean(bool value);
@@ -719,7 +726,7 @@ namespace DotNetty.Buffers
         /// </summary>
         /// <returns>
         ///     <c>-1</c> if this buffer cannot represent its content as <see cref="ArraySegment{T}" /> of <see cref="Byte" />.
-        ///     the number of the underlying {@link ByteBuffer}s if this buffer has at least one underlying segment.
+        ///     the number of the underlying <see cref="IByteBuffer"/>s if this buffer has at least one underlying segment.
         ///     Note that this method does not return <c>0</c> to avoid confusion.
         /// </returns>
         /// <seealso cref="GetIoBuffer()" />
@@ -850,19 +857,19 @@ namespace DotNetty.Buffers
         ///     Iterates over the readable bytes of this buffer with the specified <c>processor</c> in ascending order.
         /// </summary>
         /// <returns>
-        ///     <c>1</c> if the processor iterated to or beyond the end of the readable bytes.
+        ///     <c>-1</c> if the processor iterated to or beyond the end of the readable bytes.
         ///     The last-visited index If the <see cref="ByteProcessor.Process(byte)" /> returned <c>false</c>.
         /// </returns>
         /// <param name="processor">Processor.</param>
         int ForEachByte(ByteProcessor processor);
 
         /// <summary>
-        ///     Iterates over the specified area of this buffer with the specified {@code processor} in ascending order.
-        ///     (i.e. {@code index}, {@code (index + 1)},  .. {@code (index + length - 1)})
+        ///     Iterates over the specified area of this buffer with the specified <paramref name="processor"/> in ascending order.
+        ///     (i.e. <paramref name="index"/>, <c>(index + 1)</c>,  .. <c>(index + length - 1)</c>)
         /// </summary>
         /// <returns>
-        ///     {@code -1} if the processor iterated to or beyond the end of the specified area.
-        ///     The last-visited index If the {@link ByteProcessor#process(byte)} returned {@code false}.
+        ///     <c>-1</c> if the processor iterated to or beyond the end of the specified area.
+        ///     The last-visited index If the <see cref="ByteProcessor.Process(byte)"/> returned <c>false</c>.
         /// </returns>
         /// <param name="index">Index.</param>
         /// <param name="length">Length.</param>
@@ -870,22 +877,22 @@ namespace DotNetty.Buffers
         int ForEachByte(int index, int length, ByteProcessor processor);
 
         /// <summary>
-        ///     Iterates over the readable bytes of this buffer with the specified {@code processor} in descending order.
+        ///     Iterates over the readable bytes of this buffer with the specified <paramref name="processor"/> in descending order.
         /// </summary>
         /// <returns>
-        ///     {@code -1} if the processor iterated to or beyond the beginning of the readable bytes.
-        ///     The last-visited index If the {@link ByteProcessor#process(byte)} returned {@code false}.
+        ///     <c>-1</c> if the processor iterated to or beyond the beginning of the readable bytes.
+        ///     The last-visited index If the <see cref="ByteProcessor.Process(byte)"/> returned <c>false</c>.
         /// </returns>
         /// <param name="processor">Processor.</param>
         int ForEachByteDesc(ByteProcessor processor);
 
         /// <summary>
-        ///     Iterates over the specified area of this buffer with the specified {@code processor} in descending order.
-        ///     (i.e. {@code (index + length - 1)}, {@code (index + length - 2)}, ... {@code index})
+        ///     Iterates over the specified area of this buffer with the specified <paramref name="processor"/> in descending order.
+        ///     (i.e. <c>(index + length - 1)</c>, <c>(index + length - 2)</c>, ... <paramref name="index"/>)
         /// </summary>
         /// <returns>
-        ///     {@code -1} if the processor iterated to or beyond the beginning of the specified area.
-        ///     The last-visited index If the {@link ByteProcessor#process(byte)} returned {@code false}.
+        ///     <c>-1</c> if the processor iterated to or beyond the beginning of the specified area.
+        ///     The last-visited index If the <see cref="ByteProcessor.Process(byte)"/> returned <c>false</c>.
         /// </returns>
         /// <param name="index">Index.</param>
         /// <param name="length">Length.</param>

--- a/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
@@ -170,6 +170,13 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public override IByteBuffer SetZero(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            System.Array.Clear(this.Memory, this.Idx(index), length);
+            return this;
+        }
+
         public override IByteBuffer Copy(int index, int length)
         {
             this.CheckIndex(index, length);

--- a/src/DotNetty.Buffers/SlicedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SlicedByteBuffer.cs
@@ -165,5 +165,12 @@ namespace DotNetty.Buffers
             this.buffer.SetBytes(index + this.adjustment, src, srcIndex, length);
             return this;
         }
+
+        public override IByteBuffer SetZero(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            this.buffer.SetZero(index + this.adjustment, length);
+            return this;
+        }
     }
 }

--- a/src/DotNetty.Buffers/SwappedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SwappedByteBuffer.cs
@@ -344,6 +344,12 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public IByteBuffer SetZero(int index, int length)
+        {
+            this.buf.SetZero(index, length);
+            return this;
+        }
+
         public Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken) => this.buf.SetBytesAsync(index, src, length, cancellationToken);
 
         public bool ReadBoolean() => this.buf.ReadBoolean();
@@ -587,6 +593,12 @@ namespace DotNetty.Buffers
         public Task WriteBytesAsync(Stream stream, int length) => this.buf.WriteBytesAsync(stream, length);
 
         public Task WriteBytesAsync(Stream stream, int length, CancellationToken cancellationToken) => this.buf.WriteBytesAsync(stream, length, cancellationToken);
+
+        public IByteBuffer WriteZero(int length)
+        {
+            this.buf.WriteZero(length);
+            return this;
+        }
 
         public int ForEachByte(ByteProcessor processor) => this.buf.ForEachByte(processor);
 

--- a/src/DotNetty.Buffers/SwappedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SwappedByteBuffer.cs
@@ -11,6 +11,7 @@ namespace DotNetty.Buffers
     using System.Threading.Tasks;
     using DotNetty.Common;
     using DotNetty.Common.Utilities;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     ///     Wrapper which swaps the <see cref="ByteOrder" /> of a <see cref="IByteBuffer" />.
@@ -192,6 +193,12 @@ namespace DotNetty.Buffers
 
         public char GetChar(int index) => (char)this.GetShort(index);
 
+        public float GetFloat(int index)
+        {
+            int raw = this.GetInt(index);
+            return Unsafe.As<int, float>(ref raw);
+        }
+
         public double GetDouble(int index) => BitConverter.Int64BitsToDouble(this.GetLong(index));
 
         public IByteBuffer GetBytes(int index, IByteBuffer destination)
@@ -295,6 +302,12 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public IByteBuffer SetFloat(int index, float value)
+        {
+            this.SetInt(index, Unsafe.As<float, int>(ref value));
+            return this;
+        }
+
         public IByteBuffer SetDouble(int index, double value)
         {
             this.SetLong(index, BitConverter.DoubleToInt64Bits(value));
@@ -364,6 +377,12 @@ namespace DotNetty.Buffers
         public int ReadUnsignedMedium() => this.ReadMedium().ToUnsignedMediumInt();
 
         public char ReadChar() => (char)this.ReadShort();
+
+        public float ReadFloat()
+        {
+            int raw = this.ReadInt();
+            return Unsafe.As<int, float>(ref raw);
+        }
 
         public double ReadDouble() => BitConverter.Int64BitsToDouble(this.ReadLong());
 
@@ -477,6 +496,12 @@ namespace DotNetty.Buffers
         public IByteBuffer WriteChar(char value)
         {
             this.WriteShort(value);
+            return this;
+        }
+
+        public IByteBuffer WriteFloat(float value)
+        {
+            this.WriteInt(Unsafe.As<float, int>(ref value));
             return this;
         }
 

--- a/src/DotNetty.Buffers/SwappedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SwappedByteBuffer.cs
@@ -147,7 +147,8 @@ namespace DotNetty.Buffers
 
         public IByteBuffer DiscardSomeReadBytes()
         {
-            throw new NotImplementedException();
+            this.buf.DiscardSomeReadBytes();
+            return this;
         }
 
         public IByteBuffer EnsureWritable(int minWritableBytes)
@@ -156,10 +157,7 @@ namespace DotNetty.Buffers
             return this;
         }
 
-        public int EnsureWritable(int minWritableBytes, bool force)
-        {
-            throw new NotImplementedException();
-        }
+        public int EnsureWritable(int minWritableBytes, bool force) => this.buf.EnsureWritable(minWritableBytes, force);
 
         public bool GetBoolean(int index) => this.buf.GetBoolean(index);
 
@@ -256,11 +254,6 @@ namespace DotNetty.Buffers
         }
 
         public IByteBuffer SetUnsignedShort(int index, ushort value)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IByteBuffer SetUnsignedShort(int index, int value)
         {
             unchecked
             {
@@ -455,11 +448,6 @@ namespace DotNetty.Buffers
         }
 
         public IByteBuffer WriteUnsignedShort(ushort value)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IByteBuffer WriteUnsignedShort(int value)
         {
             this.buf.WriteUnsignedShort(unchecked((ushort)ByteBufferUtil.SwapShort((short)value)));
             return this;

--- a/src/DotNetty.Buffers/SwappedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SwappedByteBuffer.cs
@@ -191,11 +191,7 @@ namespace DotNetty.Buffers
 
         public char GetChar(int index) => (char)this.GetShort(index);
 
-        public float GetFloat(int index)
-        {
-            int raw = this.GetInt(index);
-            return Unsafe.As<int, float>(ref raw);
-        }
+        public float GetFloat(int index) => ByteBufferUtil.Int32BitsToSingle(this.GetInt(index));
 
         public double GetDouble(int index) => BitConverter.Int64BitsToDouble(this.GetLong(index));
 
@@ -297,7 +293,7 @@ namespace DotNetty.Buffers
 
         public IByteBuffer SetFloat(int index, float value)
         {
-            this.SetInt(index, Unsafe.As<float, int>(ref value));
+            this.SetInt(index, ByteBufferUtil.SingleToInt32Bits(value));
             return this;
         }
 
@@ -377,11 +373,7 @@ namespace DotNetty.Buffers
 
         public char ReadChar() => (char)this.ReadShort();
 
-        public float ReadFloat()
-        {
-            int raw = this.ReadInt();
-            return Unsafe.As<int, float>(ref raw);
-        }
+        public float ReadFloat() => ByteBufferUtil.Int32BitsToSingle(this.ReadInt());
 
         public double ReadDouble() => BitConverter.Int64BitsToDouble(this.ReadLong());
 
@@ -495,7 +487,7 @@ namespace DotNetty.Buffers
 
         public IByteBuffer WriteFloat(float value)
         {
-            this.WriteInt(Unsafe.As<float, int>(ref value));
+            this.WriteInt(ByteBufferUtil.SingleToInt32Bits(value));
             return this;
         }
 

--- a/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
@@ -182,6 +182,13 @@ namespace DotNetty.Buffers
             return readTotal;
         }
 
+        public override IByteBuffer SetZero(int index, int length)
+        {
+            this.CheckIndex(index, length);
+            System.Array.Clear(this.array, index, length);
+            return this;
+        }
+
         public override byte GetByte(int index)
         {
             this.EnsureAccessible();

--- a/src/DotNetty.Buffers/WrappedByteBuf.cs
+++ b/src/DotNetty.Buffers/WrappedByteBuf.cs
@@ -143,11 +143,7 @@ namespace DotNetty.Buffers
 
         public virtual char GetChar(int index) => this.Buf.GetChar(index);
 
-        // todo: port: complete
-        //public virtual float GetFloat(int index)
-        //{
-        //    return this.buf.GetFloat(index);
-        //}
+        public virtual float GetFloat(int index) => this.Buf.GetFloat(index);
 
         public virtual double GetDouble(int index) => this.Buf.GetDouble(index);
 
@@ -233,12 +229,11 @@ namespace DotNetty.Buffers
             return this;
         }
 
-        // todo: port: complete
-        //public virtual IByteBuffer SetFloat(int index, float value)
-        //{
-        //    buf.SetFloat(index, value);
-        //    return this;
-        //}
+        public virtual IByteBuffer SetFloat(int index, float value)
+        {
+            this.Buf.SetFloat(index, value);
+            return this;
+        }
 
         public virtual IByteBuffer SetDouble(int index, double value)
         {
@@ -305,11 +300,7 @@ namespace DotNetty.Buffers
 
         public virtual char ReadChar() => this.Buf.ReadChar();
 
-        // todo: port: complete
-        //public virtual float ReadFloat()
-        //{
-        //    return buf.ReadFloat();
-        //}
+        public virtual float ReadFloat() => this.Buf.ReadFloat();
 
         public virtual double ReadDouble() => this.Buf.ReadDouble();
 
@@ -409,12 +400,11 @@ namespace DotNetty.Buffers
             return this;
         }
 
-        // todo: port: complete
-        //public virtual IByteBuffer WriteFloat(float value)
-        //{
-        //    buf.WriteFloat(value);
-        //    return this;
-        //}
+        public virtual IByteBuffer WriteFloat(float value)
+        {
+            this.Buf.WriteFloat(value);
+            return this;
+        }
 
         public virtual IByteBuffer WriteDouble(double value)
         {

--- a/src/DotNetty.Buffers/WrappedByteBuf.cs
+++ b/src/DotNetty.Buffers/WrappedByteBuf.cs
@@ -273,12 +273,11 @@ namespace DotNetty.Buffers
 
         public virtual Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken) => this.Buf.SetBytesAsync(index, src, length, cancellationToken);
 
-        // todo: port: complete
-        //public virtual IByteBuffer SetZero(int index, int length)
-        //{
-        //    buf.SetZero(index, length);
-        //    return this;
-        //}
+        public virtual IByteBuffer SetZero(int index, int length)
+        {
+            this.Buf.SetZero(index, length);
+            return this;
+        }
 
         public virtual bool ReadBoolean() => this.Buf.ReadBoolean();
 
@@ -454,12 +453,11 @@ namespace DotNetty.Buffers
 
         public virtual Task WriteBytesAsync(Stream input, int length, CancellationToken cancellationToken) => this.Buf.WriteBytesAsync(input, length, cancellationToken);
 
-        // todo: port: complete
-        //public virtual IByteBuffer WriteZero(int length)
-        //{
-        //    buf.WriteZero(length);
-        //    return this;
-        //}
+        public virtual IByteBuffer WriteZero(int length)
+        {
+            this.Buf.WriteZero(length);
+            return this;
+        }
 
         //public virtual int IndexOf(int fromIndex, int toIndex, byte value)
         //{

--- a/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
@@ -1671,7 +1671,7 @@ namespace DotNetty.Buffers.Tests
             {
                 value[0] ++;
             }
-            else if (value[0] == -1)
+            else if (value[0] == 0xFF)
             {
                 value[0] --;
             }

--- a/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
@@ -517,6 +517,23 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
+        public void TestRandomFloatAccess()
+        {
+            for (int i = 0; i < this.buffer.Capacity - 3; i += 4)
+            {
+                float value = (float)this.random.NextDouble();
+                this.buffer.SetFloat(i, value);
+            }
+
+            this.random = new Random(this.seed);
+            for (int i = 0; i < this.buffer.Capacity - 3; i += 4)
+            {
+                float value = (float)this.random.NextDouble();
+                Assert.Equal(value, this.buffer.GetFloat(i), 2);
+            }
+        }
+
+        [Fact]
         public void TestSequentialByteAccess()
         {
             this.buffer.SetWriterIndex(0);

--- a/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
@@ -365,14 +365,14 @@ namespace DotNetty.Buffers.Tests
         {
             for (int i = 0; i < this.buffer.Capacity - 1; i += 2)
             {
-                short value = (short)this.random.Next();
+                ushort value = (ushort)(this.random.Next() & 0xFFFF);
                 if (testBigEndian)
                 {
-                    this.buffer.SetShort(i, value);
+                    this.buffer.SetUnsignedShort(i, value);
                 }
                 else
                 {
-                    this.buffer.WithOrder(ByteOrder.LittleEndian).SetShort(i, value);
+                    this.buffer.WithOrder(ByteOrder.LittleEndian).SetUnsignedShort(i, value);
                 }
             }
 
@@ -437,14 +437,14 @@ namespace DotNetty.Buffers.Tests
         {
             for (int i = 0; i < this.buffer.Capacity - 3; i += 4)
             {
-                int value = this.random.Next();
+                uint value = (uint)(this.random.Next() & 0xFFFFFFFFL);
                 if (testBigEndian)
                 {
-                    this.buffer.SetInt(i, value);
+                    this.buffer.SetUnsignedInt(i, value);
                 }
                 else
                 {
-                    this.buffer.WithOrder(ByteOrder.LittleEndian).SetInt(i, value);
+                    this.buffer.WithOrder(ByteOrder.LittleEndian).SetUnsignedInt(i, value);
                 }
             }
 
@@ -2105,10 +2105,22 @@ namespace DotNetty.Buffers.Tests
         public void TestSetShortLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).SetShort(0, 1));
 
         [Fact]
+        public void TestSetUnsignedShortAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetUnsignedShort(0, 1));
+
+        [Fact]
+        public void TestSetUnsignedShortLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).SetUnsignedShort(0, 1));
+
+        [Fact]
         public void TestSetIntAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetInt(0, 1));
 
         [Fact]
         public void TestSetIntLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).SetInt(0, 1));
+
+        [Fact]
+        public void TestSetUnsignedIntAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetUnsignedInt(0, 1));
+
+        [Fact]
+        public void TestSetUnsignedIntLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).SetUnsignedInt(0, 1));
 
         [Fact]
         public void TestSetLongAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetLong(0, 1));
@@ -2237,10 +2249,22 @@ namespace DotNetty.Buffers.Tests
         public void TestWriteShortLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).WriteShort(1));
 
         [Fact]
+        public void TestWriteUnsignedShortAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteUnsignedShort(1));
+
+        [Fact]
+        public void TestWriteUnsignedShortLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).WriteUnsignedShort(1));
+
+        [Fact]
         public void TestWriteIntAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteInt(1));
 
         [Fact]
         public void TestWriteIntLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).WriteInt(1));
+
+        [Fact]
+        public void TestWriteUnsignedIntAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteUnsignedInt(1));
+
+        [Fact]
+        public void TestWriteUnsignedIntLeAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WithOrder(ByteOrder.LittleEndian).WriteUnsignedInt(1));
 
         [Fact]
         public void TestWriteLongAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteLong(1));

--- a/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractByteBufTest.cs
@@ -534,6 +534,28 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
+        public void TestSetZero()
+        {
+            this.buffer.Clear();
+            while (this.buffer.IsWritable())
+            {
+                this.buffer.WriteByte((byte)0xFF);
+            }
+
+            for (int i = 0; i < this.buffer.Capacity;)
+            {
+                int length = Math.Min(this.buffer.Capacity - i, random.Next(32));
+                this.buffer.SetZero(i, length);
+                i += length;
+            }
+
+            for (int i = 0; i < this.buffer.Capacity; i++)
+            {
+                Assert.Equal(0, this.buffer.GetByte(i));
+            }
+        }
+
+        [Fact]
         public void TestSequentialByteAccess()
         {
             this.buffer.SetWriterIndex(0);
@@ -1476,6 +1498,34 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
+        public void TestWriteZero()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => this.buffer.WriteZero(-1));
+
+            this.buffer.Clear();
+            while (this.buffer.IsWritable())
+            {
+                this.buffer.WriteByte((byte)0xFF);
+            }
+
+            this.buffer.Clear();
+            for (int i = 0; i < this.buffer.Capacity;)
+            {
+                int length = Math.Min(this.buffer.Capacity - i, random.Next(32));
+                this.buffer.WriteZero(length);
+                i += length;
+            }
+
+            Assert.Equal(0, this.buffer.ReaderIndex);
+            Assert.Equal(buffer.Capacity, buffer.WriterIndex);
+
+            for (int i = 0; i < this.buffer.Capacity; i++)
+            {
+                Assert.Equal(0, this.buffer.GetByte(i));
+            }
+        }
+
+        [Fact]
         public void TestDiscardReadBytes()
         {
             this.buffer.SetWriterIndex(0);
@@ -2019,6 +2069,9 @@ namespace DotNetty.Buffers.Tests
         public void TestGetDoubleAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().GetDouble(0));
 
         [Fact]
+        public void TestGetFloatAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().GetFloat(0));
+
+        [Fact]
         public void TestGetBytesAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().GetBytes(0, ReferenceCountUtil.ReleaseLater(Unpooled.Buffer(8))));
 
         [Fact]
@@ -2070,6 +2123,9 @@ namespace DotNetty.Buffers.Tests
         public void TestSetDoubleAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetDouble(0, 1));
 
         [Fact]
+        public void TestSetFloatAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetFloat(0, 1));
+
+        [Fact]
         public void TestSetBytesAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetBytes(0, ReferenceCountUtil.ReleaseLater(Unpooled.Buffer())));
 
         [Fact]
@@ -2083,6 +2139,9 @@ namespace DotNetty.Buffers.Tests
 
         [Fact]
         public void TestSetBytesAfterRelease5() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetBytes(0, new byte[8], 0, 1));
+
+        [Fact]
+        public void TestSetZeroAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().SetZero(0, 1));
 
         [Fact]
         public void TestReadBooleanAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().ReadBoolean());
@@ -2139,6 +2198,9 @@ namespace DotNetty.Buffers.Tests
         public void TestReadDoubleAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().ReadDouble());
 
         [Fact]
+        public void TestReadFloatAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().ReadFloat());
+
+        [Fact]
         public void TestReadBytesAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().ReadBytes(1));
 
         [Fact]
@@ -2193,6 +2255,9 @@ namespace DotNetty.Buffers.Tests
         public void TestWriteDoubleAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteDouble(1));
 
         [Fact]
+        public void TestWriteFloatAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteFloat(1));
+
+        [Fact]
         public void TestWriteBytesAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteBytes(ReferenceCountUtil.ReleaseLater(Unpooled.Buffer(8))));
 
         [Fact]
@@ -2206,6 +2271,9 @@ namespace DotNetty.Buffers.Tests
 
         [Fact]
         public void TestWriteBytesAfterRelease5() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteBytes(new byte[8], 0, 1));
+
+        [Fact]
+        public void TestWriteZeroAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().WriteZero(1));
 
         [Fact]
         public void TestForEachByteAfterRelease() => Assert.Throws<IllegalReferenceCountException>(() => this.ReleasedBuffer().ForEachByte(new TestByteProcessor()));


### PR DESCRIPTION
The new methods will broken classes which implements `IByteBuffer` and not extends `AbstractByteBuffer`.
This commit also add an new dependency [System.Runtime.CompilerServices.Unsafe](https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe) 4.3.0 to `DotNetty.Buffers`.