### PR TITLE
SNI support

### DIFF
--- a/src/DotNetty.Handlers/Tls/PeekableStream.cs
+++ b/src/DotNetty.Handlers/Tls/PeekableStream.cs
@@ -1,0 +1,148 @@
+﻿// Credit http://stackoverflow.com/questions/2196767/c-implementing-networkstream-peek/7281113#7281113
+namespace DotNetty.Handlers.Tls
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// PeekableStream wraps a Stream and can be used to peek ahead in the underlying stream,
+    /// without consuming the bytes. In other words, doing Peek() will allow you to look ahead in the stream,
+    /// but it won't affect the result of subsequent Read() calls.
+    /// 
+    /// This is sometimes necessary, e.g. for peeking at the magic number of a stream of bytes and decide which
+    /// stream processor to hand over the stream.
+    /// </summary>
+    public class PeekableStream : Stream
+    {
+        readonly Stream underlyingStream;
+        readonly byte[] lookAheadBuffer;
+
+        int lookAheadIndex;
+
+        public PeekableStream(Stream underlyingStream, int maxPeekBytes)
+        {
+            this.underlyingStream = underlyingStream;
+            this.lookAheadBuffer = new byte[maxPeekBytes];
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                this.underlyingStream.Dispose();
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Peeks at a maximum of count bytes, or less if the stream ends before that number of bytes can be read.
+        /// 
+        /// Calls to this method do not influence subsequent calls to Read() and Peek().
+        /// 
+        /// Please note that this method will always peek count bytes unless the end of the stream is reached before that - in contrast to the Read()
+        /// method, which might read less than count bytes, even though the end of the stream has not been reached.
+        /// </summary>
+        /// <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array with the values between offset and
+        /// (offset + number-of-peeked-bytes - 1) replaced by the bytes peeked from the current source.</param>
+        /// <param name="offset">The zero-based byte offset in buffer at which to begin storing the data peeked from the current stream.</param>
+        /// <param name="count">The maximum number of bytes to be peeked from the current stream.</param>
+        /// <returns>The total number of bytes peeked into the buffer. If it is less than the number of bytes requested then the end of the stream has been reached.</returns>
+        public virtual int Peek(byte[] buffer, int offset, int count)
+        {
+            if (count > this.lookAheadBuffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(count), "must be smaller than peekable size, which is " + this.lookAheadBuffer.Length);
+
+            while (this.lookAheadIndex < count)
+            {
+                int bytesRead = this.underlyingStream.Read(this.lookAheadBuffer, this.lookAheadIndex, count - this.lookAheadIndex);
+
+                if (bytesRead == 0) // end of stream reached
+                    break;
+
+                this.lookAheadIndex += bytesRead;
+            }
+
+            int peeked = Math.Min(count, this.lookAheadIndex);
+            Array.Copy(this.lookAheadBuffer, 0, buffer, offset, peeked);
+            return peeked;
+        }
+
+        public override bool CanRead { get { return true; } }
+
+        public override long Position
+        {
+            get
+            {
+                return this.underlyingStream.Position - this.lookAheadIndex;
+            }
+            set
+            {
+                this.underlyingStream.Position = value;
+                this.lookAheadIndex = 0; // this needs to be done AFTER the call to underlyingStream.Position, as that might throw NotSupportedException, 
+                                    // in which case we don't want to change the lookAhead status
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int bytesTakenFromLookAheadBuffer = 0;
+            if (count > 0 && this.lookAheadIndex > 0)
+            {
+                bytesTakenFromLookAheadBuffer = Math.Min(count, this.lookAheadIndex);
+                Array.Copy(this.lookAheadBuffer, 0, buffer, offset, bytesTakenFromLookAheadBuffer);
+                count -= bytesTakenFromLookAheadBuffer;
+                offset += bytesTakenFromLookAheadBuffer;
+                this.lookAheadIndex -= bytesTakenFromLookAheadBuffer;
+                if (this.lookAheadIndex > 0) // move remaining bytes in lookAheadBuffer to front
+                                        // copying into same array should be fine, according to http://msdn.microsoft.com/en-us/library/z50k9bft(v=VS.90).aspx :
+                                        // "If sourceArray and destinationArray overlap, this method behaves as if the original values of sourceArray were preserved
+                                        // in a temporary location before destinationArray is overwritten."
+                    Array.Copy(this.lookAheadBuffer, this.lookAheadBuffer.Length - bytesTakenFromLookAheadBuffer + 1, this.lookAheadBuffer, 0, this.lookAheadIndex);
+            }
+
+            return count > 0
+                ? bytesTakenFromLookAheadBuffer + this.underlyingStream.Read(buffer, offset, count)
+                : bytesTakenFromLookAheadBuffer;
+        }
+
+        public override int ReadByte()
+        {
+            if (this.lookAheadIndex > 0)
+            {
+                this.lookAheadIndex--;
+                byte firstByte = this.lookAheadBuffer[0];
+                if (this.lookAheadIndex > 0) // move remaining bytes in lookAheadBuffer to front
+                    Array.Copy(this.lookAheadBuffer, 1, this.lookAheadBuffer, 0, this.lookAheadIndex);
+                return firstByte;
+            }
+            else
+            {
+                return this.underlyingStream.ReadByte();
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long ret = this.underlyingStream.Seek(offset, origin);
+            this.lookAheadIndex = 0; // this needs to be done AFTER the call to underlyingStream.Seek(), as that might throw NotSupportedException,
+                                // in which case we don't want to change the lookAhead status
+            return ret;
+        }
+
+        // from here on, only simple delegations to underlyingStream
+
+        public override bool CanSeek { get { return this.underlyingStream.CanSeek; } }
+        public override bool CanWrite { get { return this.underlyingStream.CanWrite; } }
+        public override bool CanTimeout { get { return this.underlyingStream.CanTimeout; } }
+        public override int ReadTimeout { get { return this.underlyingStream.ReadTimeout; } set { this.underlyingStream.ReadTimeout = value; } }
+        public override int WriteTimeout { get { return this.underlyingStream.WriteTimeout; } set { this.underlyingStream.WriteTimeout = value; } }
+        public override void Flush() {
+            this.underlyingStream.Flush(); }
+        public override long Length { get { return this.underlyingStream.Length; } }
+        public override void SetLength(long value) {
+            this.underlyingStream.SetLength(value); }
+        public override void Write(byte[] buffer, int offset, int count) {
+            this.underlyingStream.Write(buffer, offset, count); }
+        public override void WriteByte(byte value) {
+            this.underlyingStream.WriteByte(value); }
+    }
+}

--- a/src/DotNetty.Handlers/Tls/SNISslStream.cs
+++ b/src/DotNetty.Handlers/Tls/SNISslStream.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace DotNetty.Handlers.Tls
+{
+    using System;
+    using System.IO;
+    using System.Net.Security;
+    using System.Text;
+
+    public class SniSslStream : SslStream
+    {
+        const int MaxPeekSize = 512;
+        readonly PeekableStream innerStream;
+
+        public SniSslStream(Stream innerStream)
+            : base(innerStream)
+        {
+            this.innerStream = new PeekableStream(innerStream, MaxPeekSize);
+        }
+
+        public SniSslStream(Stream innerStream, bool leaveInnerStreamOpen)
+            : base(innerStream, leaveInnerStreamOpen)
+        {
+            this.innerStream = new PeekableStream(innerStream, MaxPeekSize); ;
+        }
+
+        public SniSslStream(Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback)
+            : base(innerStream, leaveInnerStreamOpen, userCertificateValidationCallback)
+        {
+            this.innerStream = new PeekableStream(innerStream, MaxPeekSize); ;
+        }
+
+        public SniSslStream(Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback, LocalCertificateSelectionCallback userCertificateSelectionCallback)
+            : base(innerStream, leaveInnerStreamOpen, userCertificateValidationCallback, userCertificateSelectionCallback)
+        {
+            this.innerStream = new PeekableStream(innerStream, MaxPeekSize); ;
+        }
+
+        public SniSslStream(Stream innerStream, bool leaveInnerStreamOpen, RemoteCertificateValidationCallback userCertificateValidationCallback, LocalCertificateSelectionCallback userCertificateSelectionCallback, EncryptionPolicy encryptionPolicy)
+            : base(innerStream, leaveInnerStreamOpen, userCertificateValidationCallback, userCertificateSelectionCallback, encryptionPolicy)
+        {
+            this.innerStream = new PeekableStream(innerStream, MaxPeekSize); ;
+        }
+
+        public string GetServerName()
+        {
+            try
+            {
+                // Using https://tools.ietf.org/html/rfc5246
+
+                var buffer = new byte[5];
+                if (this.innerStream.Peek(buffer, 0, 5) != 5)
+                    return null;
+
+                var contentType = (ContentType)buffer[0];
+                if (contentType != ContentType.Handshake)
+                {
+                    return null;
+                }
+                // byte 1 and 2 are protocol version. Should accept 0x03xx
+                if (buffer[1] != 3)
+                {
+                    return null;
+                }
+                ushort length = (ushort)(buffer[3] * 256 + buffer[4]);
+                if (length > MaxPeekSize)
+                {
+                    // size too long compared as expected
+                    return null;
+                }
+                var fragment = new byte[length];
+                if (this.innerStream.Peek(fragment, 0, length) != length)
+                    return null;
+
+                var handshakeType = (HandshakeType)fragment[0];
+                if (handshakeType != HandshakeType.ClientHello)
+                {
+                    return null;
+                }
+
+                uint size;
+                /* bytes in message: uint24 length */
+                size = (uint)(fragment[1] * 256 * 256 + fragment[2] * 256 + fragment[3]);
+
+                if (size > fragment.Length - 4)
+                    return null;
+
+                byte[] clientHello = new byte[size];
+                int shortLength = (int)size;
+                Array.Copy(fragment, 4, clientHello, 0, shortLength);
+                int index = 0;
+                byte clientVersionMajor = clientHello[index++];
+                byte clientVersionMinor = clientHello[index++];
+                if (clientVersionMajor != 3 || clientVersionMinor != 3)
+                {
+                    // not TLS 1.2
+                    return null;
+                }
+
+                // 32 bytes of random : don't use
+                index += 32;
+
+                byte sessionIdLength = clientHello[index++];
+                // skip sessionId
+                if (sessionIdLength > 32)
+                {
+                    // invalid
+                    return null;
+                }
+                index += sessionIdLength;
+
+                ushort cipherSuiteLength = (ushort)(clientHello[index++] * 256 + clientHello[index++]);
+                if (cipherSuiteLength < 2 || cipherSuiteLength > 65534)
+                {
+                    // invalid length
+                    return null;
+                }
+                // Skip CipherSuite
+                index += cipherSuiteLength;
+
+                ushort compressionMethodLength = (ushort)(clientHello[index++]);
+                if (compressionMethodLength < 1 || compressionMethodLength > 255)
+                {
+                    return null;
+                }
+                // Skip compression method
+                index += compressionMethodLength;
+
+                ushort extensionsLength = (ushort)(clientHello[index++] * 256 + clientHello[index++]);
+                if (extensionsLength < 0 || extensionsLength > 65535)
+                {
+                    return null;
+                }
+
+                // Not good !extensionsLength is the total size of extensions in bytes, not number of extensions !
+                //for (int extensionIndex = 0; extensionIndex < extensionsLength; ++extensionIndex)
+                int startOfExtensionsIndex = index;
+                while (index < startOfExtensionsIndex + extensionsLength)
+                {
+                    // ExtensionType over 2 bytes
+                    // ExtensionDataLength over 2 bytes
+                    // extension data over ExtensionDataLength bytes
+                    var extensionType = (ExtensionType)(clientHello[index++] * 256 + clientHello[index++]);
+                    ushort extensionDataLength = (ushort)(clientHello[index++] * 256 + clientHello[index++]);
+                    if (extensionType == ExtensionType.ServerName)
+                    {
+                        var extensionData = new byte[extensionDataLength];
+                        Array.Copy(clientHello, index, extensionData, 0, extensionDataLength);
+                        int eIndex = 0;
+                        ushort namesListLength = (ushort)(extensionData[eIndex++] * 256 + extensionData[eIndex++]);
+                        if (namesListLength < 1 || namesListLength > 65535)
+                            return null;
+                        for (int nameIndex = 0; nameIndex < namesListLength; ++nameIndex)
+                        {
+                            var nameType = (NameType)extensionData[eIndex++];
+                            if (nameType == NameType.HostName)
+                            {
+                                ushort nameLength = (ushort)(extensionData[eIndex++] * 256 + extensionData[eIndex++]);
+                                var name = new byte[nameLength];
+                                Array.Copy(extensionData, eIndex, name, 0, nameLength);
+                                eIndex += nameLength;
+                                string hostName = Encoding.ASCII.GetString(name);
+                                return hostName;
+                            }
+                            else
+                            {
+                                // unsupported nameType
+                                return null;
+                            }
+                        }
+                    }
+                    // Just skip data
+                    index += extensionDataLength;
+
+                }
+                return null;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        enum NameType : byte
+        {
+            HostName = 0
+        }
+
+        enum ExtensionType : ushort
+        {
+            ServerName = 0,
+            MaxFragmentLength = 1,
+            ClientCertificateUrl = 2,
+            TrustedCaKeys = 3,
+            TruncatedHmac = 4,
+            StatusRequest = 5
+        }
+
+        enum HandshakeType : byte
+        {
+            HelloRequest = 0,
+            ClientHello = 1,
+            ServerHello = 2,
+            Certificate = 11,
+            ServerKeyExchange = 12,
+            CertificateRequest = 13,
+            ServerHelloDone = 14,
+            CertificateVerify = 15,
+            ClientKeyExchange = 16,
+            Finished = 20
+        }
+
+        enum ContentType : byte
+        {
+            ChangeCipherSpec = 20,
+            Handshake = 22,
+            Alert = 21,
+            ApplicationData = 23,
+
+        }
+    }
+}

--- a/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/ServerTlsSettings.cs
@@ -3,11 +3,14 @@
 
 namespace DotNetty.Handlers.Tls
 {
+    using System.Collections.Generic;
     using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
 
     public sealed class ServerTlsSettings : TlsSettings
     {
+        public const string DefaultCertficateSelectorKey = "Default";
+
         public ServerTlsSettings(X509Certificate certificate)
             : this(certificate, false)
         {
@@ -26,12 +29,25 @@ namespace DotNetty.Handlers.Tls
         public ServerTlsSettings(X509Certificate certificate, bool negotiateClientCertificate, bool checkCertificateRevocation, SslProtocols enabledProtocols)
             : base(enabledProtocols, checkCertificateRevocation)
         {
-            this.Certificate = certificate;
+            this.Certificates = new Dictionary<string, X509Certificate>
+            {
+                { DefaultCertficateSelectorKey, certificate }
+            };
             this.NegotiateClientCertificate = negotiateClientCertificate;
         }
 
-        public X509Certificate Certificate { get; }
+        public ServerTlsSettings(IDictionary<string, X509Certificate> hostnameCertificateMapping, bool negotiateClientCertificate, bool checkCertificateRevocation, SslProtocols enabledProtocols)
+            : base(enabledProtocols, checkCertificateRevocation)
+        {
+            this.Certificates = hostnameCertificateMapping;
+            this.NegotiateClientCertificate = negotiateClientCertificate;
+            this.SniEnabled = true; // assuming SNI intended since this variant of constructor called
+        }
+
+        public IDictionary<string, X509Certificate> Certificates { get; }
 
         public bool NegotiateClientCertificate { get; }
+
+        public bool SniEnabled { get; }
     }
 }

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -28,6 +28,7 @@ namespace DotNetty.Handlers.Tls
         static readonly Action<Task, object> HandshakeCompletionCallback = new Action<Task, object>(HandleHandshakeCompleted);
 
         readonly SslStream sslStream;
+        readonly SniSslStream sniSslStream;
         readonly MediationStream mediationStream;
         readonly TaskCompletionSource closeFuture;
 
@@ -54,6 +55,17 @@ namespace DotNetty.Handlers.Tls
             this.closeFuture = new TaskCompletionSource();
             this.mediationStream = new MediationStream(this);
             this.sslStream = sslStreamFactory(this.mediationStream);
+        }
+
+        public TlsHandler(Func<Stream, SniSslStream> sslStreamFactory, TlsSettings settings)
+        {
+            Contract.Requires(sslStreamFactory != null);
+            Contract.Requires(settings != null);
+
+            this.settings = settings;
+            this.closeFuture = new TaskCompletionSource();
+            this.mediationStream = new MediationStream(this);
+            this.sniSslStream = sslStreamFactory(this.mediationStream);
         }
 
         public static TlsHandler Client(string targetHost) => new TlsHandler(new ClientTlsSettings(targetHost));
@@ -485,7 +497,25 @@ namespace DotNetty.Handlers.Tls
                 if (this.IsServer)
                 {
                     var serverSettings = (ServerTlsSettings)this.settings;
-                    this.sslStream.AuthenticateAsServerAsync(serverSettings.Certificate, serverSettings.NegotiateClientCertificate, serverSettings.EnabledProtocols, serverSettings.CheckCertificateRevocation)
+
+                    if (serverSettings.SniEnabled && this.sniSslStream == null)
+                    {
+                        throw new ArgumentException("SNI configuration is not valid");
+                    }
+
+                    if (!serverSettings.SniEnabled && this.sslStream == null)
+                    {
+                        throw new ArgumentException("SSL configuration is not valid");
+                    }
+
+                    var certficateSelector = ServerTlsSettings.DefaultCertficateSelectorKey;
+                    if (serverSettings.SniEnabled)
+                    {
+                        var serverNameIndicated = this.sniSslStream.GetServerName();
+                        certficateSelector = serverNameIndicated ?? certficateSelector;
+                    }
+
+                    this.sslStream.AuthenticateAsServerAsync(serverSettings.Certificates[certficateSelector], serverSettings.NegotiateClientCertificate, serverSettings.EnabledProtocols, serverSettings.CheckCertificateRevocation)
                         .ContinueWith(HandshakeCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);
                 }
                 else

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -513,7 +513,7 @@ namespace DotNetty.Handlers.Tls
                     {
                         var serverNameIndicated = this.sniSslStream.GetServerName();
                         certficateSelector = serverNameIndicated ?? certficateSelector;
-                    }
+                    } 
 
                     this.sslStream.AuthenticateAsServerAsync(serverSettings.Certificates[certficateSelector], serverSettings.NegotiateClientCertificate, serverSettings.EnabledProtocols, serverSettings.CheckCertificateRevocation)
                         .ContinueWith(HandshakeCompletionCallback, this, TaskContinuationOptions.ExecuteSynchronously);


### PR DESCRIPTION
This is to add support for SNI extension in TLS. Right now, there is no clean solution in C# due to the lack of support in SslStream. So, one way is to add a peek stream logic to read the ClientHello for server name extension.

N.B. Credit goes to http://stackoverflow.com/questions/2196767/c-implementing-networkstream-peek/7281113#7281113 for the PeekableStream class