### PR TITLE
Do some better log for debug

### DIFF
--- a/src/DotNetty.Common/Internal/MacAddressUtil.cs
+++ b/src/DotNetty.Common/Internal/MacAddressUtil.cs
@@ -124,7 +124,7 @@ namespace DotNetty.Common.Internal
             StringBuilder buf = new StringBuilder(24);
             foreach (byte b in addr)
             {
-                buf.Append((b & 0xFF).ToString("X2\\:"));
+                buf.Append((b & 0xFF).ToString("X2")).Append(":");
             }
             return buf.ToString(0, buf.Length - 1);
         }

--- a/src/DotNetty.Transport/Bootstrapping/AbstractBootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/AbstractBootstrap.cs
@@ -329,6 +329,37 @@ namespace DotNetty.Transport.Bootstrapping
 
         protected ICollection<AttributeValue> Attributes => this.attrs.Values;
 
+        protected static void SetChannelOptions(IChannel channel, ICollection<ChannelOptionValue> options, IInternalLogger logger)
+        {
+            foreach (var e in options)
+            {
+                SetChannelOption(channel, e, logger);
+            }
+        }
+
+        protected static void SetChannelOptions(IChannel channel, ChannelOptionValue[] options, IInternalLogger logger)
+        {
+            foreach (var e in options)
+            {
+                SetChannelOption(channel, e, logger);
+            }
+        }
+
+        protected static void SetChannelOption(IChannel channel, ChannelOptionValue option, IInternalLogger logger)
+        {
+            try
+            {
+                if (!option.Set(channel.Configuration))
+                {
+                    logger.Warn("Unknown channel option '{}' for channel '{}'", option.Option, channel);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.Warn("Failed to set channel option '{}' with value '{}' for channel '{}'", option.Option, option, channel, ex);
+            }
+        }
+
         public override string ToString()
         {
             StringBuilder buf = new StringBuilder()
@@ -413,21 +444,22 @@ namespace DotNetty.Transport.Bootstrapping
 
         protected abstract class ChannelOptionValue
         {
+            public abstract ChannelOption Option { get; }
             public abstract bool Set(IChannelConfiguration config);
         }
 
         protected sealed class ChannelOptionValue<T> : ChannelOptionValue
         {
-            readonly ChannelOption<T> option;
+            public override ChannelOption Option { get; }
             readonly T value;
 
             public ChannelOptionValue(ChannelOption<T> option, T value)
             {
-                this.option = option;
+                this.Option = option;
                 this.value = value;
             }
 
-            public override bool Set(IChannelConfiguration config) => config.SetOption(this.option, this.value);
+            public override bool Set(IChannelConfiguration config) => config.SetOption(this.Option, this.value);
 
             public override string ToString() => this.value.ToString();
         }

--- a/src/DotNetty.Transport/Bootstrapping/Bootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/Bootstrap.cs
@@ -198,20 +198,7 @@ namespace DotNetty.Transport.Bootstrapping
             p.AddLast(null, (string)null, this.Handler());
 
             ICollection<ChannelOptionValue> options = this.Options;
-            foreach (ChannelOptionValue e in options)
-            {
-                try
-                {
-                    if (!e.Set(channel.Configuration))
-                    {
-                        Logger.Warn("Unknown channel option: " + e);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warn("Failed to set a channel option: " + channel, ex);
-                }
-            }
+            SetChannelOptions(channel, options, Logger);
 
             ICollection<AttributeValue> attrs = this.Attributes;
             foreach (AttributeValue e in attrs)

--- a/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
+++ b/src/DotNetty.Transport/Bootstrapping/ServerBootstrap.cs
@@ -124,20 +124,7 @@ namespace DotNetty.Transport.Bootstrapping
 
         protected override void Init(IChannel channel)
         {
-            foreach (ChannelOptionValue e in this.Options)
-            {
-                try
-                {
-                    if (!e.Set(channel.Configuration))
-                    {
-                        Logger.Warn("Unknown channel option: " + e);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Warn("Failed to set a channel option: " + channel, ex);
-                }
-            }
+            SetChannelOptions(channel, this.Options, Logger);
 
             foreach (AttributeValue e in this.Attributes)
             {
@@ -201,20 +188,7 @@ namespace DotNetty.Transport.Bootstrapping
 
                 child.Pipeline.AddLast((string)null, this.childHandler);
 
-                foreach (ChannelOptionValue option in this.childOptions)
-                {
-                    try
-                    {
-                        if (!option.Set(child.Configuration))
-                        {
-                            Logger.Warn("Unknown channel option: " + option);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Warn("Failed to set a channel option: " + child, ex);
-                    }
-                }
+                SetChannelOptions(child, this.childOptions, Logger);
 
                 foreach (AttributeValue attr in this.childAttrs)
                 {

--- a/src/DotNetty.Transport/Channels/DefaultChannelId.cs
+++ b/src/DotNetty.Transport/Channels/DefaultChannelId.cs
@@ -48,19 +48,23 @@ namespace DotNetty.Transport.Channels
                 {
                     processId = -1;
                 }
-            }
-            if (processId < 0 || processId > MaxProcessId)
-            {
-                processId = -1;
-                Logger.Warn("-Dio.netty.processId: {0} (malformed)", customProcessId);
-            }
-            else if (Logger.DebugEnabled)
-            {
-                Logger.Debug("-Dio.netty.processId: {0} (user-set)", processId);
+                if (processId < 0 || processId > MaxProcessId)
+                {
+                    processId = -1;
+                    Logger.Warn("-Dio.netty.processId: {} (malformed)", customProcessId);
+                }
+                else if (Logger.DebugEnabled)
+                {
+                    Logger.Debug("-Dio.netty.processId: {} (user-set)", processId);
+                }
             }
             if (processId < 0)
             {
                 processId = DefaultProcessId();
+                if (Logger.DebugEnabled)
+                {
+                    Logger.Debug("-Dio.netty.processId: {} (auto-detected)", processId);
+                }
             }
             ProcessId = processId;
             byte[] machineId = null;


### PR DESCRIPTION
# Before: 
```
warn: DotNetty.Transport.Channels.DefaultChannelId[0]
      -Dio.netty.processId: {0} (malformed)
dbug: DotNetty.Transport.Channels.DefaultChannelId[0]
      -Dio.netty.machineId: X2:X2:X2:X2:X2:X2:X2:X2 (auto-detected)
...
warn: DotNetty.Transport.Bootstrapping.Bootstrap[0]
      Unknown channel option: 100
```

# After:
```
dbug: DotNetty.Transport.Channels.DefaultChannelId[0]
      -Dio.netty.processId: 3959148 (auto-detected)
dbug: DotNetty.Transport.Channels.DefaultChannelId[0]
      -Dio.netty.machineId: 00:00:00:00:00:00:00:E0 (auto-detected)
...
warn: DotNetty.Transport.Bootstrapping.ServerBootstrap[0]
      Unknown channel option 'SO_BACKLOG' for channel '[id: 0x74d9a761]'
```

# Note: 

The machineId is always `00:00:00:00:00:00:00:E0`(the MAC of Teredo Tunneling Pseudo-Interface), and it's the same as the behavior of the current version netty, which is already tracking as netty/netty#5522.