### PR TITLE
Updated error message in SNI handler and little clean up in handler project

### DIFF
--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -32,14 +32,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Net.Security" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
+    <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Globalization.Extensions">
-      <Version>4.3.0</Version>
-    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Handlers/Tls/SniHandler.cs
+++ b/src/DotNetty.Handlers/Tls/SniHandler.cs
@@ -17,7 +17,7 @@ namespace DotNetty.Handlers.Tls
 
     public sealed class SniHandler : ByteToMessageDecoder
     {
-        // Maximal number of ssl records to inspect before fallback to the default (aligned with netty) 
+        // Maximal number of ssl records to inspect before fallback to the default server TLS setting (aligned with netty) 
         const int MAX_SSL_RECORDS = 4;
         static readonly IInternalLogger Logger = InternalLoggerFactory.GetInstance(typeof(SniHandler));
         readonly Func<Stream, SslStream> sslStreamFactory;
@@ -257,13 +257,13 @@ namespace DotNetty.Handlers.Tls
 
                 if (this.serverTlsSniSettings.DefaultServerHostName != null)
                 {
-                    // Just select the default certifcate
+                    // Just select the default server TLS setting
                     this.Select(context, this.serverTlsSniSettings.DefaultServerHostName); 
                 }
                 else
                 {
                     this.handshakeFailed = true;
-                    var e = new DecoderException($"failed to get the Tls Certificate {error}");
+                    var e = new DecoderException($"failed to get the server TLS setting {error}");
                     TlsUtils.NotifyHandshakeFailure(context, e);
                     throw e;
                 }
@@ -281,7 +281,7 @@ namespace DotNetty.Handlers.Tls
             }
             catch (Exception ex)
             {
-                this.ExceptionCaught(context, new DecoderException($"failed to get the Tls Certificate for {hostName}, {ex}"));
+                this.ExceptionCaught(context, new DecoderException($"failed to get the server TLS setting for {hostName}, {ex}"));
             }
             finally
             {


### PR DESCRIPTION
Since the SNI setting was refactored at the last minute in the commit https://github.com/Azure/DotNetty/pull/219/commits/eb3c3f92acfa00e68ac0ccfd091ab3a086e35ccd 
Forgot to update the error message
#219

And since 1 netstandard nuget reference was added in handler project VS added a new section automatically. But moved that new referenece in the already existing itemgroup