### PR TITLE
Porting HashedWheelTimer

### DIFF
--- a/src/DotNetty.Common/Concurrency/RejectedExecutionException.cs
+++ b/src/DotNetty.Common/Concurrency/RejectedExecutionException.cs
@@ -1,11 +1,19 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace DotNetty.Transport.Channels
+namespace DotNetty.Common.Concurrency
 {
     using System;
 
     public class RejectedExecutionException : Exception
     {
+        public RejectedExecutionException()
+        {
+        }
+
+        public RejectedExecutionException(string message)
+            : base(message)
+        {
+        }
     }
 }

--- a/src/DotNetty.Common/PreciseTimeSpan.cs
+++ b/src/DotNetty.Common/PreciseTimeSpan.cs
@@ -10,7 +10,7 @@ namespace DotNetty.Common
     {
         static readonly long StartTime = Stopwatch.GetTimestamp();
         static readonly double PrecisionRatio = (double)Stopwatch.Frequency / TimeSpan.TicksPerSecond;
-        static readonly double ReversePrecisionRatio = 1.0 / PrecisionRatio;
+        static readonly double ReversePrecisionRatio = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
 
         readonly long ticks;
 

--- a/src/DotNetty.Common/PreciseTimeSpan.cs
+++ b/src/DotNetty.Common/PreciseTimeSpan.cs
@@ -26,6 +26,8 @@ namespace DotNetty.Common
 
         public static readonly PreciseTimeSpan MinusOne = new PreciseTimeSpan(-1);
 
+        public static PreciseTimeSpan FromTicks(long ticks) => new PreciseTimeSpan(ticks);
+
         public static PreciseTimeSpan FromStart => new PreciseTimeSpan(GetTimeChangeSinceStart());
 
         public static PreciseTimeSpan FromTimeSpan(TimeSpan timeSpan) => new PreciseTimeSpan(TicksToPreciseTicks(timeSpan.Ticks));

--- a/src/DotNetty.Common/Utilities/ActionTimerTask.cs
+++ b/src/DotNetty.Common/Utilities/ActionTimerTask.cs
@@ -9,14 +9,8 @@ namespace DotNetty.Common.Utilities
     {
         readonly Action<ITimeout> action;
 
-        public ActionTimerTask(Action<ITimeout> action)
-        {
-            this.action = action;
-        }
+        public ActionTimerTask(Action<ITimeout> action) => this.action = action;
 
-        public void Run(ITimeout timeout)
-        {
-            this.action(timeout);
-        }
+        public void Run(ITimeout timeout) => this.action(timeout);
     }
 }

--- a/src/DotNetty.Common/Utilities/ActionTimerTask.cs
+++ b/src/DotNetty.Common/Utilities/ActionTimerTask.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    using System;
+
+    public class ActionTimerTask : ITimerTask
+    {
+        readonly Action<ITimeout> action;
+
+        public ActionTimerTask(Action<ITimeout> action)
+        {
+            this.action = action;
+        }
+
+        public void Run(ITimeout timeout)
+        {
+            this.action(timeout);
+        }
+    }
+}

--- a/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
+++ b/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
@@ -1,0 +1,705 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+#pragma warning disable 420
+
+namespace DotNetty.Common.Utilities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.Contracts;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DotNetty.Common.Concurrency;
+    using DotNetty.Common.Internal;
+    using DotNetty.Common.Internal.Logging;
+
+    public sealed class HashedWheelTimer : ITimer
+    {
+        static readonly IInternalLogger Logger =
+            InternalLoggerFactory.GetInstance<HashedWheelTimer>();
+
+        static int instanceCounter;
+        static int warnedTooManyInstances;
+
+        const int InstanceCountLimit = 64;
+
+        readonly Worker worker;
+        readonly XThread workerThread;
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        const int WorkerStateInit = 0;
+        const int WorkerStateStarted = 1;
+        const int WorkerStateShutdown = 2;
+        int workerStateVolatile = WorkerStateInit; // 0 - init, 1 - started, 2 - shut down
+
+        readonly long tickDuration;
+        readonly HashedWheelBucket[] wheel;
+        readonly int mask;
+        readonly CountdownEvent startTimeInitialized = new CountdownEvent(1);
+        readonly IQueue<HashedWheelTimeout> timeouts = PlatformDependent.NewMpscQueue<HashedWheelTimeout>();
+        readonly IQueue<HashedWheelTimeout> cancelledTimeouts = PlatformDependent.NewMpscQueue<HashedWheelTimeout>();
+        internal long PendingTimeouts;
+        readonly long maxPendingTimeouts;
+        long startTimeVolatile;
+
+        public HashedWheelTimer()
+            : this(TimeSpan.FromMilliseconds(100), 512, -1)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new timer.
+        ///
+        /// </summary>
+        /// <param name="tickDuration">the duration between tick</param>
+        /// <param name="ticksPerWheel">the size of the wheel</param>
+        /// <param name=" maxPendingTimeouts">The maximum number of pending timeouts after which call to
+        /// <c>newTimeout</c> will result in <see cref="RejectedExecutionException"/> being thrown.
+        /// No maximum pending timeouts limit is assumed if this value is 0 or negative.</param>
+        /// <exception cref="ArgumentException">if either of <c>tickDuration</c> and <c>ticksPerWheel</c> is &lt;= 0</exception>
+        public HashedWheelTimer(
+            TimeSpan tickDuration,
+            int ticksPerWheel,
+            long maxPendingTimeouts)
+        {
+            if (tickDuration <= TimeSpan.Zero)
+            {
+                throw new ArgumentException("tickDuration must be greater than 0: " + tickDuration);
+            }
+            if (ticksPerWheel <= 0)
+            {
+                throw new ArgumentException("ticksPerWheel must be greater than 0: " + ticksPerWheel);
+            }
+
+            // Normalize ticksPerWheel to power of two and initialize the wheel.
+            this.wheel = CreateWheel(ticksPerWheel);
+            this.worker = new Worker(this);
+            this.mask = this.wheel.Length - 1;
+
+            // Convert tickDuration to nanos.
+            this.tickDuration = PreciseTimeSpan.FromTimeSpan(tickDuration).Ticks;
+
+            // Prevent overflow
+            if (this.tickDuration >= long.MaxValue / this.wheel.Length)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        "tickDuration: {0} (expected: 0 < tickDuration in nanos < {1}",
+                        tickDuration,
+                        long.MaxValue / this.wheel.Length));
+            }
+            this.workerThread = new XThread(st => this.worker.Run());
+
+            this.maxPendingTimeouts = maxPendingTimeouts;
+
+            if (Interlocked.Increment(ref instanceCounter) > InstanceCountLimit &&
+                Interlocked.CompareExchange(ref warnedTooManyInstances, 1, 0) == 0)
+            {
+                ReportTooManyInstances();
+            }
+        }
+
+        ~HashedWheelTimer()
+        {
+            // This object is going to be GCed and it is assumed the ship has sailed to do a proper shutdown. If
+            // we have not yet shutdown then we want to make sure we decrement the active instance count.
+            if (Interlocked.Exchange(ref this.workerStateVolatile, WorkerStateShutdown) != WorkerStateShutdown)
+            {
+                Interlocked.Decrement(ref instanceCounter);
+            }
+        }
+
+        internal CancellationToken CancellationToken => this.cancellationTokenSource.Token;
+
+        PreciseTimeSpan StartTime
+        {
+            get { return PreciseTimeSpan.FromTicks(Volatile.Read(ref this.startTimeVolatile)); }
+            set { Volatile.Write(ref this.startTimeVolatile, value.Ticks); }
+        }
+
+        static HashedWheelBucket[] CreateWheel(int ticksPerWheel)
+        {
+            if (ticksPerWheel <= 0)
+            {
+                throw new ArgumentException(
+                    "ticksPerWheel must be greater than 0: " + ticksPerWheel);
+            }
+            if (ticksPerWheel > 1073741824)
+            {
+                throw new ArgumentException(
+                    "ticksPerWheel may not be greater than 2^30: " + ticksPerWheel);
+            }
+
+            ticksPerWheel = NormalizeTicksPerWheel(ticksPerWheel);
+            var wheel = new HashedWheelBucket[ticksPerWheel];
+            for (int i = 0; i < wheel.Length; i++)
+            {
+                wheel[i] = new HashedWheelBucket();
+            }
+            return wheel;
+        }
+
+        static int NormalizeTicksPerWheel(int ticksPerWheel)
+        {
+            int normalizedTicksPerWheel = 1;
+            while (normalizedTicksPerWheel < ticksPerWheel)
+            {
+                normalizedTicksPerWheel <<= 1;
+            }
+            return normalizedTicksPerWheel;
+        }
+
+        /// <summary>
+        /// Starts the background thread explicitly. The background thread will
+        /// start automatically on demand even if you did not call this method.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">if this timer has been
+        /// stopped already.</exception>
+        public void Start()
+        {
+            switch (Volatile.Read(ref this.workerStateVolatile))
+            {
+                case WorkerStateInit:
+                    if (Interlocked.CompareExchange(ref this.workerStateVolatile, WorkerStateStarted, WorkerStateInit) == WorkerStateInit)
+                    {
+                        this.workerThread.Start();
+                    }
+                    break;
+                case WorkerStateStarted:
+                    break;
+                case WorkerStateShutdown:
+                    throw new InvalidOperationException("cannot be started once stopped");
+                default:
+                    throw new InvalidOperationException("Invalid WorkerState");
+            }
+
+            // Wait until the startTime is initialized by the worker.
+            while (this.StartTime == PreciseTimeSpan.Zero)
+            {
+                this.startTimeInitialized.Wait(this.CancellationToken);
+            }
+        }
+
+        public ISet<ITimeout> Stop()
+        {
+            if (XThread.CurrentThread == this.workerThread)
+            {
+                throw new InvalidOperationException($"{nameof(HashedWheelTimer)}.stop() cannot be called from timer task.");
+            }
+
+            if (Interlocked.CompareExchange(ref this.workerStateVolatile, WorkerStateShutdown, WorkerStateStarted) != WorkerStateStarted)
+            {
+                // workerState can be 0 or 2 at this moment - let it always be 2.
+                if (Interlocked.Exchange(ref this.workerStateVolatile, WorkerStateShutdown) != WorkerStateShutdown)
+                {
+                    Interlocked.Decrement(ref instanceCounter);
+                }
+
+                return new HashSet<ITimeout>();
+            }
+
+            try
+            {
+                this.cancellationTokenSource.Cancel();
+                this.workerThread.Join(100);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref instanceCounter);
+            }
+            return this.worker.UnprocessedTimeouts();
+        }
+
+        public ITimeout NewTimeout(ITimerTask task, TimeSpan delay)
+        {
+            if (task == null)
+            {
+                throw new ArgumentNullException(nameof(task));
+            }
+            if (this.ShouldLimitTimeouts())
+            {
+                long pendingTimeoutsCount = Interlocked.Increment(ref this.PendingTimeouts);
+                if (pendingTimeoutsCount > this.maxPendingTimeouts)
+                {
+                    Interlocked.Decrement(ref this.PendingTimeouts);
+                    throw new RejectedExecutionException($"Number of pending timeouts ({pendingTimeoutsCount}) is greater than or equal to maximum allowed pending timeouts ({this.maxPendingTimeouts})");
+                }
+            }
+
+            this.Start();
+
+            // Add the timeout to the timeout queue which will be processed on the next tick.
+            // During processing all the queued HashedWheelTimeouts will be added to the correct HashedWheelBucket.
+            PreciseTimeSpan deadline = PreciseTimeSpan.Deadline(delay) - this.StartTime;
+            var timeout = new HashedWheelTimeout(this, task, deadline);
+            this.timeouts.TryEnqueue(timeout);
+            return timeout;
+        }
+
+        bool ShouldLimitTimeouts()
+        {
+            return this.maxPendingTimeouts > 0;
+        }
+
+        static void ReportTooManyInstances() =>
+            Logger.Error($"You are creating too many {nameof(HashedWheelTimer)} instances. {nameof(HashedWheelTimer)} is a shared resource that must be reused across the process,so that only a few instances are created.");
+
+        sealed class Worker : IRunnable
+        {
+            readonly HashedWheelTimer owner;
+            readonly ISet<ITimeout> unprocessedTimeouts = new HashSet<ITimeout>();
+
+            long tick;
+
+            public Worker(HashedWheelTimer owner)
+            {
+                this.owner = owner;
+            }
+
+            public void Run()
+            {
+                try
+                {
+                    // Initialize the startTime.
+                    this.owner.StartTime = PreciseTimeSpan.FromStart;
+                    if (this.owner.StartTime == PreciseTimeSpan.Zero)
+                    {
+                        // We use 0 as an indicator for the uninitialized value here, so make sure it's not 0 when initialized.
+                        this.owner.StartTime = PreciseTimeSpan.FromTicks(1);
+                    }
+
+                    // Notify the other threads waiting for the initialization at start().
+                    this.owner.startTimeInitialized.Signal();
+
+                    do
+                    {
+                        PreciseTimeSpan deadline = this.WaitForNextTick();
+                        if (deadline > PreciseTimeSpan.Zero)
+                        {
+                            int idx = (int)(this.tick & this.owner.mask);
+                            this.ProcessCancelledTasks();
+                            HashedWheelBucket bucket = this.owner.wheel[idx];
+                            this.TransferTimeoutsToBuckets();
+                            bucket.ExpireTimeouts(deadline);
+                            this.tick++;
+                        }
+                    }
+                    while (Volatile.Read(ref this.owner.workerStateVolatile) == WorkerStateStarted);
+
+                    // Fill the unprocessedTimeouts so we can return them from stop() method.
+                    foreach (HashedWheelBucket bucket in this.owner.wheel)
+                    {
+                        bucket.ClearTimeouts(this.unprocessedTimeouts);
+                    }
+                    while (true)
+                    {
+                        HashedWheelTimeout timeout;
+                        if (!this.owner.timeouts.TryDequeue(out timeout))
+                        {
+                            break;
+                        }
+                        if (!timeout.Cancelled)
+                        {
+                            this.unprocessedTimeouts.Add(timeout);
+                        }
+                    }
+                    this.ProcessCancelledTasks();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error("", ex);
+                }
+            }
+
+            void TransferTimeoutsToBuckets()
+            {
+                // transfer only max. 100000 timeouts per tick to prevent a thread to stale the workerThread when it just
+                // adds new timeouts in a loop.
+                for (int i = 0; i < 100000; i++)
+                {
+                    HashedWheelTimeout timeout;
+                    if (!this.owner.timeouts.TryDequeue(out timeout))
+                    {
+                        // all processed
+                        break;
+                    }
+                    if (timeout.State == HashedWheelTimeout.StCancelled)
+                    {
+                        // Was cancelled in the meantime.
+                        continue;
+                    }
+
+                    long calculated = timeout.Deadline.Ticks / this.owner.tickDuration;
+                    timeout.RemainingRounds = (calculated - this.tick) / this.owner.wheel.Length;
+
+                    long ticks = Math.Max(calculated, this.tick); // Ensure we don't schedule for past.
+                    int stopIndex = (int)(ticks & this.owner.mask);
+
+                    HashedWheelBucket bucket = this.owner.wheel[stopIndex];
+                    bucket.AddTimeout(timeout);
+                }
+            }
+
+            void ProcessCancelledTasks()
+            {
+                while (true)
+                {
+                    HashedWheelTimeout timeout;
+                    if (!this.owner.cancelledTimeouts.TryDequeue(out timeout))
+                    {
+                        // all processed
+                        break;
+                    }
+                    try
+                    {
+                        timeout.Remove();
+                    }
+                    catch (Exception ex)
+                    {
+                        if (Logger.WarnEnabled)
+                        {
+                            Logger.Warn("An exception was thrown while processing a cancellation task", ex);
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// calculate timer firing time from startTime and current tick number,
+            /// then wait until that goal has been reached.
+            /// </summary>
+            /// <returns>long.MinValue if received a shutdown request,
+            /// current time otherwise (with long.MinValue changed by +1)
+            /// </returns>
+            PreciseTimeSpan WaitForNextTick()
+            {
+                long deadline = this.owner.tickDuration * (this.tick + 1);
+
+                while (true)
+                {
+                    PreciseTimeSpan currentTime = PreciseTimeSpan.FromStart - this.owner.StartTime;
+                    TimeSpan sleepTime = PreciseTimeSpan.FromTicks(deadline - currentTime.Ticks + (Stopwatch.Frequency / 1000 - 1)).ToTimeSpan();
+
+                    if (sleepTime <= TimeSpan.Zero)
+                    {
+                        if (currentTime.Ticks == long.MinValue)
+                        {
+                            return PreciseTimeSpan.FromTicks(-long.MaxValue);
+                        }
+                        else
+                        {
+                            return currentTime;
+                        }
+                    }
+
+                    Task delay = null;
+                    try
+                    {
+                        delay = Task.Delay(sleepTime, this.owner.CancellationToken);
+                        delay.Wait();
+                    }
+                    catch (AggregateException) when (delay != null && delay.IsCanceled)
+                    {
+                        if (Volatile.Read(ref this.owner.workerStateVolatile) == WorkerStateShutdown)
+                        {
+                            return PreciseTimeSpan.FromTicks(long.MinValue);
+                        }
+                    }
+                }
+            }
+
+            internal ISet<ITimeout> UnprocessedTimeouts() => this.unprocessedTimeouts;
+        }
+
+        sealed class HashedWheelTimeout : ITimeout
+        {
+            const int StInit = 0;
+            internal const int StCancelled = 1;
+            const int StExpired = 2;
+
+            internal readonly HashedWheelTimer timer;
+            internal readonly PreciseTimeSpan Deadline;
+
+            volatile int state = StInit;
+
+            // remainingRounds will be calculated and set by Worker.transferTimeoutsToBuckets() before the
+            // HashedWheelTimeout will be added to the correct HashedWheelBucket.
+            internal long RemainingRounds;
+
+            // This will be used to chain timeouts in HashedWheelTimerBucket via a double-linked-list.
+            // As only the workerThread will act on it there is no need for synchronization / volatile.
+            internal HashedWheelTimeout Next;
+
+            internal HashedWheelTimeout Prev;
+
+            // The bucket to which the timeout was added
+            internal HashedWheelBucket Bucket;
+
+            internal HashedWheelTimeout(HashedWheelTimer timer, ITimerTask task, PreciseTimeSpan deadline)
+            {
+                this.timer = timer;
+                this.Task = task;
+                this.Deadline = deadline;
+            }
+
+            public ITimer Timer => this.timer;
+
+            public ITimerTask Task { get; }
+
+            public bool Cancel()
+            {
+                // only update the state it will be removed from HashedWheelBucket on next tick.
+                if (!this.CompareAndSetState(StInit, StCancelled))
+                {
+                    return false;
+                }
+                // If a task should be canceled we put this to another queue which will be processed on each tick.
+                // So this means that we will have a GC latency of max. 1 tick duration which is good enough. This way
+                // we can make again use of our MpscLinkedQueue and so minimize the locking / overhead as much as possible.
+                this.timer.cancelledTimeouts.TryEnqueue(this);
+                return true;
+            }
+
+            internal void Remove()
+            {
+                HashedWheelBucket bucket = this.Bucket;
+                if (bucket != null)
+                {
+                    bucket.Remove(this);
+                }
+                else if (this.timer.ShouldLimitTimeouts())
+                {
+                    Interlocked.Decrement(ref this.timer.PendingTimeouts);
+                }
+            }
+
+            bool CompareAndSetState(int expected, int state)
+            {
+                return Interlocked.CompareExchange(ref this.state, state, expected) == expected;
+            }
+
+            internal int State => this.state;
+
+            public bool Cancelled => this.State == StCancelled;
+
+            public bool Expired => this.State == StExpired;
+
+            internal void Expire()
+            {
+                if (!this.CompareAndSetState(StInit, StExpired))
+                {
+                    return;
+                }
+
+                try
+                {
+                    this.Task.Run(this);
+                }
+                catch (Exception t)
+                {
+                    if (Logger.WarnEnabled)
+                    {
+                        Logger.Warn($"An exception was thrown by {this.Task.GetType().Name}.", t);
+                    }
+                }
+            }
+
+            public override string ToString()
+            {
+                PreciseTimeSpan currentTime = PreciseTimeSpan.FromStart;
+                PreciseTimeSpan remaining = this.Deadline - currentTime;
+
+                StringBuilder buf = new StringBuilder(192)
+                    .Append(this.GetType().Name)
+                    .Append('(')
+                    .Append("deadline: ");
+                if (remaining > PreciseTimeSpan.Zero)
+                {
+                    buf.Append(remaining.ToTimeSpan())
+                        .Append(" later");
+                }
+                else if (remaining < PreciseTimeSpan.Zero)
+                {
+                    buf.Append(-remaining.ToTimeSpan())
+                        .Append(" ago");
+                }
+                else
+                {
+                    buf.Append("now");
+                }
+
+                if (this.Cancelled)
+                {
+                    buf.Append(", cancelled");
+                }
+
+                return buf.Append(", task: ")
+                    .Append(this.Task)
+                    .Append(')')
+                    .ToString();
+            }
+        }
+
+        /// <summary>
+        /// Bucket that stores HashedWheelTimeouts. These are stored in a linked-list like datastructure to allow easy
+        /// removal of HashedWheelTimeouts in the middle. Also the HashedWheelTimeout act as nodes themself and so no
+        /// extra object creation is needed.
+        /// </summary>
+        sealed class HashedWheelBucket
+        {
+            // Used for the linked-list datastructure
+            HashedWheelTimeout head;
+            HashedWheelTimeout tail;
+
+            /// <summary>
+            /// Add {@link HashedWheelTimeout} to this bucket.
+            /// </summary>
+            public void AddTimeout(HashedWheelTimeout timeout)
+            {
+                Contract.Assert(timeout.Bucket == null);
+                timeout.Bucket = this;
+                if (this.head == null)
+                {
+                    this.head = this.tail = timeout;
+                }
+                else
+                {
+                    this.tail.Next = timeout;
+                    timeout.Prev = this.tail;
+                    this.tail = timeout;
+                }
+            }
+
+            /// <summary>
+            /// Expire all <see cref="HashedWheelTimeout"/>s for the given <c>deadline</c>.
+            /// </summary>
+            public void ExpireTimeouts(PreciseTimeSpan deadline)
+            {
+                HashedWheelTimeout timeout = this.head;
+
+                // process all timeouts
+                while (timeout != null)
+                {
+                    HashedWheelTimeout next = timeout.Next;
+                    if (timeout.RemainingRounds <= 0)
+                    {
+                        next = this.Remove(timeout);
+                        if (timeout.Deadline <= deadline)
+                        {
+                            timeout.Expire();
+                        }
+                        else
+                        {
+                            // The timeout was placed into a wrong slot. This should never happen.
+                            throw new InvalidOperationException(
+                                string.Format(
+                                    "timeout.deadline (%d) > deadline (%d)",
+                                    timeout.Deadline,
+                                    deadline));
+                        }
+                    }
+                    else if (timeout.Cancelled)
+                    {
+                        next = this.Remove(timeout);
+                    }
+                    else
+                    {
+                        timeout.RemainingRounds--;
+                    }
+                    timeout = next;
+                }
+            }
+
+            public HashedWheelTimeout Remove(HashedWheelTimeout timeout)
+            {
+                HashedWheelTimeout next = timeout.Next;
+                // remove timeout that was either processed or cancelled by updating the linked-list
+                if (timeout.Prev != null)
+                {
+                    timeout.Prev.Next = next;
+                }
+                if (timeout.Next != null)
+                {
+                    timeout.Next.Prev = timeout.Prev;
+                }
+
+                if (timeout == this.head)
+                {
+                    // if timeout is also the tail we need to adjust the entry too
+                    if (timeout == this.tail)
+                    {
+                        this.tail = null;
+                        this.head = null;
+                    }
+                    else
+                    {
+                        this.head = next;
+                    }
+                }
+                else if (timeout == this.tail)
+                {
+                    // if the timeout is the tail modify the tail to be the prev node.
+                    this.tail = timeout.Prev;
+                }
+                // null out prev, next and bucket to allow for GC.
+                timeout.Prev = null;
+                timeout.Next = null;
+                timeout.Bucket = null;
+                if (timeout.timer.ShouldLimitTimeouts())
+                {
+                    Interlocked.Decrement(ref timeout.timer.PendingTimeouts);
+                }
+                return next;
+            }
+
+            /// <summary>
+            /// Clear this bucket and return all not expired / cancelled <see cref="ITimeout"/>s.
+            /// </summary>
+            public void ClearTimeouts(ISet<ITimeout> set)
+            {
+                while (true)
+                {
+                    HashedWheelTimeout timeout = this.PollTimeout();
+                    if (timeout == null)
+                    {
+                        return;
+                    }
+                    if (timeout.Expired || timeout.Cancelled)
+                    {
+                        continue;
+                    }
+                    set.Add(timeout);
+                }
+            }
+
+            HashedWheelTimeout PollTimeout()
+            {
+                HashedWheelTimeout head = this.head;
+                if (head == null)
+                {
+                    return null;
+                }
+                HashedWheelTimeout next = head.Next;
+                if (next == null)
+                {
+                    this.tail = this.head = null;
+                }
+                else
+                {
+                    this.head = next;
+                    next.Prev = null;
+                }
+
+                // null out prev and next to allow for GC.
+                head.Next = null;
+                head.Prev = null;
+                head.Bucket = null;
+                return head;
+            }
+        }
+    }
+}

--- a/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
+++ b/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
@@ -307,7 +307,7 @@ namespace DotNetty.Common.Utilities
                         {
                             break;
                         }
-                        if (!timeout.Cancelled)
+                        if (!timeout.Canceled)
                         {
                             this.unprocessedTimeouts.Add(timeout);
                         }
@@ -332,7 +332,7 @@ namespace DotNetty.Common.Utilities
                         // all processed
                         break;
                     }
-                    if (timeout.State == HashedWheelTimeout.StCancelled)
+                    if (timeout.State == HashedWheelTimeout.StCanceled)
                     {
                         // Was cancelled in the meantime.
                         continue;
@@ -425,7 +425,7 @@ namespace DotNetty.Common.Utilities
         sealed class HashedWheelTimeout : ITimeout
         {
             const int StInit = 0;
-            internal const int StCancelled = 1;
+            internal const int StCanceled = 1;
             const int StExpired = 2;
 
             internal readonly HashedWheelTimer timer;
@@ -460,7 +460,7 @@ namespace DotNetty.Common.Utilities
             public bool Cancel()
             {
                 // only update the state it will be removed from HashedWheelBucket on next tick.
-                if (!this.CompareAndSetState(StInit, StCancelled))
+                if (!this.CompareAndSetState(StInit, StCanceled))
                 {
                     return false;
                 }
@@ -491,7 +491,7 @@ namespace DotNetty.Common.Utilities
 
             internal int State => this.state;
 
-            public bool Cancelled => this.State == StCancelled;
+            public bool Canceled => this.State == StCanceled;
 
             public bool Expired => this.State == StExpired;
 
@@ -539,7 +539,7 @@ namespace DotNetty.Common.Utilities
                     buf.Append("now");
                 }
 
-                if (this.Cancelled)
+                if (this.Canceled)
                 {
                     buf.Append(", cancelled");
                 }
@@ -609,7 +609,7 @@ namespace DotNetty.Common.Utilities
                                     deadline));
                         }
                     }
-                    else if (timeout.Cancelled)
+                    else if (timeout.Canceled)
                     {
                         next = this.Remove(timeout);
                     }
@@ -675,7 +675,7 @@ namespace DotNetty.Common.Utilities
                     {
                         return;
                     }
-                    if (timeout.Expired || timeout.Cancelled)
+                    if (timeout.Expired || timeout.Canceled)
                     {
                         continue;
                     }

--- a/src/DotNetty.Common/Utilities/ITimeout.cs
+++ b/src/DotNetty.Common/Utilities/ITimeout.cs
@@ -27,13 +27,13 @@ namespace DotNetty.Common.Utilities
 
         /// <summary>
         /// Returns <c>true</c> if and only if the <see cref="ITimerTask"/> associated
-        /// with this handle has been cancelled.
+        /// with this handle has been canceled.
         /// </summary>
-        bool Cancelled { get; }
+        bool Canceled { get; }
 
         /// <summary>
         /// Attempts to cancel the <see cref="ITimerTask"/> associated with this handle.
-        /// If the task has been executed or cancelled already, it will return with
+        /// If the task has been executed or canceled already, it will return with
         /// no side effect.
         ///
         /// @return True if the cancellation completed successfully, otherwise false

--- a/src/DotNetty.Common/Utilities/ITimeout.cs
+++ b/src/DotNetty.Common/Utilities/ITimeout.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    /// <summary>
+    /// A handle associated with a <see cref="ITimerTask"/> that is returned by a
+    /// <see cref="ITimer"/>.
+    /// </summary>
+    public interface ITimeout
+    {
+        /// <summary>
+        /// Returns the <see cref="ITimer"/> that created this handle.
+        /// </summary>
+        ITimer Timer { get; }
+
+        /// <summary>
+        /// Returns the <see cref="ITimerTask"/> which is associated with this handle.
+        /// </summary>
+        ITimerTask Task { get; }
+
+        /// <summary>
+        /// Returns {@code true} if and only if the <see cref="ITimerTask"/> associated
+        /// with this handle has been expired.
+        /// </summary>
+        bool Expired { get; }
+
+        /// <summary>
+        /// Returns <c>true</c> if and only if the <see cref="ITimerTask"/> associated
+        /// with this handle has been cancelled.
+        /// </summary>
+        bool Cancelled { get; }
+
+        /// <summary>
+        /// Attempts to cancel the <see cref="ITimerTask"/> associated with this handle.
+        /// If the task has been executed or cancelled already, it will return with
+        /// no side effect.
+        ///
+        /// @return True if the cancellation completed successfully, otherwise false
+        /// </summary>
+        bool Cancel();
+    }
+}

--- a/src/DotNetty.Common/Utilities/ITimer.cs
+++ b/src/DotNetty.Common/Utilities/ITimer.cs
@@ -5,6 +5,7 @@ namespace DotNetty.Common.Utilities
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using DotNetty.Common.Concurrency;
 
     /// <summary>
@@ -28,6 +29,6 @@ namespace DotNetty.Common.Utilities
         /// </summary>
         /// <returns>the handles associated with the tasks which were canceled by
         /// this method</returns>
-        ISet<ITimeout> Stop();
+        Task<ISet<ITimeout>> StopAsync();
     }
 }

--- a/src/DotNetty.Common/Utilities/ITimer.cs
+++ b/src/DotNetty.Common/Utilities/ITimer.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    using System;
+    using System.Collections.Generic;
+    using DotNetty.Common.Concurrency;
+
+    /// <summary>
+    /// Schedules <see cref="ITimerTask"/>s for one-time future execution in a background
+    /// thread.
+    /// </summary>
+    public interface ITimer
+    {
+        /// <summary>
+        /// Schedules the specified <see cref="ITimerTask"/> for one-time execution after the specified delay.
+        /// </summary>
+        /// <returns>a handle which is associated with the specified task</returns>
+        /// <exception cref="InvalidOperationException">if this timer has been stopped already</exception>
+        /// <exception cref="RejectedExecutionException">if the pending timeouts are too many and creating new timeout
+        /// can cause instability in the system.</exception>
+        ITimeout NewTimeout(ITimerTask task, TimeSpan delay);
+
+        /// <summary>
+        /// Releases all resources acquired by this {@link Timer} and cancels all
+        /// tasks which were scheduled but not executed yet.
+        /// </summary>
+        /// <returns>the handles associated with the tasks which were canceled by
+        /// this method</returns>
+        ISet<ITimeout> Stop();
+    }
+}

--- a/src/DotNetty.Common/Utilities/ITimerTask.cs
+++ b/src/DotNetty.Common/Utilities/ITimerTask.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    /// <summary>
+    /// A task which is executed after the delay specified with
+    /// <see cref="ITimer.NewTimeout"/>.
+    /// </summary>
+    public interface ITimerTask
+    {
+        /// <summary>
+        /// Executed after the delay specified with
+        /// <see cref="ITimer.NewTimeout"/>.
+        /// </summary>
+        /// <param name="timeout">a handle which is associated with this task</param>
+        void Run(ITimeout timeout);
+    }
+}

--- a/test/DotNetty.Common.Tests/Utilities/HashedWheelTimerTest.cs
+++ b/test/DotNetty.Common.Tests/Utilities/HashedWheelTimerTest.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Tests.Utilities
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using DotNetty.Common.Concurrency;
+    using DotNetty.Common.Utilities;
+    using Xunit;
+
+    public class HashedWheelTimerTest
+    {
+        [Fact]
+        public void TestScheduleTimeoutShouldNotRunBeforeDelay()
+        {
+            ITimer timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(100), 512, -1);
+            var barrier = new CountdownEvent(1);
+            ITimeout timeout = timer.NewTimeout(
+                new ActionTimerTask(
+                    t =>
+                    {
+                        Assert.True(false, "This should not have run");
+                        barrier.Signal();
+                    }),
+                TimeSpan.FromSeconds(10));
+            Assert.False(barrier.Wait(TimeSpan.FromSeconds(3)));
+            Assert.False(timeout.Expired, "timer should not expire");
+            timer.Stop();
+        }
+
+        [Fact]
+        public void TestScheduleTimeoutShouldRunAfterDelay()
+        {
+            ITimer timer = new HashedWheelTimer();
+            var barrier = new CountdownEvent(1);
+            ITimeout timeout = timer.NewTimeout(
+                new ActionTimerTask(
+                    t => { barrier.Signal(); }),
+                TimeSpan.FromSeconds(2));
+            Assert.True(barrier.Wait(TimeSpan.FromSeconds(3)));
+            Assert.True(timeout.Expired, "timer should expire");
+            timer.Stop();
+        }
+
+        [Fact] // (timeout = 3000)
+        public void TestStopTimer()
+        {
+            var latch = new CountdownEvent(3);
+            ITimer timerProcessed = new HashedWheelTimer();
+            for (int i = 0; i < 3; i++)
+            {
+                timerProcessed.NewTimeout(
+                    new ActionTimerTask(
+                        t => { latch.Signal(); }),
+                    TimeSpan.FromMilliseconds(1));
+            }
+
+            latch.Wait();
+            Assert.Equal(0, timerProcessed.Stop().Count); // "Number of unprocessed timeouts should be 0"
+
+            ITimer timerUnprocessed = new HashedWheelTimer();
+            for (int i = 0; i < 5; i++)
+            {
+                timerUnprocessed.NewTimeout(
+                    new ActionTimerTask(
+                        t => { }),
+                    TimeSpan.FromSeconds(5));
+            }
+            Thread.Sleep(1000); // sleep for a second
+            Assert.False(timerUnprocessed.Stop().Count == 0, "Number of unprocessed timeouts should be greater than 0");
+        }
+
+        [Fact] // (timeout = 3000)
+        public void TestTimerShouldThrowExceptionAfterShutdownForNewTimeouts()
+        {
+            var latch = new CountdownEvent(3);
+            ITimer timer = new HashedWheelTimer();
+            for (int i = 0; i < 3; i++)
+            {
+                timer.NewTimeout(
+                    new ActionTimerTask(
+                        t => { latch.Signal(); }),
+                    TimeSpan.FromMilliseconds(1));
+            }
+
+            latch.Wait(3000);
+            timer.Stop();
+
+            try
+            {
+                timer.NewTimeout(CreateNoOpTimerTask(), TimeSpan.FromMilliseconds(1));
+                Assert.True(false, "Expected exception didn't occur.");
+            }
+            catch (InvalidOperationException ignored)
+            {
+                // expected
+            }
+        }
+
+        [Fact] // (timeout = 5000)
+        public void TestTimerOverflowWheelLength()
+        {
+            var timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(32), 512, -1);
+            var latch = new CountdownEvent(3);
+
+            ActionTimerTask task = null;
+            task = new ActionTimerTask(
+                t =>
+                {
+                    timer.NewTimeout(task, TimeSpan.FromMilliseconds(100));
+                    latch.Signal();
+                });
+            timer.NewTimeout(task, TimeSpan.FromMilliseconds(100));
+
+            latch.Wait(5000);
+            Assert.False(timer.Stop().Count == 0);
+        }
+
+        [Fact]
+        public void TestExecutionOnTime()
+        {
+            int tickDuration = 200;
+            int timeout = 125;
+            int maxTimeout = 2 * (tickDuration + timeout);
+            var timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(tickDuration), 512, -1);
+            var queue = new BlockingCollection<PreciseTimeSpan>();
+
+            int scheduledTasks = 100000;
+            for (int i = 0; i < scheduledTasks; i++)
+            {
+                PreciseTimeSpan start = PreciseTimeSpan.FromStart;
+                timer.NewTimeout(
+                    new ActionTimerTask(
+                        t => { queue.Add(PreciseTimeSpan.FromStart - start); }),
+                    TimeSpan.FromMilliseconds(timeout));
+            }
+
+            for (int i = 0; i < scheduledTasks; i++)
+            {
+                double delay = queue.Take().ToTimeSpan().TotalMilliseconds;
+                Assert.True(delay >= timeout && delay < maxTimeout, "Timeout + " + scheduledTasks + " delay " + delay + " must be " + timeout + " < " + maxTimeout);
+            }
+
+            timer.Stop();
+        }
+
+        [Fact]
+        public void TestRejectedExecutionExceptionWhenTooManyTimeoutsAreAddedBackToBack()
+        {
+            var timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(100), 32, 2);
+            timer.NewTimeout(CreateNoOpTimerTask(), TimeSpan.FromSeconds(5));
+            timer.NewTimeout(CreateNoOpTimerTask(), TimeSpan.FromSeconds(5));
+            try
+            {
+                timer.NewTimeout(CreateNoOpTimerTask(), TimeSpan.FromMilliseconds(1));
+                Assert.True(false, "Timer allowed adding 3 timeouts when maxPendingTimeouts was 2");
+            }
+            catch (RejectedExecutionException e)
+            {
+                // Expected
+            }
+            finally
+            {
+                timer.Stop();
+            }
+        }
+
+        [Fact]
+        public void TestNewTimeoutShouldStopThrowingRejectedExecutionExceptionWhenExistingTimeoutIsCancelled()
+
+        {
+            int tickDurationMs = 100;
+            var timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(tickDurationMs), 32, 2);
+            timer.NewTimeout(CreateNoOpTimerTask(), TimeSpan.FromSeconds(5));
+            ITimeout timeoutToCancel = timer.NewTimeout(CreateNoOpTimerTask(), TimeSpan.FromSeconds(5));
+            Assert.True(timeoutToCancel.Cancel());
+
+            Thread.Sleep(tickDurationMs * 5);
+
+            var secondLatch = new CountdownEvent(1);
+            timer.NewTimeout(CreateCountdownEventTimerTask(secondLatch), TimeSpan.FromMilliseconds(90));
+
+            secondLatch.Wait();
+            timer.Stop();
+        }
+
+        [Fact] // (timeout = 3000)
+        public void TestNewTimeoutShouldStopThrowingRejectedExecutionExceptionWhenExistingTimeoutIsExecuted()
+
+        {
+            var latch = new CountdownEvent(1);
+            var timer = new HashedWheelTimer(TimeSpan.FromMilliseconds(25), 4, 2);
+            timer.NewTimeout(CreateNoOpTimerTask(), TimeSpan.FromSeconds(5));
+            timer.NewTimeout(CreateCountdownEventTimerTask(latch), TimeSpan.FromMilliseconds(90));
+
+            latch.Wait(3000);
+
+            var secondLatch = new CountdownEvent(1);
+            timer.NewTimeout(CreateCountdownEventTimerTask(secondLatch), TimeSpan.FromMilliseconds(90));
+
+            secondLatch.Wait(3000);
+            timer.Stop();
+        }
+
+        static ActionTimerTask CreateNoOpTimerTask() => new ActionTimerTask(t => { });
+
+        static ActionTimerTask CreateCountdownEventTimerTask(CountdownEvent latch) => new ActionTimerTask(t => { latch.Signal(); });
+    }
+}


### PR DESCRIPTION
Motivation:
It is a common task to manage various timeouts in networking code. Normal high precision timers usually trade performance for precision which is a flexible requirement with timeouts.

Modifications:
- added HashedWheelTimer
- moved RejectedExecutionException to Common.Concurrency

Result:
- users may choose to use HWT in their code to avoid contentions due to frequent timer management.