### PR TITLE
Implemented GetMedium, GetUnsignedMedium, ReadMedium, ReadUnsignedMedium, WriteMedium, SetMedium

### DIFF
--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -57,6 +57,7 @@ namespace DotNetty.Buffers
             {
                 throw new IndexOutOfRangeException($"ReaderIndex: {readerIndex} (expected: 0 <= readerIndex <= writerIndex({this.WriterIndex})");
             }
+
             this.ReaderIndex = readerIndex;
             return this;
         }
@@ -276,6 +277,19 @@ namespace DotNetty.Buffers
             }
         }
 
+        public virtual int GetMedium(int index)
+        {
+            this.CheckIndex(index, 3);
+            return this._GetMedium(index);
+        }
+
+        public virtual int GetUnsignedMedium(int index)
+        {
+            return this.GetMedium(index).ToUnsignedMediumInt();
+        }
+
+        protected abstract int _GetMedium(int index);
+
         public virtual int GetInt(int index)
         {
             this.CheckIndex(index, 4);
@@ -386,6 +400,15 @@ namespace DotNetty.Buffers
 
         protected abstract void _SetLong(int index, long value);
 
+        public virtual IByteBuffer SetMedium(int index, int value)
+        {
+            this.CheckIndex(index, 3);
+            this._SetMedium(index, value);
+            return this;
+        }
+
+        protected abstract void _SetMedium(int index, int value);
+
         public virtual IByteBuffer SetChar(int index, char value)
         {
             this.SetShort(index, value);
@@ -467,6 +490,17 @@ namespace DotNetty.Buffers
             return v;
         }
 
+        public virtual int ReadMedium()
+        {
+            this.CheckReadableBytes(3);
+            int v = this._GetMedium(this.ReaderIndex);
+            this.ReaderIndex += 3;
+            return v;
+        }
+        public virtual int ReadUnsignedMedium()
+        {
+            return this.ReadMedium().ToUnsignedMediumInt();
+        }
         public virtual uint ReadUnsignedInt()
         {
             unchecked
@@ -585,6 +619,21 @@ namespace DotNetty.Buffers
             {
                 this.WriteShort((short)value);
             }
+            return this;
+        }
+
+        public IByteBuffer WriteUnsignedMedium(int value)
+        {
+            this.WriteMedium(value.ToUnsignedMediumInt());
+            return this;
+        }
+
+        public virtual IByteBuffer WriteMedium(int value)
+        {
+            this.EnsureAccessible();
+            this.EnsureWritable(3);
+            this._SetMedium(this.WriterIndex, value);
+            this.WriterIndex += 3;
             return this;
         }
 

--- a/src/DotNetty.Buffers/AdvancedLeakAwareByteBuffer.cs
+++ b/src/DotNetty.Buffers/AdvancedLeakAwareByteBuffer.cs
@@ -117,6 +117,18 @@ namespace DotNetty.Buffers
             return base.GetByte(index);
         }
 
+        public override int GetMedium(int index)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.GetMedium(index);
+        }
+
+        public override int GetUnsignedMedium(int index)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.GetUnsignedMedium(index);
+        }
+
         public override short GetShort(int index)
         {
             this.RecordLeakNonRefCountingOperation();
@@ -212,6 +224,12 @@ namespace DotNetty.Buffers
         {
             this.RecordLeakNonRefCountingOperation();
             return base.SetByte(index, value);
+        }
+
+        public override IByteBuffer SetMedium(int index, int value)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.SetMedium(index, value);
         }
 
         public override IByteBuffer SetShort(int index, int value)
@@ -316,6 +334,18 @@ namespace DotNetty.Buffers
         {
             this.RecordLeakNonRefCountingOperation();
             return base.ReadUnsignedShort();
+        }
+
+        public override int ReadMedium()
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.ReadMedium();
+        }
+
+        public override int ReadUnsignedMedium()
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.ReadUnsignedMedium();
         }
 
         public override int ReadInt()
@@ -425,6 +455,12 @@ namespace DotNetty.Buffers
         {
             this.RecordLeakNonRefCountingOperation();
             return base.WriteInt(value);
+        }
+
+        public override IByteBuffer WriteMedium(int value)
+        {
+            this.RecordLeakNonRefCountingOperation();
+            return base.WriteMedium(value);
         }
 
         public override IByteBuffer WriteLong(long value)

--- a/src/DotNetty.Buffers/ByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/ByteBufferUtil.cs
@@ -383,6 +383,15 @@ namespace DotNetty.Buffers
         public static short SwapShort(short value) => (short)(((value & 0xFF) << 8) | (value >> 8) & 0xFF);
 
         /// <summary>
+        ///     Toggles the endianness of the specified 24-bit medium integer.
+        /// </summary>
+        public static int SwapMedium(int value)
+        {
+            int swapped = value << 16 & 0xff0000 | value & 0xff00 | value.RightUShift(16) & 0xff;
+            return swapped.ToMediumInt();
+        }
+
+        /// <summary>
         ///     Read the given amount of bytes into a new {@link ByteBuf} that is allocated from the {@link ByteBufAllocator}.
         /// </summary>
         public static IByteBuffer ReadBytes(IByteBufferAllocator alloc, IByteBuffer buffer, int length)

--- a/src/DotNetty.Buffers/CompositeByteBuffer.cs
+++ b/src/DotNetty.Buffers/CompositeByteBuffer.cs
@@ -702,6 +702,23 @@ namespace DotNetty.Buffers
             }
         }
 
+        protected override int _GetMedium(int index)
+        {
+            ComponentEntry c = this.FindComponent(index);
+            if (index + 3 <= c.EndOffset)
+            {
+                return c.Buffer.GetMedium(index - c.Offset);
+            }
+            else if (this.Order == ByteOrder.BigEndian)
+            {
+                return this._GetShort(index) << 8 | this._GetByte(index + 2);
+            }
+            else
+            {
+                return (ushort)this._GetShort(index) | (sbyte)this._GetByte(index + 2) << 16;
+            }
+        }
+
         protected override long _GetLong(int index)
         {
             ComponentEntry c = this.FindComponent(index);
@@ -815,6 +832,25 @@ namespace DotNetty.Buffers
             {
                 this._SetByte(index, (byte)value);
                 this._SetByte(index + 1, (byte)((uint)value >> 8));
+            }
+        }
+
+        protected override void _SetMedium(int index, int value)
+        {
+            ComponentEntry c = this.FindComponent(index);
+            if (index + 3 <= c.EndOffset)
+            {
+                c.Buffer.SetMedium(index - c.Offset, value);
+            }
+            else if (this.Order == ByteOrder.BigEndian)
+            {
+                this._SetShort(index, (short)(value >> 8));
+                this._SetByte(index + 2, (byte)value);
+            }
+            else
+            {
+                this._SetShort(index, (short)value);
+                this._SetByte(index + 2, (byte)(value.RightUShift(16)));
             }
         }
 

--- a/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
+++ b/src/DotNetty.Buffers/DuplicatedByteBuffer.cs
@@ -41,6 +41,10 @@ namespace DotNetty.Buffers
 
         protected override int _GetInt(int index) => this.buffer.GetInt(index);
 
+        public override int GetMedium(int index) => this._GetMedium(index);
+
+        protected override int _GetMedium(int index) => this.buffer.GetMedium(index);
+
         public override long GetLong(int index) => this._GetLong(index);
 
         protected override long _GetLong(int index) => this.buffer.GetLong(index);
@@ -92,6 +96,14 @@ namespace DotNetty.Buffers
         }
 
         protected override void _SetInt(int index, int value) => this.buffer.SetInt(index, value);
+
+        public override IByteBuffer SetMedium(int index, int value)
+        {
+            this._SetMedium(index, value);
+            return this;
+        }
+
+        protected override void _SetMedium(int index, int value) => this.buffer.SetMedium(index, value);
 
         public override IByteBuffer SetLong(int index, long value)
         {

--- a/src/DotNetty.Buffers/EmptyByteBuffer.cs
+++ b/src/DotNetty.Buffers/EmptyByteBuffer.cs
@@ -158,6 +158,16 @@ namespace DotNetty.Buffers
             throw new IndexOutOfRangeException();
         }
 
+        public int GetMedium(int index)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public int GetUnsignedMedium(int index)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
         public IByteBuffer GetBytes(int index, IByteBuffer destination) => this.CheckIndex(index, destination.WritableBytes);
 
         public IByteBuffer GetBytes(int index, IByteBuffer destination, int length) => this.CheckIndex(index, length);
@@ -195,7 +205,13 @@ namespace DotNetty.Buffers
             throw new IndexOutOfRangeException();
         }
 
+
         public IByteBuffer SetUnsignedInt(int index, uint value)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public IByteBuffer SetMedium(int index, int value)
         {
             throw new IndexOutOfRangeException();
         }
@@ -269,6 +285,16 @@ namespace DotNetty.Buffers
             throw new IndexOutOfRangeException();
         }
 
+        public int ReadMedium()
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public int ReadUnsignedMedium()
+        {
+            throw new IndexOutOfRangeException();
+        }
+
         public char ReadChar()
         {
             throw new IndexOutOfRangeException();
@@ -326,6 +352,16 @@ namespace DotNetty.Buffers
         }
 
         public IByteBuffer WriteLong(long value)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public IByteBuffer WriteUnsignedMedium(int value)
+        {
+            throw new IndexOutOfRangeException();
+        }
+
+        public IByteBuffer WriteMedium(int value)
         {
             throw new IndexOutOfRangeException();
         }

--- a/src/DotNetty.Buffers/IByteBuffer.cs
+++ b/src/DotNetty.Buffers/IByteBuffer.cs
@@ -260,6 +260,28 @@ namespace DotNetty.Buffers
         long GetLong(int index);
 
         /// <summary>
+        ///     Gets a 24-bit medium integer at the specified absolute index in this buffer.
+        ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
+        ///     of this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">
+        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     <c>index + 3</c> greater than <see cref="Capacity" />
+        /// </exception>
+        int GetMedium(int index);
+
+        /// <summary>
+        ///     Gets an unsigned 24-bit medium integer at the specified absolute index in this buffer.
+        ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
+        ///     of this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">
+        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     <c>index + 3</c> greater than <see cref="Capacity" />
+        /// </exception>
+        int GetUnsignedMedium(int index);
+
+        /// <summary>
         ///     Gets a char at the specified absolute <see cref="index" /> in this buffer.
         ///     This method does not modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" />
         ///     of this buffer.
@@ -410,6 +432,17 @@ namespace DotNetty.Buffers
         IByteBuffer SetUnsignedInt(int index, uint value);
 
         /// <summary>
+        ///     Sets the specified 24-bit medium integer at the specified absolute <see cref="index" /> in this buffer.
+        ///     Note that the most significant byte is ignored in the specified value.
+        ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">
+        ///     if the specified <see cref="index" /> is less than <c>0</c> or
+        ///     <c>index + 3</c> greater than <see cref="Capacity" />
+        /// </exception>
+        IByteBuffer SetMedium(int index, int value);
+
+        /// <summary>
         ///     Sets the specified long integer at the specified absolute <see cref="index" /> in this buffer.
         ///     This method does not directly modify <see cref="ReaderIndex" /> or <see cref="WriterIndex" /> of this buffer.
         /// </summary>
@@ -528,6 +561,20 @@ namespace DotNetty.Buffers
         short ReadShort();
 
         /// <summary>
+        ///     Gets a 24-bit medium integer at the current <see cref="ReaderIndex" /> and increases the <see cref="ReaderIndex" />
+        ///     by <c>3</c> in this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">if <see cref="ReadableBytes" /> is less than <c>3</c></exception>
+        int ReadMedium();
+
+        /// <summary>
+        ///     Gets an unsigned 24-bit medium integer at the current <see cref="ReaderIndex" /> and increases the <see cref="ReaderIndex" />
+        ///     by <c>3</c> in this buffer.
+        /// </summary>
+        /// <exception cref="IndexOutOfRangeException">if <see cref="ReadableBytes" /> is less than <c>3</c></exception>
+        int ReadUnsignedMedium();
+
+        /// <summary>
         ///     Gets an unsigned short at the current <see cref="ReaderIndex" /> and increases the <see cref="ReaderIndex" />
         ///     by <c>2</c> in this buffer.
         /// </summary>
@@ -618,6 +665,10 @@ namespace DotNetty.Buffers
         IByteBuffer WriteChar(char value);
 
         IByteBuffer WriteDouble(double value);
+
+        IByteBuffer WriteUnsignedMedium(int value);
+
+        IByteBuffer WriteMedium(int value);
 
         IByteBuffer WriteBytes(IByteBuffer src);
 

--- a/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
@@ -59,6 +59,14 @@ namespace DotNetty.Buffers
                 (long)this.Memory[index + 7] & 0xff;
         }
 
+        protected override int _GetMedium(int index)
+        {
+            index = this.Idx(index);
+            return (sbyte)this.Memory[index] << 16 |
+                   this.Memory[index + 1] << 8 |
+                   this.Memory[index + 2];
+        }
+
         public override IByteBuffer GetBytes(int index, IByteBuffer dst, int dstIndex, int length)
         {
             this.CheckDstIndex(index, length, dstIndex, dst.Capacity);
@@ -103,6 +111,14 @@ namespace DotNetty.Buffers
             this.Memory[index + 1] = (byte)value.RightUShift(16);
             this.Memory[index + 2] = (byte)value.RightUShift(8);
             this.Memory[index + 3] = (byte)value;
+        }
+
+        protected override void _SetMedium(int index, int value)
+        {
+            index = this.Idx(index);
+            this.Memory[index] = (byte)value.RightUShift(16);
+            this.Memory[index + 1] = (byte)value.RightUShift(8);
+            this.Memory[index + 2] = (byte)value;
         }
 
         protected override void _SetLong(int index, long value)

--- a/src/DotNetty.Buffers/SlicedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SlicedByteBuffer.cs
@@ -84,6 +84,8 @@ namespace DotNetty.Buffers
 
         protected override long _GetLong(int index) => this.buffer.GetLong(index + this.adjustment);
 
+        protected override int _GetMedium(int index) => this.buffer.GetMedium(index + this.adjustment);
+
         public override IByteBuffer Duplicate()
         {
             IByteBuffer duplicate = this.buffer.Slice(this.adjustment, this.length);
@@ -141,6 +143,8 @@ namespace DotNetty.Buffers
         protected override void _SetInt(int index, int value) => this.buffer.SetInt(index + this.adjustment, value);
 
         protected override void _SetLong(int index, long value) => this.buffer.SetLong(index + this.adjustment, value);
+
+        protected override void _SetMedium(int index, int value) => this.buffer.SetMedium(index + this.adjustment, value);
 
         public override IByteBuffer SetBytes(int index, byte[] src, int srcIndex, int length)
         {

--- a/src/DotNetty.Buffers/SwappedByteBuffer.cs
+++ b/src/DotNetty.Buffers/SwappedByteBuffer.cs
@@ -186,6 +186,10 @@ namespace DotNetty.Buffers
 
         public long GetLong(int index) => ByteBufferUtil.SwapLong(this.buf.GetLong(index));
 
+        public int GetMedium(int index) => ByteBufferUtil.SwapMedium(this.buf.GetMedium(index));
+
+        public int GetUnsignedMedium(int index) => this.GetMedium(index).ToUnsignedMediumInt();
+
         public char GetChar(int index) => (char)this.GetShort(index);
 
         public double GetDouble(int index) => BitConverter.Int64BitsToDouble(this.GetLong(index));
@@ -279,6 +283,12 @@ namespace DotNetty.Buffers
             return this;
         }
 
+        public IByteBuffer SetMedium(int index, int value)
+        {
+            this.buf.SetMedium(index, ByteBufferUtil.SwapMedium(value));
+            return this;
+        }
+
         public IByteBuffer SetChar(int index, char value)
         {
             this.SetShort(index, (short)value);
@@ -348,6 +358,10 @@ namespace DotNetty.Buffers
         }
 
         public long ReadLong() => ByteBufferUtil.SwapLong(this.buf.ReadLong());
+
+        public int ReadMedium() => ByteBufferUtil.SwapMedium(this.buf.ReadMedium());
+
+        public int ReadUnsignedMedium() => this.ReadMedium().ToUnsignedMediumInt();
 
         public char ReadChar() => (char)this.ReadShort();
 
@@ -445,6 +459,18 @@ namespace DotNetty.Buffers
         public IByteBuffer WriteLong(long value)
         {
             this.buf.WriteLong(ByteBufferUtil.SwapLong(value));
+            return this;
+        }
+
+        public IByteBuffer WriteUnsignedMedium(int value)
+        {
+            this.buf.WriteMedium(ByteBufferUtil.SwapMedium(value.ToUnsignedMediumInt()));
+            return this;
+        }
+
+        public IByteBuffer WriteMedium(int value)
+        {
+            this.buf.WriteMedium(ByteBufferUtil.SwapMedium(value));
             return this;
         }
 

--- a/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/UnpooledHeapByteBuffer.cs
@@ -3,6 +3,7 @@
 
 namespace DotNetty.Buffers
 {
+    using DotNetty.Common.Utilities;
     using System;
     using System.Diagnostics.Contracts;
     using System.IO;
@@ -217,6 +218,19 @@ namespace DotNetty.Buffers
             return this._GetLong(index);
         }
 
+        public override int GetMedium(int index)
+        {
+            this.EnsureAccessible();
+            return this._GetMedium(index);
+        }
+
+        protected override int _GetMedium(int index)
+        {
+            return (sbyte)this.array[index] << 16 |
+                    this.array[index + 1] << 8 |
+                    this.array[index + 2];
+        }
+
         protected override long _GetLong(int index)
         {
             unchecked
@@ -255,6 +269,24 @@ namespace DotNetty.Buffers
             {
                 this.array[index] = (byte)((ushort)value >> 8);
                 this.array[index + 1] = (byte)value;
+            }
+        }
+
+        public override IByteBuffer SetMedium(int index, int value)
+        {
+            this.EnsureAccessible();
+            this._SetMedium(index, value);
+            return this;
+        }
+
+        protected override void _SetMedium(int index, int value)
+        {
+            unchecked
+            {
+                uint unsignedValue = (uint)value;
+                this.array[index] = (byte)(unsignedValue >> 16);
+                this.array[index + 1] = (byte)(unsignedValue >> 8);
+                this.array[index + 2] = (byte)value;
             }
         }
 

--- a/src/DotNetty.Buffers/WrappedByteBuf.cs
+++ b/src/DotNetty.Buffers/WrappedByteBuf.cs
@@ -137,6 +137,10 @@ namespace DotNetty.Buffers
 
         public virtual long GetLong(int index) => this.Buf.GetLong(index);
 
+        public virtual int GetMedium(int index) => this.Buf.GetMedium(index);
+
+        public virtual int GetUnsignedMedium(int index) => this.Buf.GetUnsignedMedium(index);
+
         public virtual char GetChar(int index) => this.Buf.GetChar(index);
 
         // todo: port: complete
@@ -206,6 +210,12 @@ namespace DotNetty.Buffers
         public virtual IByteBuffer SetInt(int index, int value)
         {
             this.Buf.SetInt(index, value);
+            return this;
+        }
+
+        public virtual IByteBuffer SetMedium(int index, int value)
+        {
+            this.Buf.SetMedium(index, value);
             return this;
         }
 
@@ -288,6 +298,10 @@ namespace DotNetty.Buffers
         public virtual uint ReadUnsignedInt() => this.Buf.ReadUnsignedInt();
 
         public virtual long ReadLong() => this.Buf.ReadLong();
+
+        public virtual int ReadMedium() => this.Buf.ReadMedium();
+
+        public virtual int ReadUnsignedMedium() => this.Buf.ReadUnsignedMedium();
 
         public virtual char ReadChar() => this.Buf.ReadChar();
 
@@ -384,6 +398,14 @@ namespace DotNetty.Buffers
         public virtual IByteBuffer WriteChar(char value)
         {
             this.Buf.WriteChar(value);
+            return this;
+        }
+
+        public virtual IByteBuffer WriteUnsignedMedium(int value) => this.Buf.WriteUnsignedMedium(value);
+
+        public virtual IByteBuffer WriteMedium(int value)
+        {
+            this.Buf.WriteMedium(value);
             return this;
         }
 

--- a/src/DotNetty.Common/Utilities/MediumUtil.cs
+++ b/src/DotNetty.Common/Utilities/MediumUtil.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Common.Utilities
+{
+    using System;
+
+    public static class MediumUtil
+    {
+        //High byte bit-mask used when a 24-bit integer is stored within a 32-bit integer.
+        const uint MediumBitMask = 0xff000000;
+
+        public static int ToMediumInt(this int value)
+        {
+            // Check bit 23, the sign bit in a signed 24-bit integer
+            if ((value & 0x00800000) > 0)
+            {
+                // If the sign-bit is set, this number will be negative - set all high-byte bits (keeps 32-bit number in 24-bit range)
+                value |= unchecked((int)MediumBitMask);
+            }
+            else
+            {
+                // If the sign-bit is not set, this number will be positive - clear all high-byte bits (keeps 32-bit number in 24-bit range)
+                value &= ~unchecked((int)MediumBitMask);
+            }
+
+            return value;
+        }
+
+        public static int ToUnsignedMediumInt(this int value)
+        {
+            return (int)((uint)value & ~MediumBitMask);
+        }
+    }
+}


### PR DESCRIPTION
Implemented functions

- https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html#getMedium-int-
- https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html#getUnsignedMedium-int-
- https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html#readMedium--
- https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html#readUnsignedMedium--
- https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html#writeMedium-int-
- https://netty.io/4.0/api/io/netty/buffer/ByteBuf.html#setMedium-int-int-
- https://netty.io/4.0/api/io/netty/buffer/ByteBufUtil.html#swapMedium-int-

Implemented tests

- GetMediumBoundaryCheck1
- GetMediumBoundaryCheck2
- TestSequentialMediumAccess
- TestSequentialMediumLeAccess
- TestSequentialUnsignedMediumAccess
- TestSequentialUnsignedMediumLeAccess
- TestGetMediumAfterRelease
- TestGetMediumLeAfterRelease
- TestGetUnsignedMediumAfterRelease
- TestGetUnsignedMediumLeAfterRelease
- TestSetMediumAfterRelease
- TestSetMediumLeAfterRelease
- TestReadMediumAfterRelease
- TestReadMediumLeAfterRelease
- TestReadUnsignedMediumAfterRelease
- TestReadUnsignedMediumLeAfterRelease
- TestWriteMediumAfterRelease
- TestWriteMediumLeAfterRelease
- TestRandomMediumAccess
- TestRandomMediumLeAccess
- TestRandomUnsignedMediumAccess
- TestRandomUnsignedMediumLeAccess

Related with [#241](https://github.com/Azure/DotNetty/issues/241)