### PR TITLE
X509Chain Propogation

### DIFF
--- a/src/DotNetty.Handlers/Tls/TlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/TlsSettings.cs
@@ -3,10 +3,31 @@
 
 namespace DotNetty.Handlers.Tls
 {
+    using System.Net.Security;
     using System.Security.Authentication;
 
     public abstract class TlsSettings
     {
+        protected TlsSettings(
+            SslProtocols enabledProtocols, 
+            bool checkCertificateRevocation,
+            RemoteCertificateValidationCallback remoteCertificateValidationCallback,
+            LocalCertificateSelectionCallback localCertificateSelectionCallback)
+            :this(enabledProtocols, checkCertificateRevocation)
+        {
+            this.RemoteCertificateValidationCallback = remoteCertificateValidationCallback;
+            this.LocalCertificateSelectionCallback = localCertificateSelectionCallback;
+        }
+
+        protected TlsSettings(
+            SslProtocols enabledProtocols,
+            bool checkCertificateRevocation,
+            RemoteCertificateValidationCallback remoteCertificateValidationCallback)
+            : this(enabledProtocols, checkCertificateRevocation)
+        {
+            this.RemoteCertificateValidationCallback = remoteCertificateValidationCallback;
+        }
+
         protected TlsSettings(SslProtocols enabledProtocols, bool checkCertificateRevocation)
         {
             this.EnabledProtocols = enabledProtocols;
@@ -16,5 +37,9 @@ namespace DotNetty.Handlers.Tls
         public SslProtocols EnabledProtocols { get; }
 
         public bool CheckCertificateRevocation { get; }
+
+        public RemoteCertificateValidationCallback RemoteCertificateValidationCallback { get; }
+
+        public LocalCertificateSelectionCallback LocalCertificateSelectionCallback { get; }
     }
 }


### PR DESCRIPTION
Motivation:
X509Chain is requied for X509CA validation purposes. Currently there is no way to get access to the chain on the application level to delay the authentication decision.

Modifications:
TlsSettings was extended. Two more fields were added:
Remote CertificateValidation callback to address the current needs and LocalCertificateSelectionCallback for completness and parity with the SslStream. The only option that has been left is EncryptionPolicy - it looks too dangerous.

Results:
X509Chain is available on TlsHandler as a public property.