### PR TITLE
Always use uppercase for HexDump

### DIFF
--- a/src/DotNetty.Common/Utilities/StringUtil.cs
+++ b/src/DotNetty.Common/Utilities/StringUtil.cs
@@ -47,7 +47,7 @@ namespace DotNetty.Common.Utilities
             for (; i < 16; i++)
             {
                 var buf = new StringBuilder(2);
-                char c = (char)('a' + i - 10);
+                char c = (char)('A' + i - 10);
                 buf.Append('0');
                 buf.Append(c);
                 Byte2HexPad[i] = buf.ToString();


### PR DESCRIPTION
The current version get `0a` for `0x0A`, but `1A` for `0x1A` for value, and always upper for Prefix. ~The patch make it always output lowercase as netty does.~
***Which one should be used? Upper or Lower?***