### PR TITLE
Realigning API of IdleStateHandler, and some bugfix

### DIFF
--- a/src/DotNetty.Handlers/Properties/Friends.cs
+++ b/src/DotNetty.Handlers/Properties/Friends.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DotNetty.Handlers.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d9782d5a0b850f230f71e06de2e101d8441d83e15eef715837eee38fdbf5cb369b41ec36e6e7668c18cbb09e5419c179360461e740c1cce6ffbdcf81f245e1e705482797fe42aff2d31ecd72ea87362ded3c14066746fbab4a8e1896f8b982323c84e2c1b08407c0de18b7feef1535fb972a3b26181f5a304ebd181795a46d8f")]

--- a/src/DotNetty.Handlers/Timeout/IdleStateEvent.cs
+++ b/src/DotNetty.Handlers/Timeout/IdleStateEvent.cs
@@ -6,7 +6,7 @@ namespace DotNetty.Handlers.Timeout
     /// <summary>
     /// A user event triggered by <see cref="IdleStateHandler"/> when a <see cref="DotNetty.Transport.Channels.IChannel"/> is idle.
     /// </summary>
-    public sealed class IdleStateEvent
+    public class IdleStateEvent
     {
         public static readonly IdleStateEvent FirstReaderIdleStateEvent = new IdleStateEvent(IdleState.ReaderIdle, true);
         public static readonly IdleStateEvent ReaderIdleStateEvent = new IdleStateEvent(IdleState.ReaderIdle, false);
@@ -15,7 +15,12 @@ namespace DotNetty.Handlers.Timeout
         public static readonly IdleStateEvent FirstAllIdleStateEvent = new IdleStateEvent(IdleState.AllIdle, true);
         public static readonly IdleStateEvent AllIdleStateEvent = new IdleStateEvent(IdleState.AllIdle, false);
 
-        IdleStateEvent(IdleState state, bool first)
+        /// <summary>
+        /// Constructor for sub-classes.
+        /// </summary>
+        /// <param name="state">the <see cref="IdleStateEvent"/> which triggered the event.</param>
+        /// <param name="first"><code>true</code> if its the first idle event for the <see cref="IdleStateEvent"/>.</param>
+        protected IdleStateEvent(IdleState state, bool first)
         {
             this.State = state;
             this.First = first;

--- a/src/DotNetty.Handlers/Timeout/ReadTimeoutHandler.cs
+++ b/src/DotNetty.Handlers/Timeout/ReadTimeoutHandler.cs
@@ -8,6 +8,7 @@ namespace DotNetty.Handlers.Timeout
     using DotNetty.Common.Utilities;
     using DotNetty.Common.Concurrency;
     using DotNetty.Transport.Channels;
+    using System.Diagnostics.Contracts;
 
     /// <summary>
     /// Raises a <see cref="ReadTimeoutException"/> when no data was read within a certain
@@ -21,7 +22,7 @@ namespace DotNetty.Handlers.Timeout
     /// <c>
     /// var bootstrap = new <see cref="DotNetty.Transport.Bootstrapping.ServerBootstrap"/>();
     ///
-    /// bootstrap.ChildHandler(new ActionChannelInitializer<ISocketChannel>(channel =>
+    /// bootstrap.ChildHandler(new ActionChannelInitializer&lt;ISocketChannel&gt;(channel =>
     /// {
     ///     IChannelPipeline pipeline = channel.Pipeline;
     ///     
@@ -47,23 +48,14 @@ namespace DotNetty.Handlers.Timeout
     /// }
     /// </c>
     /// </example>
+    /// </pre>
     /// 
     /// <seealso cref="WriteTimeoutHandler"/>
     /// <seealso cref="IdleStateHandler"/>
     /// </summary>
-    public class ReadTimeoutHandler : ChannelHandlerAdapter
+    public class ReadTimeoutHandler : IdleStateHandler
     {
-        static readonly TimeSpan MinTimeout = TimeSpan.FromMilliseconds(1);
-
-        readonly TimeSpan timeout;
-        TimeSpan lastReadTime;
-
-        volatile IScheduledTask timeoutTask; 
-        volatile int state; // 0 - none, 1 - Initialized, 2 - Destroyed;
-        volatile bool reading;
         bool closed;
-
-        static readonly Action<object, object> ReadTimeoutAction = HandleReadTimeout;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetty.Handlers.Timeout.ReadTimeoutHandler"/> class.
@@ -79,98 +71,14 @@ namespace DotNetty.Handlers.Timeout
         /// </summary>
         /// <param name="timeout">Timeout.</param>
         public ReadTimeoutHandler(TimeSpan timeout)
+            : base(timeout, TimeSpan.Zero, TimeSpan.Zero)
         {
-            this.timeout = 
-                TimeUtil.Max(timeout, ReadTimeoutHandler.MinTimeout);
         }
 
-        public override void HandlerAdded(IChannelHandlerContext context)
+        protected override void ChannelIdle(IChannelHandlerContext context, IdleStateEvent stateEvent)
         {
-            if (context.Channel.Active && context.Channel.Registered)
-            {
-                // channelActvie() event has been fired already, which means this.channelActive() will
-                // not be invoked. We have to initialize here instead.
-                this.Initialize(context);
-            }
-            else
-            {
-                // channelActive() event has not been fired yet.  this.channelActive() will be invoked
-                // and initialization will occur there.
-            }
-        }
-
-        public override void HandlerRemoved(IChannelHandlerContext context)
-        {
-            this.Destroy();
-        }
-
-        public override void ChannelRegistered(IChannelHandlerContext context)
-        {
-            // Initialize early if channel is active already.
-            if (context.Channel.Active)
-            {
-                this.Initialize(context);
-            }
-
-            base.ChannelRegistered(context);
-        }
-
-        public override void ChannelActive(IChannelHandlerContext context)
-        {
-            // This method will be invoked only if this handler was added
-            // before channelActive() event is fired.  If a user adds this handler
-            // after the channelActive() event, initialize() will be called by beforeAdd().
-            this.Initialize(context);
-            base.ChannelActive(context);
-        }
-
-        public override void ChannelInactive(IChannelHandlerContext context)
-        {
-            this.Destroy();
-            base.ChannelInactive(context);
-        }
-
-        public override void ChannelRead(IChannelHandlerContext context, object message)
-        {
-            this.reading = true;
-            context.FireChannelRead(message);
-        }
-
-        public override void ChannelReadComplete(IChannelHandlerContext context)
-        {
-            this.lastReadTime = TimeUtil.GetSystemTime();
-            this.reading = false;
-            context.FireChannelReadComplete();
-        }
-
-        private void Initialize(IChannelHandlerContext context)
-        {
-            switch(this.state)
-            {
-                case 1:
-                case 2:
-                    return;
-            }
-
-            this.state = 1;
-
-            this.lastReadTime = TimeUtil.GetSystemTime();
-            if (this.timeout.Ticks > 0) 
-            {
-                this.timeoutTask = context.Executor.Schedule(ReadTimeoutAction, this, context, 
-                    this.timeout);
-            }
-        }
-
-        private void Destroy()
-        {
-            state = 2;
-
-            if(this.timeoutTask != null)
-            {
-                this.timeoutTask.Cancel();
-                this.timeoutTask = null;
-            }
+            Contract.Requires(stateEvent.State == IdleState.ReaderIdle);
+            this.ReadTimedOut(context);
         }
 
         /// <summary>
@@ -182,46 +90,8 @@ namespace DotNetty.Handlers.Timeout
             if(!this.closed)
             {
                 context.FireExceptionCaught(ReadTimeoutException.Instance);
-                context.Flush();
+                context.CloseAsync();
                 this.closed = true;
-            }
-        }
-
-        static void HandleReadTimeout(object handler, object ctx)
-        {
-            var self = (ReadTimeoutHandler)handler;
-            var context = (IChannelHandlerContext)ctx;
-
-            if (!context.Channel.Open)
-            {
-                return;
-            }
-
-            TimeSpan nextDelay = self.timeout;
-            if(!self.reading)
-            {
-                nextDelay -= TimeUtil.GetSystemTime() - self.lastReadTime;
-            }
-
-            if(nextDelay.Ticks <= 0)
-            {
-                // Read timed out - set a new timeout and notify the callback.
-                self.timeoutTask = context.Executor.Schedule(ReadTimeoutAction, self, context, 
-                    self.timeout);
-
-                try
-                {
-                    self.ReadTimedOut(context);
-                }
-                catch(Exception ex)
-                {
-                    context.FireExceptionCaught(ex);
-                }
-            }
-            else
-            {
-                self.timeoutTask = context.Executor.Schedule(ReadTimeoutAction, self, context, 
-                    nextDelay);
             }
         }
     }

--- a/src/DotNetty.Transport/Channels/Embedded/EmbeddedChannel.cs
+++ b/src/DotNetty.Transport/Channels/Embedded/EmbeddedChannel.cs
@@ -392,7 +392,7 @@ namespace DotNetty.Transport.Channels.Embedded
 
         static bool ReleaseAll(Queue<object> queue)
         {
-            if (queue.Count > 0)
+            if (queue != null && queue.Count > 0)
             {
                 for (;;)
                 {

--- a/test/DotNetty.Handlers.Tests/IdleStateHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/IdleStateHandlerTest.cs
@@ -1,0 +1,365 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace DotNetty.Handlers.Tests
+{
+    using System.Threading.Tasks;
+    using DotNetty.Tests.Common;
+    using Xunit;
+    using Xunit.Abstractions;
+    using DotNetty.Handlers.Timeout;
+    using DotNetty.Common.Concurrency;
+    using System;
+    using DotNetty.Common.Utilities;
+    using DotNetty.Transport.Channels;
+    using DotNetty.Transport.Channels.Embedded;
+    using System.Collections.Generic;
+    using DotNetty.Buffers;
+
+    public class IdleStateHandlerTest : TestBase
+    {
+        private readonly TimeSpan oneSecond = TimeSpan.FromSeconds(1);
+        private readonly TimeSpan zeroSecond = TimeSpan.Zero;
+
+        public IdleStateHandlerTest(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
+        [Fact]
+        public void TestReaderIdle()
+        {
+            TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
+                    false, oneSecond, zeroSecond, zeroSecond);
+
+            // We start with one FIRST_READER_IDLE_STATE_EVENT, followed by an infinite number of READER_IDLE_STATE_EVENTs
+            AnyIdle(idleStateHandler, IdleStateEvent.FirstReaderIdleStateEvent,
+                    IdleStateEvent.ReaderIdleStateEvent, IdleStateEvent.ReaderIdleStateEvent);
+        }
+
+        [Fact]
+        public void TestWriterIdle()
+        {
+            TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
+                    false, zeroSecond, oneSecond, zeroSecond);
+
+            AnyIdle(idleStateHandler, IdleStateEvent.FirstWriterIdleStateEvent,
+                    IdleStateEvent.WriterIdleStateEvent, IdleStateEvent.WriterIdleStateEvent);
+        }
+
+        [Fact]
+        public void TestAllIdle()
+        {
+            TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
+                    false, zeroSecond, zeroSecond, oneSecond);
+
+            AnyIdle(idleStateHandler, IdleStateEvent.FirstAllIdleStateEvent,
+                    IdleStateEvent.AllIdleStateEvent, IdleStateEvent.AllIdleStateEvent);
+        }
+
+        private void AnyIdle(TestableIdleStateHandler idleStateHandler, params object[] expected)
+        {
+            Assert.True(expected.Length >= 1, "The number of expected events must be >= 1");
+
+            var events = new List<object>();
+            var handler = new TestEventChannelInboundHandlerAdapter(events);
+
+            var channel = new EmbeddedChannel(idleStateHandler, handler);
+            try
+            {
+                // For each expected event advance the ticker and run() the task. Each
+                // step should yield in an IdleStateEvent because we haven't written
+                // or read anything from the channel.
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    idleStateHandler.TickRun();
+                }
+
+                Assert.Equal(expected.Length, events.Count);
+
+                // Compare the expected with the actual IdleStateEvents
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    Object evt = events[i];
+                    Assert.Same(expected[i], evt);//"Element " + i + " is not matching"
+                }
+            }
+            finally
+            {
+                channel.FinishAndReleaseAll();
+            }
+        }
+
+        [Fact]
+        public void TestReaderNotIdle()
+        {
+            TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
+                    false, oneSecond, zeroSecond, zeroSecond);
+
+            Action<EmbeddedChannel> action = (channel) => channel.WriteInbound("Hello, World!");
+
+            AnyNotIdle(idleStateHandler, action, IdleStateEvent.FirstReaderIdleStateEvent);
+        }
+
+        [Fact]
+        public void TestWriterNotIdle()
+        {
+            TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
+                    false, zeroSecond, oneSecond, zeroSecond);
+
+            Action<EmbeddedChannel> action = (channel) => channel.WriteAndFlushAsync("Hello, World!");
+
+            AnyNotIdle(idleStateHandler, action, IdleStateEvent.FirstWriterIdleStateEvent);
+        }
+
+        [Fact]
+        public void TestAllNotIdle()
+        {
+            // Reader...
+            TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
+                    false, zeroSecond, zeroSecond, oneSecond);
+
+            Action<EmbeddedChannel> reader = (channel) => channel.WriteInbound("Hello, World!");
+
+            AnyNotIdle(idleStateHandler, reader, IdleStateEvent.FirstAllIdleStateEvent);
+
+            // Writer...
+            idleStateHandler = new TestableIdleStateHandler(
+                    false, zeroSecond, zeroSecond, oneSecond);
+
+            Action<EmbeddedChannel> writer = (channel) => channel.WriteAndFlushAsync("Hello, World!");
+
+            AnyNotIdle(idleStateHandler, writer, IdleStateEvent.FirstAllIdleStateEvent);
+        }
+
+        private void AnyNotIdle(TestableIdleStateHandler idleStateHandler,
+            Action<EmbeddedChannel> action, object expected)
+        {
+            var events = new List<object>();
+            var handler = new TestEventChannelInboundHandlerAdapter(events);
+
+            var channel = new EmbeddedChannel(idleStateHandler, handler);
+            try
+            {
+                //TODO: No NANOSECONDS(0.01 Ticks) support in DotNetty for IdleStateHandler, but is it really needed?
+                idleStateHandler.DoTick(TimeSpan.FromTicks(1));
+                action.Invoke(channel);
+
+                // Advance the ticker by some fraction and run() the task.
+                // There shouldn't be an IdleStateEvent getting fired because
+                // we've just performed an action on the channel that is meant
+                // to reset the idle task.
+                TimeSpan delayInNanos = idleStateHandler.Delay;
+                Assert.NotEqual(zeroSecond, delayInNanos);
+
+                idleStateHandler.TickRun(TimeSpan.FromTicks(delayInNanos.Ticks / 2));
+                Assert.Equal(0, events.Count);
+
+                // Advance the ticker by the full amount and it should yield
+                // in an IdleStateEvent.
+                idleStateHandler.TickRun();
+                Assert.Equal(1, events.Count);
+                Assert.Same(expected, events[0]);
+            }
+            finally
+            {
+                channel.FinishAndReleaseAll();
+            }
+        }
+
+        [Fact]
+        public void TestObserveWriterIdle() => ObserveOutputIdle(true);
+
+        [Fact]
+        public void TestObserveAllIdle() => ObserveOutputIdle(false);
+
+        private void ObserveOutputIdle(bool writer)
+        {
+            TimeSpan writerIdleTime = zeroSecond;
+            TimeSpan allIdleTime = zeroSecond;
+            IdleStateEvent expected;
+
+            if (writer)
+            {
+                writerIdleTime = TimeSpan.FromSeconds(5);
+                expected = IdleStateEvent.FirstWriterIdleStateEvent;
+            }
+            else
+            {
+                allIdleTime = TimeSpan.FromSeconds(5);
+                expected = IdleStateEvent.FirstAllIdleStateEvent;
+            }
+
+            TestableIdleStateHandler idleStateHandler = new TestableIdleStateHandler(
+                    true, zeroSecond, writerIdleTime, allIdleTime);
+
+            var events = new List<object>();
+            var handler = new TestEventChannelInboundHandlerAdapter(events);
+
+            ObservableChannel channel = new ObservableChannel(idleStateHandler, handler);
+            try
+            {
+                // We're writing 3 messages that will be consumed at different rates!
+                channel.WriteAndFlushAsync(Unpooled.WrappedBuffer(new byte[] { 1 }));
+                channel.WriteAndFlushAsync(Unpooled.WrappedBuffer(new byte[] { 2 }));
+                channel.WriteAndFlushAsync(Unpooled.WrappedBuffer(new byte[] { 3 }));
+
+                // Establish a baseline. We're not consuming anything and let it idle once.
+                idleStateHandler.TickRun();
+                Assert.Equal(1, events.Count);
+                Assert.Same(expected, events[0]);
+                events.Clear();
+
+                // Our ticker should be at second 5
+                Assert.Equal(TimeSpan.FromSeconds(5), idleStateHandler.Tick);
+
+                // Consume one message in 4 seconds, then be idle for 2 seconds,
+                // then run the task and we shouldn't get an IdleStateEvent because
+                // we haven't been idle for long enough!
+                idleStateHandler.DoTick(TimeSpan.FromSeconds(4));
+                AssertNotNullAndRelease(channel.Consume());
+
+                idleStateHandler.TickRun(TimeSpan.FromSeconds(2));
+                Assert.Equal(0, events.Count);
+                Assert.Equal(TimeSpan.FromSeconds(11), idleStateHandler.Tick); // 5s + 4s + 2s
+
+                // Consume one message in 3 seconds, then be idle for 4 seconds,
+                // then run the task and we shouldn't get an IdleStateEvent because
+                // we haven't been idle for long enough!
+                idleStateHandler.DoTick(TimeSpan.FromSeconds(3));
+                AssertNotNullAndRelease(channel.Consume());
+
+                idleStateHandler.TickRun(TimeSpan.FromSeconds(4));
+                Assert.Equal(0, events.Count);
+                Assert.Equal(TimeSpan.FromSeconds(18), idleStateHandler.Tick); // 11s + 3s + 4s
+
+                // Don't consume a message and be idle for 5 seconds.
+                // We should get an IdleStateEvent!
+                idleStateHandler.TickRun(TimeSpan.FromSeconds(5));
+                Assert.Equal(1, events.Count);
+                Assert.Equal(TimeSpan.FromSeconds(23), idleStateHandler.Tick); // 18s + 5s
+                events.Clear();
+
+                // Consume one message in 2 seconds, then be idle for 1 seconds,
+                // then run the task and we shouldn't get an IdleStateEvent because
+                // we haven't been idle for long enough!
+                idleStateHandler.DoTick(TimeSpan.FromSeconds(2));
+                AssertNotNullAndRelease(channel.Consume());
+
+                idleStateHandler.TickRun(TimeSpan.FromSeconds(1));
+                Assert.Equal(0, events.Count);
+                Assert.Equal(TimeSpan.FromSeconds(26), idleStateHandler.Tick); // 23s + 2s + 1s
+
+                // There are no messages left! Advance the ticker by 3 seconds,
+                // attempt a consume() but it will be null, then advance the
+                // ticker by an another 2 seconds and we should get an IdleStateEvent
+                // because we've been idle for 5 seconds.
+                idleStateHandler.DoTick(TimeSpan.FromSeconds(3));
+                Assert.Null(channel.Consume());
+
+                idleStateHandler.TickRun(TimeSpan.FromSeconds(2));
+                Assert.Equal(1, events.Count);
+                Assert.Equal(TimeSpan.FromSeconds(31), idleStateHandler.Tick); // 26s + 3s + 2s
+
+                // q.e.d.
+            }
+            finally
+            {
+                channel.FinishAndReleaseAll();
+            }
+        }
+
+        private static void AssertNotNullAndRelease(Object msg)
+        {
+            Assert.NotNull(msg);
+            ReferenceCountUtil.Release(msg);
+        }
+
+        /*private interface Action
+        {
+            void run(EmbeddedChannel channel) throws Exception;
+        }*/
+
+        class TestableIdleStateHandler : IdleStateHandler
+        {
+            Action task;
+            public TimeSpan Delay { get; private set; }
+            public TimeSpan Tick { get; private set; }
+
+            public TestableIdleStateHandler(bool observeOutput,
+                TimeSpan readerIdleTime, TimeSpan writerIdleTime, TimeSpan allIdleTime)
+                : base(observeOutput, readerIdleTime, writerIdleTime, allIdleTime)
+            {
+            }
+
+            public void Run() => task.Invoke();
+
+            public void TickRun() => this.TickRun(Delay);
+
+            public void TickRun(TimeSpan delay)
+            {
+                this.DoTick(delay);
+                this.Run();
+            }
+
+            public void DoTick(TimeSpan delay)
+            {
+                this.Tick += delay;
+            }
+
+            internal override TimeSpan Ticks() => this.Tick;
+
+            internal override IScheduledTask Schedule(IChannelHandlerContext ctx, Action<object, object> task, object context, object state, TimeSpan delay)
+            {
+                this.task = task != null ? () => task(context, state) : default(Action);
+                this.Delay = delay;
+                return null;
+            }
+        }
+
+        class TestEventChannelInboundHandlerAdapter : ChannelHandlerAdapter
+        {
+            readonly List<object> events;
+
+            public TestEventChannelInboundHandlerAdapter(List<object> events)
+            {
+                this.events = events;
+            }
+
+            public override void UserEventTriggered(IChannelHandlerContext context, object evt)
+            {
+                events.Add(evt);
+            }
+        }
+
+        class ObservableChannel : EmbeddedChannel
+        {
+            public ObservableChannel(params IChannelHandler[] handlers)
+                : base(handlers)
+            {
+            }
+
+            protected override void DoWrite(ChannelOutboundBuffer input)
+            {
+                // Overridden to change EmbeddedChannel's default behavior. We went to keep
+                // the messages in the ChannelOutboundBuffer.
+            }
+
+            public object Consume()
+            {
+                ChannelOutboundBuffer buf = Unsafe.OutboundBuffer;
+                if (buf != null)
+                {
+                    Object msg = buf.Current;
+                    if (msg != null)
+                    {
+                        ReferenceCountUtil.Retain(msg);
+                        buf.Remove();
+                        return msg;
+                    }
+                }
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Align API and Test of IdleStateHandler with netty 4.1.15([f9003293...7460d90a](https://github.com/netty/netty/commits/4.1/handler/src/main/java/io/netty/handler/timeout))
* Fix EmbeddedChannel.ReleaseAll crashes when queue is null
* Fix ReadTimeoutHandler don't close channel when timeout
* Change IdleStateHandler.ChannelIdle and WriteTimeoutHandler.WriteTimedOut to virtual