### PR TITLE
Fix #309

### DIFF
--- a/src/DotNetty.Common/Internal/MacAddressUtil.cs
+++ b/src/DotNetty.Common/Internal/MacAddressUtil.cs
@@ -60,7 +60,7 @@ namespace DotNetty.Common.Internal
                 NetworkInterface iface = entry.Key;
                 IPAddress inetAddr = entry.Value;
                 // todo: netty has a check for whether interface is virtual but it always returns false. There is no equivalent in .NET
-                byte[] macAddr = iface.GetPhysicalAddress().GetAddressBytes();
+                byte[] macAddr = iface.GetPhysicalAddress()?.GetAddressBytes();
                 bool replace = false;
                 int res = CompareAddresses(bestMacAddr, macAddr);
                 if (res < 0)


### PR DESCRIPTION
Add an workaround for NetworkInterface.GetPhysicalAddress() may return null in special case