### PR TITLE
According to MSDN, "Using Shutdown on a connectionless Socket is not …

### DIFF
--- a/src/DotNetty.Transport/Channels/Sockets/SocketDatagramChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/SocketDatagramChannel.cs
@@ -97,7 +97,9 @@ namespace DotNetty.Transport.Channels.Sockets
         {
             if (this.TryResetState(StateFlags.Open | StateFlags.Active))
             {
-                this.Socket.Shutdown(SocketShutdown.Both);
+#if !NETSTANDARD1_3                
+                this.Socket.Close();
+#endif                
                 this.Socket.Dispose();
             }
         }

--- a/src/DotNetty.Transport/Channels/Sockets/SocketDatagramChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/SocketDatagramChannel.cs
@@ -97,9 +97,6 @@ namespace DotNetty.Transport.Channels.Sockets
         {
             if (this.TryResetState(StateFlags.Open | StateFlags.Active))
             {
-#if !NETSTANDARD1_3                
-                this.Socket.Close();
-#endif                
                 this.Socket.Dispose();
             }
         }


### PR DESCRIPTION
…recommended"

and the fact is calling Shutdown() on  an udp socket will cause an exception (socket not connected)
So we should simply call Close() then Dispose().
But there's no Close() method in dotnet core 1.1, so just an Dispose() would be enough.

P.S. I can't get the example QuoteOfTheMoment working with netCore 1.1 (1.1.7) on macOS 10.13, "Exception: System.PlatformNotSupportedException: This platform does not support packet information for dual-mode sockets", disable dual mode of the socket gives a invalid argument socket error (22). 
