### PR TITLE
Update condition value for medium int length validation for #252

### DIFF
--- a/src/DotNetty.Codecs/LengthFieldPrepender.cs
+++ b/src/DotNetty.Codecs/LengthFieldPrepender.cs
@@ -160,7 +160,7 @@ namespace DotNetty.Codecs
                         : context.Allocator.Buffer(2).WriteShortLE((short)length));
                     break;
                 case 3:
-                    if (length >= 167772156)
+                    if (length >= 16777216)
                     {
                         throw new ArgumentException("length of object does not fit into a medium integer: " + length);
                     }


### PR DESCRIPTION
The max value of a medium 24-bit integer is 2^24 which is 16,777,216 - not 167,772,156 as previously implemented.