### PR TITLE
Fix Libuv write buffers #348

### DIFF
--- a/src/DotNetty.Transport.Libuv/LoopExecutor.cs
+++ b/src/DotNetty.Transport.Libuv/LoopExecutor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // ReSharper disable ConvertToAutoPropertyWhenPossible
+// ReSharper disable ConvertToAutoProperty
 #pragma warning disable 420
 namespace DotNetty.Transport.Libuv
 {
@@ -32,6 +33,7 @@ namespace DotNetty.Transport.Libuv
         const int ShutdownState = 4;
         const int TerminatedState = 5;
 
+        readonly ThreadLocalPool<WriteRequest> writeRequestPool = new ThreadLocalPool<WriteRequest>(handle => new WriteRequest(handle));
         readonly long preciseBreakoutInterval;
         readonly IQueue<IRunnable> taskQueue;
         readonly XThread thread;
@@ -81,6 +83,8 @@ namespace DotNetty.Transport.Libuv
             this.thread = new XThread(Run) { Name = name };
             this.loopRunStart = new ManualResetEventSlim(false, 1);
         }
+
+        internal ThreadLocalPool<WriteRequest> WriteRequestPool => this.writeRequestPool;
 
         protected void Start()
         {

--- a/src/DotNetty.Transport.Libuv/Native/ReadOperation.cs
+++ b/src/DotNetty.Transport.Libuv/Native/ReadOperation.cs
@@ -46,7 +46,11 @@ namespace DotNetty.Transport.Libuv.Native
             Debug.Assert(!this.pin.IsAllocated);
 
             // Do not pin the buffer again if it is already pinned
-            IntPtr arrayHandle = buf.AddressOfPinnedMemory();
+            IntPtr arrayHandle = IntPtr.Zero;
+            if (buf.HasMemoryAddress)
+            {
+                arrayHandle = buf.AddressOfPinnedMemory();
+            }
             int index = buf.WriterIndex;
 
             if (arrayHandle == IntPtr.Zero)

--- a/src/DotNetty.Transport.Libuv/Native/Tcp.cs
+++ b/src/DotNetty.Transport.Libuv/Native/Tcp.cs
@@ -72,26 +72,6 @@ namespace DotNetty.Transport.Libuv.Native
             tcp.OnReadCallback(status, error);
         }
 
-        public void Write(WriteRequest request)
-        {
-            this.Validate();
-            try
-            {
-                int result = NativeMethods.uv_write(
-                    request.Handle,
-                    this.Handle,
-                    request.Bufs,
-                    request.BufferCount,
-                    WriteRequest.WriteCallback);
-                NativeMethods.ThrowIfError(result);
-            }
-            catch
-            {
-                request.Release();
-                throw;
-            }
-        }
-
         protected override void OnClosed()
         {
             base.OnClosed();

--- a/src/DotNetty.Transport.Libuv/NativeChannel.cs
+++ b/src/DotNetty.Transport.Libuv/NativeChannel.cs
@@ -302,23 +302,14 @@ namespace DotNetty.Transport.Libuv
                 }
             }
 
-            // Write request callback from libuv thread
-            void INativeUnsafe.FinishWrite(WriteRequest writeRequest)
+            // Write request callback from libuv thread, note this is only called
+            // if there are errors in write operations.
+            void INativeUnsafe.FinishWrite(OperationException error)
             {
-                try
-                {
-                    if (writeRequest.Error != null)
-                    {
-                        ChannelOutboundBuffer input = this.OutboundBuffer;
-                        var error = new ChannelException(writeRequest.Error);
-                        input?.FailFlushed(error, true);
-                        this.channel.Pipeline.FireExceptionCaught(error);
-                    }
-                }
-                finally
-                {
-                    writeRequest.Release();
-                }
+                ChannelOutboundBuffer input = this.OutboundBuffer;
+                var exception = new ChannelException(error);
+                input?.FailFlushed(exception, true);
+                this.channel.Pipeline.FireExceptionCaught(exception);
             }
         }
     }
@@ -333,7 +324,7 @@ namespace DotNetty.Transport.Libuv
 
         void FinishRead(ReadOperation readOperation);
 
-        void FinishWrite(WriteRequest writeRequest);
+        void FinishWrite(OperationException error);
     }
     
     interface IServerNativeUnsafe

--- a/src/DotNetty.Transport.Libuv/TcpChannel.cs
+++ b/src/DotNetty.Transport.Libuv/TcpChannel.cs
@@ -5,16 +5,12 @@
 namespace DotNetty.Transport.Libuv
 {
     using System;
-    using System.Collections.Generic;
     using System.Net;
-    using DotNetty.Buffers;
-    using DotNetty.Common;
     using DotNetty.Transport.Channels;
     using DotNetty.Transport.Libuv.Native;
 
     public sealed class TcpChannel : NativeChannel
     {
-        static readonly ThreadLocalPool<WriteRequest> Pool = new ThreadLocalPool<WriteRequest>(handle => new WriteRequest(handle));
         static readonly ChannelMetadata TcpMetadata = new ChannelMetadata(false);
 
         static readonly Action<object> FlushAction = c => ((TcpChannel)c).Flush();
@@ -142,143 +138,33 @@ namespace DotNetty.Transport.Libuv
 
         protected override void DoWrite(ChannelOutboundBuffer input)
         {
-            List<ArraySegment<byte>> sharedBufferList = null;
-            try
+            int writeSpinCount = this.config.WriteSpinCount;
+            var loopExecutor = (LoopExecutor)this.EventLoop;
+
+            long writtenBytes = 0;
+            int inputCount = input.Size;
+            do
             {
-                while (true)
+                if (inputCount == 0)
                 {
-                    int size = input.Count;
-                    if (size == 0)
-                    {
-                        // All written
-                        break;
-                    }
-                    long writtenBytes = 0;
-                    bool done = false;
-
-                    // Ensure the pending writes are made of ByteBufs only.
-                    sharedBufferList = input.GetSharedBufferList();
-                    int nioBufferCnt = sharedBufferList.Count;
-                    long expectedWrittenBytes = input.NioBufferSize;
-                    switch (nioBufferCnt)
-                    {
-                        case 0:
-                            this.DoWrite0(input);
-                            return;
-                        case 1:
-                            {
-                                ArraySegment<byte> nioBuffer = sharedBufferList[0];
-                                WriteRequest request = Pool.Take();
-                                int localWrittenBytes = request.Prepare((TcpChannelUnsafe)this.Unsafe, nioBuffer);
-                                this.tcp.Write(request);
-
-                                expectedWrittenBytes -= localWrittenBytes;
-                                writtenBytes += localWrittenBytes;
-                                if (expectedWrittenBytes == 0)
-                                {
-                                    done = true;
-                                }
-                            }
-                            break;
-                        default:
-                            for (int i = this.Configuration.WriteSpinCount - 1; i >= 0; i--)
-                            {
-                                WriteRequest request = Pool.Take();
-                                int localWrittenBytes = request.Prepare((TcpChannelUnsafe)this.Unsafe, sharedBufferList);
-                                this.tcp.Write(request);
-
-                                expectedWrittenBytes -= localWrittenBytes;
-                                writtenBytes += localWrittenBytes;
-                                if (expectedWrittenBytes == 0)
-                                {
-                                    done = true;
-                                    break;
-                                }
-                            }
-                            break;
-                    }
-
-                    input.RemoveBytes(writtenBytes);
-                    if (!done)
-                    {
-                        // Flush later
-                        this.EventLoop.Execute(FlushAction, this);
-                        break;
-                    }
-                }
-            }
-            finally
-            {
-                sharedBufferList?.Clear();
-            }
-        }
-
-        // Non gathering writes
-        void DoWrite0(ChannelOutboundBuffer input)
-        {
-            int writeSpinCount = -1;
-            while (true)
-            {
-                object msg = input.Current;
-                if (msg == null)
-                {
-                    // Wrote all messages.
                     break;
                 }
 
-                if (msg is IByteBuffer buf)
-                {
-                    int readableBytes = buf.ReadableBytes;
-                    if (readableBytes == 0)
-                    {
-                        input.Remove();
-                        continue;
-                    }
+                WriteRequest request = loopExecutor.WriteRequestPool.Take();
+                int bytes = request.Prepare((TcpChannelUnsafe)this.Unsafe, input);
+                int flushed = request.DoWrite();
 
-                    bool done = false;
-                    long flushedAmount = 0;
-                    if (writeSpinCount == -1)
-                    {
-                        writeSpinCount = this.Configuration.WriteSpinCount;
-                    }
-
-                    for (int i = writeSpinCount - 1; i >= 0; i--)
-                    {
-                        flushedAmount += this.WriteBytes(buf);
-                        if (!buf.IsReadable())
-                        {
-                            done = true;
-                            break;
-                        }
-                    }
-
-                    input.Progress(flushedAmount);
-                    if (done)
-                    {
-                        input.Remove();
-                    }
-                    else
-                    {
-                        this.EventLoop.Execute(FlushAction, this);
-                        break;
-                    }
-                }
-                else
-                {
-                    // Should not reach here.
-                    throw new InvalidOperationException();
-                }
+                writtenBytes += bytes;
+                inputCount -= flushed;
+                writeSpinCount--;
             }
-        }
+            while (writeSpinCount > 0);
+            input.RemoveBytes(writtenBytes, false);
 
-        int WriteBytes(IByteBuffer buf)
-        {
-            WriteRequest writeRequest = Pool.Take();
-            int totalBytes = writeRequest.Prepare((TcpChannelUnsafe)this.Unsafe, buf);
-            this.tcp.Write(writeRequest);
-
-            buf.SetReaderIndex(buf.ReaderIndex + totalBytes);
-            return totalBytes;
+            if (inputCount > 0)
+            {
+                loopExecutor.Execute(FlushAction, this);
+            }
         }
 
         sealed class TcpChannelUnsafe : NativeChannelUnsafe

--- a/src/DotNetty.Transport/Channels/ChannelOutboundBuffer.cs
+++ b/src/DotNetty.Transport/Channels/ChannelOutboundBuffer.cs
@@ -1,10 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// ReSharper disable ConvertToAutoProperty
+// ReSharper disable ConvertToAutoPropertyWithPrivateSetter
+// ReSharper disable ConvertToAutoPropertyWhenPossible
+
+#pragma warning disable 420 // all volatile fields are used with referenced in Interlocked methods only
 namespace DotNetty.Transport.Channels
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Diagnostics.Contracts;
     using System.Threading;
     using DotNetty.Buffers;
@@ -15,8 +21,6 @@ namespace DotNetty.Transport.Channels
 
     public sealed class ChannelOutboundBuffer
     {
-#pragma warning disable 420 // all volatile fields are used with referenced in Interlocked methods only
-
         static readonly IInternalLogger Logger = InternalLoggerFactory.GetInstance<ChannelOutboundBuffer>();
 
         static readonly ThreadLocalByteBufferList NioBuffers = new ThreadLocalByteBufferList();
@@ -34,7 +38,7 @@ namespace DotNetty.Transport.Channels
         // The number of flushed entries that are not written yet
         int flushed;
 
-        //int nioBufferCount;
+        long nioBufferSize;
 
         bool inFail;
 
@@ -179,7 +183,7 @@ namespace DotNetty.Transport.Channels
         ///     flushed message exists at the time this method is called it will return {@code false} to signal that no more
         ///     messages are ready to be handled.
         /// </summary>
-        public bool Remove()
+        public bool Remove(bool releaseMessages = true)
         {
             Entry e = this.flushedEntry;
             if (e == null)
@@ -197,8 +201,11 @@ namespace DotNetty.Transport.Channels
             if (!e.Cancelled)
             {
                 // only release message, notify and decrement if it was not canceled before.
-                ReferenceCountUtil.SafeRelease(msg);
-                Util.SafeSetSuccess(promise, Logger);
+                if (releaseMessages)
+                {
+                    ReferenceCountUtil.SafeRelease(msg);
+                }
+                SafeSuccess(promise);
                 this.DecrementPendingOutboundBytes(size, false, true);
             }
 
@@ -268,18 +275,17 @@ namespace DotNetty.Transport.Channels
         ///     Removes the fully written entries and update the reader index of the partially written entry.
         ///     This operation assumes all messages in this buffer is {@link ByteBuf}.
         /// </summary>
-        public void RemoveBytes(long writtenBytes)
+        public void RemoveBytes(long writtenBytes, bool releaseMessages = true)
         {
             while (true)
             {
                 object msg = this.Current;
-                if (!(msg is IByteBuffer))
+                if (!(msg is IByteBuffer buf))
                 {
                     Contract.Assert(writtenBytes == 0);
                     break;
                 }
 
-                var buf = (IByteBuffer)msg;
                 int readerIndex = buf.ReaderIndex;
                 int readableBytes = buf.WriterIndex - readerIndex;
 
@@ -290,7 +296,7 @@ namespace DotNetty.Transport.Channels
                         this.Progress(readableBytes);
                         writtenBytes -= readableBytes;
                     }
-                    this.Remove();
+                    this.Remove(releaseMessages);
                 }
                 else
                 {
@@ -319,18 +325,33 @@ namespace DotNetty.Transport.Channels
         ///{@link AbstractChannel#doWrite(ChannelOutboundBuffer)}.
         ///Refer to {@link NioSocketChannel#doWrite(ChannelOutboundBuffer)} for an example.
         ///</p>
+        ///
+        public List<ArraySegment<byte>> GetSharedBufferList() => this.GetSharedBufferList(int.MaxValue, int.MaxValue);
+
+        ///
+        ///Returns an array of direct NIO buffers if the currently pending messages are made of {@link ByteBuf} only.
+        ///{@link #nioBufferCount()} and {@link #nioBufferSize()} will return the number of NIO buffers in the returned
+        ///array and the total number of readable bytes of the NIO buffers respectively.
+        ///<p>
+        ///Note that the returned array is reused and thus should not escape
+        ///{@link AbstractChannel#doWrite(ChannelOutboundBuffer)}.
+        ///Refer to {@link NioSocketChannel#doWrite(ChannelOutboundBuffer)} for an example.
+        ///</p>
         /// @param maxCount The maximum amount of buffers that will be added to the return value.
         /// @param maxBytes A hint toward the maximum number of bytes to include as part of the return value. Note that this
         ///                 value maybe exceeded because we make a best effort to include at least 1 {@link ByteBuffer}
         ///                 in the return value to ensure write progress is made.
         /// 
-        public List<ArraySegment<byte>> GetSharedBufferList(int maxCount, long maxBytes = int.MaxValue)
+        public List<ArraySegment<byte>> GetSharedBufferList(int maxCount, long maxBytes)
         {
-            long nioBufferSize = 0;
+            Debug.Assert(maxCount > 0);
+            Debug.Assert(maxBytes > 0);
+
+            long ioBufferSize = 0;
+            int nioBufferCount = 0;
             InternalThreadLocalMap threadLocalMap = InternalThreadLocalMap.Get();
             List<ArraySegment<byte>> nioBuffers = NioBuffers.Get(threadLocalMap);
             Entry entry = this.flushedEntry;
-            int nioBufferCount = 0;
             while (this.IsFlushedEntry(entry) && entry.Message is IByteBuffer)
             {
                 if (!entry.Cancelled)
@@ -341,7 +362,7 @@ namespace DotNetty.Transport.Channels
 
                     if (readableBytes > 0)
                     {
-                        if (maxBytes - readableBytes < nioBufferSize && nioBufferCount != 0)
+                        if (maxBytes - readableBytes < ioBufferSize && nioBufferCount != 0)
                         {
                             // If the nioBufferSize + readableBytes will overflow an Integer we stop populate the
                             // ByteBuffer array. This is done as bsd/osx don't allow to write more bytes then
@@ -355,11 +376,10 @@ namespace DotNetty.Transport.Channels
                             // - http://linux.die.net/man/2/writev
                             break;
                         }
-                        nioBufferSize += readableBytes;
+                        ioBufferSize += readableBytes;
                         int count = entry.Count;
                         if (count == -1)
                         {
-                            //noinspection ConstantValueVariableUse
                             entry.Count = count = buf.IoBufferCount;
                         }
                         if (count == 1)
@@ -406,24 +426,9 @@ namespace DotNetty.Transport.Channels
                 }
                 entry = entry.Next;
             }
-            this.NioBufferSize = nioBufferSize;
+            this.nioBufferSize = ioBufferSize;
 
             return nioBuffers;
-        }
-
-        ///
-        ///Returns an array of direct NIO buffers if the currently pending messages are made of {@link ByteBuf} only.
-        ///{@link #nioBufferCount()} and {@link #nioBufferSize()} will return the number of NIO buffers in the returned
-        ///array and the total number of readable bytes of the NIO buffers respectively.
-        ///<p>
-        ///Note that the returned array is reused and thus should not escape
-        ///{@link AbstractChannel#doWrite(ChannelOutboundBuffer)}.
-        ///Refer to {@link NioSocketChannel#doWrite(ChannelOutboundBuffer)} for an example.
-        ///</p>
-        ///
-        public List<ArraySegment<byte>> GetSharedBufferList()
-        {
-            return this.GetSharedBufferList(int.MaxValue, int.MaxValue);
         }
 
         /**
@@ -431,7 +436,7 @@ namespace DotNetty.Transport.Channels
          * obtained via {@link #nioBuffers()}. This method <strong>MUST</strong> be called after {@link #nioBuffers()}
          * was called.
          */
-        public long NioBufferSize { get; private set; }
+        public long NioBufferSize => this.nioBufferSize;
 
         /// <summary>
         ///     Returns an array of direct NIO buffers if the currently pending messages are made of {@link ByteBuf} only.
@@ -556,7 +561,6 @@ namespace DotNetty.Transport.Channels
             IChannelPipeline pipeline = this.channel.Pipeline;
             if (invokeLater)
             {
-                // todo: allocation check
                 this.channel.EventLoop.Execute(p => ((IChannelPipeline)p).FireChannelWritabilityChanged(), pipeline);
             }
             else
@@ -568,7 +572,7 @@ namespace DotNetty.Transport.Channels
         /// <summary>
         ///     Returns the number of flushed messages in this {@link ChannelOutboundBuffer}.
         /// </summary>
-        public int Count => this.flushed;
+        public int Size => this.flushed;
 
         /// <summary>
         ///     Returns {@code true} if there are flushed messages in this {@link ChannelOutboundBuffer} or {@code false}
@@ -591,7 +595,7 @@ namespace DotNetty.Transport.Channels
             try
             {
                 this.inFail = true;
-                for (; ; )
+                for (;;)
                 {
                     if (!this.Remove0(cause, notify))
                     {
@@ -605,18 +609,33 @@ namespace DotNetty.Transport.Channels
             }
         }
 
-        internal void Close(ClosedChannelException cause)
+        sealed class CloseChannelTask : IRunnable
+        {
+            readonly ChannelOutboundBuffer buf;
+            readonly Exception cause;
+            readonly bool allowChannelOpen;
+
+            public CloseChannelTask(ChannelOutboundBuffer buf, Exception cause, bool allowChannelOpen)
+            {
+                this.buf = buf;
+                this.cause = cause;
+                this.allowChannelOpen = allowChannelOpen;
+            }
+
+            public void Run() => this.buf.Close(this.cause, this.allowChannelOpen);
+        }
+
+        internal void Close(Exception cause, bool allowChannelOpen)
         {
             if (this.inFail)
             {
-                this.channel.EventLoop.Execute((buf, ex) => ((ChannelOutboundBuffer)buf).Close((ClosedChannelException)ex),
-                    this, cause);
+                this.channel.EventLoop.Execute(new CloseChannelTask(this, cause, allowChannelOpen));
                 return;
             }
 
             this.inFail = true;
 
-            if (this.channel.Open)
+            if (!allowChannelOpen && this.channel.Open)
             {
                 throw new InvalidOperationException("close() must be invoked after the channel is closed.");
             }
@@ -639,6 +658,7 @@ namespace DotNetty.Transport.Channels
                     if (!e.Cancelled)
                     {
                         ReferenceCountUtil.SafeRelease(e.Message);
+                        SafeFail(e.Promise, cause);
                         Util.SafeSetFailure(e.Promise, cause, Logger);
                     }
                     e = e.RecycleAndGetNext();
@@ -651,7 +671,83 @@ namespace DotNetty.Transport.Channels
             this.ClearNioBuffers();
         }
 
+        internal void Close(ClosedChannelException cause) => this.Close(cause, false);
+
+        static void SafeSuccess(TaskCompletionSource promise)
+        {
+            // TODO:ChannelPromise
+            // Only log if the given promise is not of type VoidChannelPromise as trySuccess(...) is expected to return
+            // false.
+            Util.SafeSetSuccess(promise, Logger);
+        }
+
+        static void SafeFail(TaskCompletionSource promise, Exception cause)
+        {
+            // TODO:ChannelPromise
+            // Only log if the given promise is not of type VoidChannelPromise as tryFailure(...) is expected to return
+            // false.
+            Util.SafeSetFailure(promise, cause, Logger);
+        }
+
         public long TotalPendingWriteBytes() => Volatile.Read(ref this.totalPendingSize);
+
+        /**
+          * Get how many bytes can be written until {@link #isWritable()} returns {@code false}.
+          * This quantity will always be non-negative. If {@link #isWritable()} is {@code false} then 0.
+          */
+        public long BytesBeforeUnwritable()
+        {
+            long bytes = this.channel.Configuration.WriteBufferHighWaterMark - this.totalPendingSize;
+            // If bytes is negative we know we are not writable, but if bytes is non-negative we have to check writability.
+            // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
+            // together. totalPendingSize will be updated before isWritable().
+            if (bytes > 0)
+            {
+                return this.IsWritable ? bytes : 0;
+            }
+            return 0;
+        }
+
+        /**
+          * Get how many bytes must be drained from the underlying buffer until {@link #isWritable()} returns {@code true}.
+          * This quantity will always be non-negative. If {@link #isWritable()} is {@code true} then 0.
+          */
+        public long BytesBeforeWritable()
+        {
+            long bytes = this.totalPendingSize - this.channel.Configuration.WriteBufferLowWaterMark;
+            // If bytes is negative we know we are writable, but if bytes is non-negative we have to check writability.
+            // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
+            // together. totalPendingSize will be updated before isWritable().
+            if (bytes > 0)
+            {
+                return this.IsWritable ? 0 : bytes;
+            }
+            return 0;
+        }
+
+        public void ForEachFlushedMessage(IMessageProcessor processor)
+        {
+            Contract.Requires(processor != null);
+
+            Entry entry = this.flushedEntry;
+            if (entry == null)
+            {
+                return;
+            }
+
+            do
+            {
+                if (!entry.Cancelled)
+                {
+                    if (!processor.ProcessMessage(entry.Message))
+                    {
+                        return;
+                    }
+                }
+                entry = entry.Next;
+            }
+            while (this.IsFlushedEntry(entry));
+        }
 
         /// <summary>
         ///     Call {@link IMessageProcessor#processMessage(Object)} for each flushed message
@@ -659,6 +755,15 @@ namespace DotNetty.Transport.Channels
         ///     returns {@code false} or there are no more flushed messages to process.
         /// </summary>
         bool IsFlushedEntry(Entry e) => e != null && e != this.unflushedEntry;
+
+        public interface IMessageProcessor
+        {
+            /**
+             * Will be called for each flushed message until it either there are no more flushed messages or this
+             * method returns {@code false}.
+             */
+            bool ProcessMessage(object msg);
+        }
 
         sealed class Entry
         {

--- a/src/DotNetty.Transport/Channels/Sockets/DefaultSocketChannelConfiguration.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/DefaultSocketChannelConfiguration.cs
@@ -156,7 +156,7 @@ namespace DotNetty.Transport.Channels.Sockets
             }
         }
 
-        public int SendBufferSize
+        public virtual int SendBufferSize
         {
             get
             {

--- a/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
@@ -190,8 +190,7 @@ namespace DotNetty.Transport.Channels.Sockets
                 return -1; // prevents ObjectDisposedException from being thrown in case connection has been lost in the meantime
             }
 
-            SocketError errorCode;
-            int received = this.Socket.Receive(byteBuf.Array, byteBuf.ArrayOffset + byteBuf.WriterIndex, byteBuf.WritableBytes, SocketFlags.None, out errorCode);
+            int received = this.Socket.Receive(byteBuf.Array, byteBuf.ArrayOffset + byteBuf.WriterIndex, byteBuf.WritableBytes, SocketFlags.None, out SocketError errorCode);
 
             switch (errorCode)
             {
@@ -223,8 +222,7 @@ namespace DotNetty.Transport.Channels.Sockets
                 throw new NotImplementedException("Only IByteBuffer implementations backed by array are supported.");
             }
 
-            SocketError errorCode;
-            int sent = this.Socket.Send(buf.Array, buf.ArrayOffset + buf.ReaderIndex, buf.ReadableBytes, SocketFlags.None, out errorCode);
+            int sent = this.Socket.Send(buf.Array, buf.ArrayOffset + buf.ReaderIndex, buf.ReadableBytes, SocketFlags.None, out SocketError errorCode);
 
             if (errorCode != SocketError.Success && errorCode != SocketError.WouldBlock)
             {
@@ -252,7 +250,7 @@ namespace DotNetty.Transport.Channels.Sockets
             {
                 while (true)
                 {
-                    int size = input.Count;
+                    int size = input.Size;
                     if (size == 0)
                     {
                         // All written
@@ -262,7 +260,8 @@ namespace DotNetty.Transport.Channels.Sockets
                     bool done = false;
 
                     // Ensure the pending writes are made of ByteBufs only.
-                    sharedBufferList = input.GetSharedBufferList(1024);
+                    int maxBytesPerGatheringWrite = ((TcpSocketChannelConfig)this.config).GetMaxBytesPerGatheringWrite();
+                    sharedBufferList = input.GetSharedBufferList(1024, maxBytesPerGatheringWrite);
                     int nioBufferCnt = sharedBufferList.Count;
                     long expectedWrittenBytes = input.NioBufferSize;
                     Socket socket = this.Socket;
@@ -279,8 +278,7 @@ namespace DotNetty.Transport.Channels.Sockets
                         default:
                             for (int i = this.Configuration.WriteSpinCount - 1; i >= 0; i--)
                             {
-                                SocketError errorCode;
-                                long localWrittenBytes = socket.Send(bufferList, SocketFlags.None, out errorCode);
+                                long localWrittenBytes = socket.Send(bufferList, SocketFlags.None, out SocketError errorCode);
                                 if (errorCode != SocketError.Success && errorCode != SocketError.WouldBlock)
                                 {
                                     throw new SocketException((int)errorCode);
@@ -381,9 +379,34 @@ namespace DotNetty.Transport.Channels.Sockets
 
         sealed class TcpSocketChannelConfig : DefaultSocketChannelConfiguration
         {
+            volatile int maxBytesPerGatheringWrite = int.MaxValue;
+
             public TcpSocketChannelConfig(TcpSocketChannel channel, Socket javaSocket)
                 : base(channel, javaSocket)
             {
+                this.CalculateMaxBytesPerGatheringWrite();
+            }
+
+            public int GetMaxBytesPerGatheringWrite() => this.maxBytesPerGatheringWrite;
+
+            public override int SendBufferSize
+            {
+                get => base.SendBufferSize;
+                set
+                {
+                    base.SendBufferSize = value;
+                    this.CalculateMaxBytesPerGatheringWrite();
+                }
+            }
+
+            void CalculateMaxBytesPerGatheringWrite()
+            {
+                // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
+                int newSendBufferSize = this.SendBufferSize << 1;
+                if (newSendBufferSize > 0)
+                {
+                    this.maxBytesPerGatheringWrite = newSendBufferSize;
+                }
             }
 
             protected override void AutoReadCleared() => ((TcpSocketChannel)this.Channel).ClearReadPending();

--- a/test/DotNetty.Transport.Libuv.Tests/BufReleaseTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/BufReleaseTests.cs
@@ -117,6 +117,7 @@ namespace DotNetty.Transport.Libuv.Tests
                 Assert.True(this.writeTask.Wait(DefaultTimeout), "Write task timed out");
                 Assert.Equal(1, this.buf.ReferenceCount);
             }
+
             public void Release()
             {
                 this.buf.Release();

--- a/test/DotNetty.Transport.Libuv.Tests/EventLoopTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/EventLoopTests.cs
@@ -44,7 +44,7 @@ namespace DotNetty.Transport.Libuv.Tests
             {
                 if (Interlocked.Increment(ref this.count) >= this.expected)
                 {
-                    this.EndTime = DateTime.Now.Ticks;
+                    this.EndTime = DateTime.UtcNow.Ticks;
                     this.completionSource.TryComplete();
                 }
             }


### PR DESCRIPTION
Pending write buffers released before Libuv write callbacks.

Modifications:
According to Libuv documentation, write requests sent with uv_write will be queued. It is safe to reuse the uv_write_t object only after the callback passed to uv_write is fired.
Made Libuv tcp writes release buffers only after the write callback is called. Aslo avoid write buffer pin/unpin operations if the byte buffers to write already pinned.

Result:
Fix #348 and potentially reduced write pin/unpin operations.