### PR TITLE
Improve unittest and fix some leak

### DIFF
--- a/src/DotNetty.Handlers/Tls/ClientTlsSettings.cs
+++ b/src/DotNetty.Handlers/Tls/ClientTlsSettings.cs
@@ -10,8 +10,6 @@ namespace DotNetty.Handlers.Tls
 
     public sealed class ClientTlsSettings : TlsSettings
     {
-        IReadOnlyCollection<X509Certificate2> certificates;
-
         public ClientTlsSettings(string targetHost)
             : this(targetHost, new List<X509Certificate>())
         {

--- a/src/DotNetty.Handlers/Tls/SniHandler.cs
+++ b/src/DotNetty.Handlers/Tls/SniHandler.cs
@@ -28,7 +28,7 @@ namespace DotNetty.Handlers.Tls
         bool readPending;
 
         public SniHandler(ServerTlsSniSettings settings)
-            : this(stream => new SslStream(stream, true), settings)
+            : this(stream => new SslStream(stream, false), settings)
         {
         }
 

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -637,6 +637,10 @@ namespace DotNetty.Handlers.Tls
                 //    //Logger.Debug("{} SSLEngine.closeInbound() raised an exception.", ctx.channel(), e);
                 //}
             }
+            this.pendingSslStreamReadBuffer?.SafeRelease();
+            this.pendingSslStreamReadBuffer = null;
+            this.pendingSslStreamReadFuture = null;
+
             this.NotifyHandshakeFailure(cause);
             this.pendingUnencryptedWrites.RemoveAndFailAll(cause);
         }

--- a/src/DotNetty.Transport/Channels/Embedded/EmbeddedChannel.cs
+++ b/src/DotNetty.Transport/Channels/Embedded/EmbeddedChannel.cs
@@ -304,11 +304,8 @@ namespace DotNetty.Transport.Channels.Embedded
                     // The write may be delayed to run later by runPendingTasks()
                     future.ContinueWith(t => this.RecordException(t));
                 }
-                if (future.Exception != null)
-                {
-                    this.RecordException(future.Exception);
-                }
             }
+            futures.Return();
 
             this.RunPendingTasks();
             this.CheckException();

--- a/test/DotNetty.Buffers.Tests/AbstractByteBufferTests.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractByteBufferTests.cs
@@ -320,12 +320,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RandomShortAccess() => this.RandomShortAccess(true);
+        public void RandomShortAccess() => this.RandomShortAccess0(true);
 
         [Fact]
-        public void RandomShortLEAccess() => this.RandomShortAccess(false);
+        public void RandomShortLEAccess() => this.RandomShortAccess0(false);
 
-        void RandomShortAccess(bool testBigEndian)
+        void RandomShortAccess0(bool testBigEndian)
         {
             for (int i = 0; i < this.buffer.Capacity - 1; i += 2)
             {
@@ -356,12 +356,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RandomUnsignedShortAccess() => this.RandomUnsignedShortAccess(true);
+        public void RandomUnsignedShortAccess() => this.RandomUnsignedShortAccess0(true);
 
         [Fact]
-        public void RandomUnsignedShortLEAccess() => this.RandomUnsignedShortAccess(false);
+        public void RandomUnsignedShortLEAccess() => this.RandomUnsignedShortAccess0(false);
 
-        void RandomUnsignedShortAccess(bool testBigEndian)
+        void RandomUnsignedShortAccess0(bool testBigEndian)
         {
             for (int i = 0; i < this.buffer.Capacity - 1; i += 2)
             {
@@ -392,12 +392,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RandomMediumAccess() => this.RandomMediumAccess(true);
+        public void RandomMediumAccess() => this.RandomMediumAccess0(true);
 
         [Fact]
-        public void RandomMediumLEAccess() => this.RandomMediumAccess(false);
+        public void RandomMediumLEAccess() => this.RandomMediumAccess0(false);
 
-        public void RandomMediumAccess(bool testBigEndian)
+        public void RandomMediumAccess0(bool testBigEndian)
         {
             for (int i = 0; i < this.buffer.Capacity - 2; i += 3)
             {
@@ -428,12 +428,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RandomUnsignedMediumAccess() => this.RandomUnsignedMediumAccess(true);
+        public void RandomUnsignedMediumAccess() => this.RandomUnsignedMediumAccess0(true);
 
         [Fact]
-        public void RandomUnsignedMediumLEAccess() => this.RandomUnsignedMediumAccess(false);
+        public void RandomUnsignedMediumLEAccess() => this.RandomUnsignedMediumAccess0(false);
 
-        public void RandomUnsignedMediumAccess(bool testBigEndian)
+        public void RandomUnsignedMediumAccess0(bool testBigEndian)
         {
             for (int i = 0; i < this.buffer.Capacity - 2; i += 3)
             {
@@ -464,12 +464,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RandomIntAccess() => this.RandomIntAccess(true);
+        public void RandomIntAccess() => this.RandomIntAccess0(true);
 
         [Fact]
-        public void RandomIntLEAccess() => this.RandomIntAccess(false);
+        public void RandomIntLEAccess() => this.RandomIntAccess0(false);
 
-        void RandomIntAccess(bool testBigEndian)
+        void RandomIntAccess0(bool testBigEndian)
         {
             for (int i = 0; i < this.buffer.Capacity - 3; i += 4)
             {
@@ -500,12 +500,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RandomUnsignedIntAccess() => this.RandomUnsignedIntAccess(true);
+        public void RandomUnsignedIntAccess() => this.RandomUnsignedIntAccess0(true);
 
         [Fact]
-        public void RandomUnsignedIntLEAccess() => this.RandomUnsignedIntAccess(false);
+        public void RandomUnsignedIntLEAccess() => this.RandomUnsignedIntAccess0(false);
 
-        void RandomUnsignedIntAccess(bool testBigEndian)
+        void RandomUnsignedIntAccess0(bool testBigEndian)
         {
             for (int i = 0; i < this.buffer.Capacity - 3; i += 4)
             {
@@ -536,12 +536,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RandomLongAccess() => this.RandomLongAccess(true);
+        public void RandomLongAccess() => this.RandomLongAccess0(true);
 
         [Fact]
-        public void RandomLongLEAccess() => this.RandomLongAccess(false);
+        public void RandomLongLEAccess() => this.RandomLongAccess0(false);
 
-        void RandomLongAccess(bool testBigEndian)
+        void RandomLongAccess0(bool testBigEndian)
         {
             for (int i = 0; i < this.buffer.Capacity - 7; i += 8)
             {
@@ -659,12 +659,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void SequentialShortAccess() => this.SequentialShortAccess(true);
+        public void SequentialShortAccess() => this.SequentialShortAccess0(true);
 
         [Fact]
-        public void SequentialShortLEAccess() => this.SequentialShortAccess(false);
+        public void SequentialShortLEAccess() => this.SequentialShortAccess0(false);
 
-        void SequentialShortAccess(bool testBigEndian)
+        void SequentialShortAccess0(bool testBigEndian)
         {
             this.buffer.SetWriterIndex(0);
             for (int i = 0; i < this.buffer.Capacity; i += 2)
@@ -709,12 +709,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void SequentialUnsignedShortAccess() => this.SequentialUnsignedShortAccess(true);
+        public void SequentialUnsignedShortAccess() => this.SequentialUnsignedShortAccess0(true);
 
         [Fact]
-        public void SequentialUnsignedShortLEAccess() => this.SequentialUnsignedShortAccess(true);
+        public void SequentialUnsignedShortLEAccess() => this.SequentialUnsignedShortAccess0(true);
 
-        void SequentialUnsignedShortAccess(bool testBigEndian)
+        void SequentialUnsignedShortAccess0(bool testBigEndian)
         {
             this.buffer.SetWriterIndex(0);
             for (int i = 0; i < this.buffer.Capacity; i += 2)
@@ -759,12 +759,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void SequentialMediumAccess() => this.SequentialMediumAccess(true);
+        public void SequentialMediumAccess() => this.SequentialMediumAccess0(true);
 
         [Fact]
-        public void SequentialMediumLEAccess() => this.SequentialMediumAccess(false);
+        public void SequentialMediumLEAccess() => this.SequentialMediumAccess0(false);
 
-        void SequentialMediumAccess(bool testBigEndian)
+        void SequentialMediumAccess0(bool testBigEndian)
         {
             this.buffer.SetWriterIndex(0);
             for (int i = 0; i < this.buffer.Capacity / 3 * 3; i += 3)
@@ -808,12 +808,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void SequentialUnsignedMediumAccess() => this.SequentialUnsignedMediumAccess(true);
+        public void SequentialUnsignedMediumAccess() => this.SequentialUnsignedMediumAccess0(true);
 
         [Fact]
-        public void SequentialUnsignedMediumLEAccess() => this.SequentialUnsignedMediumAccess(false);
+        public void SequentialUnsignedMediumLEAccess() => this.SequentialUnsignedMediumAccess0(false);
 
-        void SequentialUnsignedMediumAccess(bool testBigEndian)
+        void SequentialUnsignedMediumAccess0(bool testBigEndian)
         {
             this.buffer.SetWriterIndex(0);
             for (int i = 0; i < this.buffer.Capacity / 3 * 3; i += 3)
@@ -857,12 +857,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void SequentialIntAccess() => this.SequentialIntAccess(true);
+        public void SequentialIntAccess() => this.SequentialIntAccess0(true);
 
         [Fact]
-        public void SequentialIntLEAccess() => this.SequentialIntAccess(false);
+        public void SequentialIntLEAccess() => this.SequentialIntAccess0(false);
 
-        void SequentialIntAccess(bool testBigEndian)
+        void SequentialIntAccess0(bool testBigEndian)
         {
             this.buffer.SetWriterIndex(0);
             for (int i = 0; i < this.buffer.Capacity; i += 4)
@@ -907,12 +907,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void SequentialUnsignedIntAccess() => this.SequentialUnsignedIntAccess(true);
+        public void SequentialUnsignedIntAccess() => this.SequentialUnsignedIntAccess0(true);
 
         [Fact]
-        public void SequentialUnsignedIntLEAccess() => this.SequentialUnsignedIntAccess(false);
+        public void SequentialUnsignedIntLEAccess() => this.SequentialUnsignedIntAccess0(false);
 
-        void SequentialUnsignedIntAccess(bool testBigEndian)
+        void SequentialUnsignedIntAccess0(bool testBigEndian)
         {
             this.buffer.SetWriterIndex(0);
             for (int i = 0; i < this.buffer.Capacity; i += 4)
@@ -957,12 +957,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void SequentialLongAccess() => this.SequentialLongAccess(true);
+        public void SequentialLongAccess() => this.SequentialLongAccess0(true);
 
         [Fact]
-        public void SequentialLongLEAccess() => this.SequentialLongAccess(false);
+        public void SequentialLongLEAccess() => this.SequentialLongAccess0(false);
 
-        void SequentialLongAccess(bool testBigEndian)
+        void SequentialLongAccess0(bool testBigEndian)
         {
             this.buffer.SetWriterIndex(0);
             for (int i = 0; i < this.buffer.Capacity; i += 8)
@@ -1784,7 +1784,7 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void TestEquals()
         {
             Assert.False(this.buffer.Equals(null));
             Assert.False(this.buffer.Equals(new object()));
@@ -2466,12 +2466,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void ReadSliceOutOfBounds() => Assert.Throws<IndexOutOfRangeException>(() => this.ReadSliceOutOfBounds(false));
+        public void ReadSliceOutOfBounds() => Assert.Throws<IndexOutOfRangeException>(() => this.ReadSliceOutOfBounds0(false));
 
         [Fact]
-        public void ReadRetainedSliceOutOfBounds() => Assert.Throws<IndexOutOfRangeException>(() => this.ReadSliceOutOfBounds(true));
+        public void ReadRetainedSliceOutOfBounds() => Assert.Throws<IndexOutOfRangeException>(() => this.ReadSliceOutOfBounds0(true));
 
-        void ReadSliceOutOfBounds(bool retainedSlice)
+        void ReadSliceOutOfBounds0(bool retainedSlice)
         {
             IByteBuffer buf = this.NewBuffer(100);
             try
@@ -2636,7 +2636,7 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void RetainedSliceContents() => this.SliceContents(true);
+        public void RetainedSliceContents() => this.SliceContents0(true);
 
         [Fact]
         public void MultipleLevelRetainedSlice1() => this.MultipleLevelRetainedSliceWithNonRetained(true, true);
@@ -2699,27 +2699,27 @@ namespace DotNetty.Buffers.Tests
         public void MultipleRetainedDuplicateReleaseOriginal4() => this.MultipleRetainedDuplicateReleaseOriginal(false, false);
 
         [Fact]
-        public void SliceContents() => this.SliceContents(false);
+        public void SliceContents() => this.SliceContents0(false);
 
         [Fact]
-        public void RetainedDuplicateContents() => this.DuplicateContents(true);
+        public void RetainedDuplicateContents() => this.DuplicateContents0(true);
 
         [Fact]
-        public void DuplicateContents() => this.DuplicateContents(false);
+        public void DuplicateContents() => this.DuplicateContents0(false);
 
         [Fact]
-        public virtual void DuplicateCapacityChange() => this.DuplicateCapacityChange(false);
+        public virtual void DuplicateCapacityChange() => this.DuplicateCapacityChange0(false);
 
         [Fact]
-        public virtual void RetainedDuplicateCapacityChange() => this.DuplicateCapacityChange(true);
+        public virtual void RetainedDuplicateCapacityChange() => this.DuplicateCapacityChange0(true);
 
         [Fact]
-        public void SliceCapacityChange() => Assert.Throws<NotSupportedException>(() => this.SliceCapacityChange(false));
+        public void SliceCapacityChange() => Assert.Throws<NotSupportedException>(() => this.SliceCapacityChange0(false));
 
         [Fact]
-        public void RetainedSliceCapacityChange() => Assert.Throws<NotSupportedException>(() => this.SliceCapacityChange(true));
+        public void RetainedSliceCapacityChange() => Assert.Throws<NotSupportedException>(() => this.SliceCapacityChange0(true));
 
-        void DuplicateCapacityChange(bool retainedDuplicate)
+        void DuplicateCapacityChange0(bool retainedDuplicate)
         {
             IByteBuffer buf = this.NewBuffer(8);
             IByteBuffer dup = retainedDuplicate ? buf.RetainedDuplicate() : buf.Duplicate();
@@ -2740,7 +2740,7 @@ namespace DotNetty.Buffers.Tests
             }
         }
 
-        void SliceCapacityChange(bool retainedSlice)
+        void SliceCapacityChange0(bool retainedSlice)
         {
             IByteBuffer buf = this.NewBuffer(8);
             IByteBuffer slice = retainedSlice ? buf.RetainedSlice(buf.ReaderIndex + 1, 3)
@@ -2790,7 +2790,7 @@ namespace DotNetty.Buffers.Tests
             }
         }
 
-        void SliceContents(bool retainedSlice)
+        void SliceContents0(bool retainedSlice)
         {
             IByteBuffer buf = this.NewBuffer(8).ResetWriterIndex();
             IByteBuffer expected = this.NewBuffer(3).ResetWriterIndex();
@@ -3055,7 +3055,7 @@ namespace DotNetty.Buffers.Tests
             Assert.Equal(0, dup3.ReferenceCount);
         }
 
-        void DuplicateContents(bool retainedDuplicate)
+        void DuplicateContents0(bool retainedDuplicate)
         {
             IByteBuffer buf = this.NewBuffer(8).ResetWriterIndex();
             buf.WriteBytes(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });

--- a/test/DotNetty.Buffers.Tests/AbstractCompositeByteBufferTests.cs
+++ b/test/DotNetty.Buffers.Tests/AbstractCompositeByteBufferTests.cs
@@ -812,12 +812,12 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void AllocatorIsSameWhenCopy() => this.AllocatorIsSameWhenCopy(false);
+        public void AllocatorIsSameWhenCopy() => this.AllocatorIsSameWhenCopy0(false);
 
         [Fact]
-        public void AllocatorIsSameWhenCopyUsingIndexAndLength() => this.AllocatorIsSameWhenCopy(true);
+        public void AllocatorIsSameWhenCopyUsingIndexAndLength() => this.AllocatorIsSameWhenCopy0(true);
 
-        void AllocatorIsSameWhenCopy(bool withIndexAndLength)
+        void AllocatorIsSameWhenCopy0(bool withIndexAndLength)
         {
             IByteBuffer buffer = this.NewBuffer(8);
             buffer.WriteZero(4);

--- a/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
+++ b/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
@@ -6,22 +6,12 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj" />

--- a/test/DotNetty.Buffers.Tests/PooledByteBufferAllocatorTests.cs
+++ b/test/DotNetty.Buffers.Tests/PooledByteBufferAllocatorTests.cs
@@ -138,16 +138,16 @@ namespace DotNetty.Buffers.Tests
         {
             var allocator = new PooledByteBufferAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
             // Huge allocation
-            AllocNotNull(allocator, allocator.Metric.ChunkSize + 1);
+            AllocNotNull0(allocator, allocator.Metric.ChunkSize + 1);
             // Normal allocation
-            AllocNotNull(allocator, 1024);
+            AllocNotNull0(allocator, 1024);
             // Small allocation
-            AllocNotNull(allocator, 512);
+            AllocNotNull0(allocator, 512);
             // Tiny allocation
-            AllocNotNull(allocator, 1);
+            AllocNotNull0(allocator, 1);
         }
 
-        static void AllocNotNull(PooledByteBufferAllocator allocator, int capacity)
+        static void AllocNotNull0(PooledByteBufferAllocator allocator, int capacity)
         {
             IByteBuffer buffer = allocator.HeapBuffer(capacity);
             Assert.NotNull(buffer.Allocator);

--- a/test/DotNetty.Buffers.Tests/UnpooledTests.cs
+++ b/test/DotNetty.Buffers.Tests/UnpooledTests.cs
@@ -93,7 +93,7 @@ namespace DotNetty.Buffers.Tests
         }
 
         [Fact]
-        public void Equals()
+        public void TestEquals()
         {
             // Different length.
             IByteBuffer a = WrappedBuffer(new byte[] { 1 });

--- a/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
+++ b/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
@@ -6,22 +6,12 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
+++ b/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
@@ -6,22 +6,12 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Protobuf.Tests/RoundTripTests.cs
+++ b/test/DotNetty.Codecs.Protobuf.Tests/RoundTripTests.cs
@@ -13,7 +13,7 @@ namespace DotNetty.Codecs.Protobuf.Tests
 
     public class RoundTripTests
     {
-        static IEnumerable<object[]> GetAddressBookCases()
+        public static IEnumerable<object[]> GetAddressBookCases()
         {
             var person = new Person
             {

--- a/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
+++ b/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
@@ -5,22 +5,12 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.ProtocolBuffers.Tests/RoundTripTests.cs
+++ b/test/DotNetty.Codecs.ProtocolBuffers.Tests/RoundTripTests.cs
@@ -13,7 +13,7 @@ namespace DotNetty.Codecs.ProtocolBuffers.Tests
 
     public class RoundTripTests
     {
-        static IEnumerable<object[]> GetAddressBookCases()
+        public static IEnumerable<object[]> GetAddressBookCases()
         {
             Person.Builder personBuilder = Person.CreateBuilder();
             personBuilder.SetId(1);

--- a/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
+++ b/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
@@ -6,22 +6,12 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
+++ b/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
@@ -6,22 +6,12 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Tests/Protobuf/ProtobufVarint32LengthFieldPrependerTests.cs
+++ b/test/DotNetty.Codecs.Tests/Protobuf/ProtobufVarint32LengthFieldPrependerTests.cs
@@ -162,7 +162,7 @@ namespace DotNetty.Codecs.Tests.Protobuf
 
         static readonly object[][] EncodeVarint32SizeCases = GetVarint32Data().ToArray();
 
-        static IEnumerable<object[]> GetVarint32DataAliases()
+        public static IEnumerable<object[]> GetVarint32DataAliases()
         {
             return Enumerable.Range(0, EncodeVarint32SizeCases.Length).Select(i => new object[] { i });
         }

--- a/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
+++ b/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
@@ -6,22 +6,13 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Common.Tests/ThreadLocalPoolTest.cs
+++ b/test/DotNetty.Common.Tests/ThreadLocalPoolTest.cs
@@ -74,15 +74,15 @@ namespace DotNetty.Common.Tests
         [Fact]
         public void MaxCapacityTest()
         {
-            this.MaxCapacityTest(300);
+            this.MaxCapacityTest0(300);
             var rand = new Random();
             for (int i = 0; i < 50; i++)
             {
-                this.MaxCapacityTest(rand.Next(1000) + 256); // 256 - 1256
+                this.MaxCapacityTest0(rand.Next(1000) + 256); // 256 - 1256
             }
         }
 
-        void MaxCapacityTest(int maxCapacity)
+        void MaxCapacityTest0(int maxCapacity)
         {
             var recycler = new ThreadLocalPool<HandledObject>(handle => new HandledObject(handle), maxCapacity);
 

--- a/test/DotNetty.Handlers.Tests/BatchingWriteStrategy.cs
+++ b/test/DotNetty.Handlers.Tests/BatchingWriteStrategy.cs
@@ -79,7 +79,7 @@ namespace DotNetty.Handlers.Tests
                     {
                         this.channel.WriteInbound(this.pendingBuffer.ReadBytes(this.maxBatchSize));
                     }
-                    while (this.pendingBuffer.ReadableBytes > this.maxBatchSize);
+                    while (this.pendingBuffer.ReadableBytes >= this.maxBatchSize);
                     if (!this.pendingBuffer.IsReadable())
                     {
                         this.pendingBuffer = null;
@@ -116,6 +116,6 @@ namespace DotNetty.Handlers.Tests
             }
         }
 
-        public override string ToString() => $"batch({this.maxBatchSize}, {this.timeWindow})";
+        public override string ToString() => $"batch({this.maxBatchSize}, {this.timeWindow}, {this.forceSizing})";
     }
 }

--- a/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
+++ b/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
@@ -6,22 +6,12 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Handlers.Tests/MediationStream.cs
+++ b/test/DotNetty.Handlers.Tests/MediationStream.cs
@@ -12,11 +12,13 @@ namespace DotNetty.Handlers.Tests
     {
         readonly Func<ArraySegment<byte>, Task<int>> readDataFunc;
         readonly Func<ArraySegment<byte>, Task> writeDataFunc;
+        readonly Action disposeFunc;
 
-        public MediationStream(Func<ArraySegment<byte>, Task<int>> readDataFunc, Func<ArraySegment<byte>, Task> writeDataFunc)
+        public MediationStream(Func<ArraySegment<byte>, Task<int>> readDataFunc, Func<ArraySegment<byte>, Task> writeDataFunc, Action disposeFunc = null)
         {
             this.readDataFunc = readDataFunc;
             this.writeDataFunc = writeDataFunc;
+            this.disposeFunc = disposeFunc;
         }
 
         public override void Flush()
@@ -68,6 +70,15 @@ namespace DotNetty.Handlers.Tests
 
         public override void EndWrite(IAsyncResult asyncResult) => ((Task<int>)asyncResult).Wait();
 #endif
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (disposing)
+            {
+                disposeFunc?.Invoke();
+            }
+        }
 
         public override int Read(byte[] buffer, int offset, int count)
         {

--- a/test/DotNetty.Handlers.Tests/SniHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/SniHandlerTest.cs
@@ -217,7 +217,7 @@ namespace DotNetty.Handlers.Tests
 
                 if (readResultBuffer.ReadableBytes < output.Count)
                 {
-                    await ReadOutboundAsync(async () => ch.ReadOutbound<IByteBuffer>(), output.Count - readResultBuffer.ReadableBytes, readResultBuffer, TestTimeout);
+                    await ReadOutboundAsync(async () => ch.ReadOutbound<IByteBuffer>(), 1, readResultBuffer, TestTimeout);
                 }
                 Assert.NotEqual(0, readResultBuffer.ReadableBytes);
                 int read = Math.Min(output.Count, readResultBuffer.ReadableBytes);

--- a/test/DotNetty.Handlers.Tests/SniHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/SniHandlerTest.cs
@@ -194,7 +194,7 @@ namespace DotNetty.Handlers.Tests
                 {
                     Assert.Equal(targetHost, certificate.Issuer.Replace("CN=", string.Empty));
                     return true;
-                }), new ClientTlsSettings(SslProtocols.Tls12, false, new List<X509Certificate>(), targetHost)) :
+                }), new ClientTlsSettings(protocol, false, new List<X509Certificate>(), targetHost)) :
                 new SniHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), new ServerTlsSniSettings(CertificateSelector));
             //var ch = new EmbeddedChannel(new LoggingHandler("BEFORE"), tlsHandler, new LoggingHandler("AFTER"));
             var ch = new EmbeddedChannel(tlsHandler);
@@ -234,7 +234,8 @@ namespace DotNetty.Handlers.Tests
             var driverStream = new SslStream(mediationStream, true, (_1, _2, _3, _4) => true);
             if (isClient)
             {
-                await Task.Run(() => driverStream.AuthenticateAsServerAsync(CertificateSelector(targetHost).Result.Certificate).WithTimeout(TimeSpan.FromSeconds(5)));
+                ServerTlsSettings serverTlsSettings = CertificateSelector(targetHost).Result;
+                await Task.Run(() => driverStream.AuthenticateAsServerAsync(serverTlsSettings.Certificate, false, protocol | serverTlsSettings.EnabledProtocols, false).WithTimeout(TimeSpan.FromSeconds(5)));
             }
             else
             {

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -45,7 +45,14 @@ namespace DotNetty.Handlers.Tests
                     Enumerable.Repeat(0, 30).Select(_ => random.Next(0, 17000)).ToArray()
                 };
             var boolToggle = new[] { false, true };
-            var protocols = new[] { SslProtocols.Tls, SslProtocols.Tls11, SslProtocols.Tls12 };
+            var protocols = new[]
+            {
+                Tuple.Create(SslProtocols.Tls, SslProtocols.Tls),
+                Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11),
+                Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12),
+                Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls, SslProtocols.Tls12 | SslProtocols.Tls11),
+                Tuple.Create(SslProtocols.Tls | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11)
+            };
             var writeStrategyFactories = new Func<IWriteStrategy>[]
             {
                 () => new AsIsWriteStrategy(),
@@ -59,24 +66,25 @@ namespace DotNetty.Handlers.Tests
                 from isClient in boolToggle
                 from writeStrategyFactory in writeStrategyFactories
                 from protocol in protocols
-                select new object[] { frameLengths, isClient, writeStrategyFactory(), protocol };
+                select new object[] { frameLengths, isClient, writeStrategyFactory(), protocol.Item1, protocol.Item2 };
         }
 
 
         [Theory]
         [MemberData(nameof(GetTlsReadTestData))]
-        public async Task TlsRead(int[] frameLengths, bool isClient, IWriteStrategy writeStrategy, SslProtocols protocol)
+        public async Task TlsRead(int[] frameLengths, bool isClient, IWriteStrategy writeStrategy, SslProtocols serverProtocol, SslProtocols clientProtocol)
         {
             this.Output.WriteLine($"frameLengths: {string.Join(", ", frameLengths)}");
             this.Output.WriteLine($"writeStrategy: {writeStrategy}");
-            this.Output.WriteLine($"protocol: {protocol}");
+            this.Output.WriteLine($"serverProtocol: {serverProtocol}");
+            this.Output.WriteLine($"clientProtocol: {clientProtocol}");
 
             var executor = new SingleThreadEventExecutor("test executor", TimeSpan.FromMilliseconds(10));
 
             try
             {
                 var writeTasks = new List<Task>();
-                var pair = await SetupStreamAndChannelAsync(isClient, executor, writeStrategy, protocol, writeTasks).WithTimeout(TimeSpan.FromSeconds(10));
+                var pair = await SetupStreamAndChannelAsync(isClient, executor, writeStrategy, serverProtocol, clientProtocol, writeTasks).WithTimeout(TimeSpan.FromSeconds(10));
                 EmbeddedChannel ch = pair.Item1;
                 SslStream driverStream = pair.Item2;
 
@@ -95,6 +103,7 @@ namespace DotNetty.Handlers.Tests
                 await ReadOutboundAsync(async () => ch.ReadInbound<IByteBuffer>(), expectedBuffer.ReadableBytes, finalReadBuffer, TestTimeout);
                 Assert.True(ByteBufferUtil.Equals(expectedBuffer, finalReadBuffer), $"---Expected:\n{ByteBufferUtil.PrettyHexDump(expectedBuffer)}\n---Actual:\n{ByteBufferUtil.PrettyHexDump(finalReadBuffer)}");
                 driverStream.Dispose();
+                Assert.False(ch.Finish());
             }
             finally
             {
@@ -118,18 +127,25 @@ namespace DotNetty.Handlers.Tests
                     Enumerable.Repeat(0, 30).Select(_ => random.Next(0, 10) < 2 ? -1 : random.Next(0, 17000)).ToArray()
                 };
             var boolToggle = new[] { false, true };
-            var protocols = new[] { SslProtocols.Tls, SslProtocols.Tls11, SslProtocols.Tls12 };
+            var protocols = new[]
+            {
+                Tuple.Create(SslProtocols.Tls, SslProtocols.Tls),
+                Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11),
+                Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12),
+                Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls, SslProtocols.Tls12 | SslProtocols.Tls11),
+                Tuple.Create(SslProtocols.Tls | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11)
+            };
 
             return
                 from frameLengths in lengthVariations
                 from isClient in boolToggle
                 from protocol in protocols
-                select new object[] { frameLengths, isClient, protocol };
+                select new object[] { frameLengths, isClient, protocol.Item1, protocol.Item2 };
         }
 
         [Theory]
         [MemberData(nameof(GetTlsWriteTestData))]
-        public async Task TlsWrite(int[] frameLengths, bool isClient, SslProtocols protocol)
+        public async Task TlsWrite(int[] frameLengths, bool isClient, SslProtocols serverProtocol, SslProtocols clientProtocol)
         {
             this.Output.WriteLine("frameLengths: " + string.Join(", ", frameLengths));
 
@@ -140,7 +156,7 @@ namespace DotNetty.Handlers.Tests
             try
             {
                 var writeTasks = new List<Task>();
-                var pair = await SetupStreamAndChannelAsync(isClient, executor, writeStrategy, protocol, writeTasks);
+                var pair = await SetupStreamAndChannelAsync(isClient, executor, writeStrategy, serverProtocol, clientProtocol, writeTasks);
                 EmbeddedChannel ch = pair.Item1;
                 SslStream driverStream = pair.Item2;
 
@@ -169,6 +185,7 @@ namespace DotNetty.Handlers.Tests
                     expectedBuffer.ReadableBytes, finalReadBuffer, TestTimeout);
                 Assert.True(ByteBufferUtil.Equals(expectedBuffer, finalReadBuffer), $"---Expected:\n{ByteBufferUtil.PrettyHexDump(expectedBuffer)}\n---Actual:\n{ByteBufferUtil.PrettyHexDump(finalReadBuffer)}");
                 driverStream.Dispose();
+                Assert.False(ch.Finish());
             }
             finally
             {
@@ -176,13 +193,13 @@ namespace DotNetty.Handlers.Tests
             }
         }
 
-        static async Task<Tuple<EmbeddedChannel, SslStream>> SetupStreamAndChannelAsync(bool isClient, IEventExecutor executor, IWriteStrategy writeStrategy, SslProtocols protocol, List<Task> writeTasks)
+        static async Task<Tuple<EmbeddedChannel, SslStream>> SetupStreamAndChannelAsync(bool isClient, IEventExecutor executor, IWriteStrategy writeStrategy, SslProtocols serverProtocol, SslProtocols clientProtocol, List<Task> writeTasks)
         {
             X509Certificate2 tlsCertificate = TestResourceHelper.GetTestCertificate();
             string targetHost = tlsCertificate.GetNameInfo(X509NameType.DnsName, false);
             TlsHandler tlsHandler = isClient ?
-                new TlsHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), new ClientTlsSettings(protocol, false, new List<X509Certificate>(), targetHost)) :
-                new TlsHandler(new ServerTlsSettings(tlsCertificate, false, false, protocol));
+                new TlsHandler(stream => new SslStream(stream, true, (sender, certificate, chain, errors) => true), new ClientTlsSettings(clientProtocol, false, new List<X509Certificate>(), targetHost)) :
+                new TlsHandler(new ServerTlsSettings(tlsCertificate, false, false, serverProtocol));
             //var ch = new EmbeddedChannel(new LoggingHandler("BEFORE"), tlsHandler, new LoggingHandler("AFTER"));
             var ch = new EmbeddedChannel(tlsHandler);
 
@@ -197,7 +214,7 @@ namespace DotNetty.Handlers.Tests
 
                 if (readResultBuffer.ReadableBytes < output.Count)
                 {
-                    await ReadOutboundAsync(async () => ch.ReadOutbound<IByteBuffer>(), 1, readResultBuffer, TestTimeout);
+                    await ReadOutboundAsync(async () => ch.ReadOutbound<IByteBuffer>(), output.Count - readResultBuffer.ReadableBytes, readResultBuffer, TestTimeout, readResultBuffer.ReadableBytes != 0 ? 0 : 1);
                 }
                 Assert.NotEqual(0, readResultBuffer.ReadableBytes);
                 int read = Math.Min(output.Count, readResultBuffer.ReadableBytes);
@@ -214,21 +231,23 @@ namespace DotNetty.Handlers.Tests
             var driverStream = new SslStream(mediationStream, true, (_1, _2, _3, _4) => true);
             if (isClient)
             {
-                await Task.Run(() => driverStream.AuthenticateAsServerAsync(tlsCertificate, false, protocol, false)).WithTimeout(TimeSpan.FromSeconds(5));
+                await Task.Run(() => driverStream.AuthenticateAsServerAsync(tlsCertificate, false, serverProtocol, false)).WithTimeout(TimeSpan.FromSeconds(5));
             }
             else
             {
-                await Task.Run(() => driverStream.AuthenticateAsClientAsync(targetHost, null, protocol, false)).WithTimeout(TimeSpan.FromSeconds(5));
+                await Task.Run(() => driverStream.AuthenticateAsClientAsync(targetHost, null, clientProtocol, false)).WithTimeout(TimeSpan.FromSeconds(5));
             }
             writeTasks.Clear();
 
             return Tuple.Create(ch, driverStream);
         }
 
-        static Task ReadOutboundAsync(Func<Task<IByteBuffer>> readFunc, int expectedBytes, IByteBuffer result, TimeSpan timeout)
+        static Task ReadOutboundAsync(Func<Task<IByteBuffer>> readFunc, int expectedBytes, IByteBuffer result, TimeSpan timeout, int minBytes = -1)
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
             int remaining = expectedBytes;
+            if (minBytes < 0) minBytes = expectedBytes;
+            if (minBytes > expectedBytes) throw new ArgumentOutOfRangeException("minBytes can not greater than expectedBytes");
             return AssertEx.EventuallyAsync(
                 async () =>
                 {
@@ -238,13 +257,22 @@ namespace DotNetty.Handlers.Tests
                         return false;
                     }
 
-                    IByteBuffer output = await readFunc().WithTimeout(readTimeout);//inbound ? ch.ReadInbound<IByteBuffer>() : ch.ReadOutbound<IByteBuffer>();
-                    if (output != null)
+                    IByteBuffer output;
+                    while(true)
                     {
+                        output = await readFunc().WithTimeout(readTimeout);//inbound ? ch.ReadInbound<IByteBuffer>() : ch.ReadOutbound<IByteBuffer>();
+                        if (output == null)
+                            break;
+
                         remaining -= output.ReadableBytes;
+                        minBytes -= output.ReadableBytes;
                         result.WriteBytes(output);
+                        output.Release();
+
+                        if (remaining <= 0)
+                            return true;
                     }
-                    return remaining <= 0;
+                    return minBytes <= 0;
                 },
                 TimeSpan.FromMilliseconds(10),
                 timeout);

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -295,6 +295,7 @@ namespace DotNetty.Handlers.Tests
            Assert.False(ch.Configuration.AutoRead);
            Assert.True(ch.WriteOutbound(Unpooled.Empty));
            Assert.True(readHandler.ReadIssued);
+           ch.CloseAsync();
         }
 
         class ReadRegisterHandler : ChannelHandlerAdapter

--- a/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
+++ b/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
@@ -10,19 +10,11 @@
     <EmbeddedResource Include="..\..\shared\dotnetty.com.pfx" />
     <EmbeddedResource Include="..\..\shared\contoso.com.pfx" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -6,19 +6,11 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj" />

--- a/test/DotNetty.Transport.Libuv.Tests/AutoReadTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/AutoReadTests.cs
@@ -38,10 +38,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            this.AutoReadOffDuringReadOnlyReadsOneTime(readOutsideEventLoopThread, sb, cb);
+            this.AutoReadOffDuringReadOnlyReadsOneTime0(readOutsideEventLoopThread, sb, cb);
         }
 
-        void AutoReadOffDuringReadOnlyReadsOneTime(bool readOutsideEventLoopThread, ServerBootstrap sb, Bootstrap cb)
+        void AutoReadOffDuringReadOnlyReadsOneTime0(bool readOutsideEventLoopThread, ServerBootstrap sb, Bootstrap cb)
         {
             var serverInitializer = new AutoReadInitializer(!readOutsideEventLoopThread);
             var clientInitializer = new AutoReadInitializer(!readOutsideEventLoopThread);

--- a/test/DotNetty.Transport.Libuv.Tests/BufReleaseTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/BufReleaseTests.cs
@@ -35,10 +35,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            this.BufRelease(sb, cb);
+            this.BufRelease0(sb, cb);
         }
 
-        void BufRelease(ServerBootstrap sb, Bootstrap cb)
+        void BufRelease0(ServerBootstrap sb, Bootstrap cb)
         {
             var serverHandler = new BufWriterHandler();
             var clientHandler = new BufWriterHandler();

--- a/test/DotNetty.Transport.Libuv.Tests/CloseForciblyTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/CloseForciblyTests.cs
@@ -33,10 +33,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            this.CloseForcibly(sb, cb);
+            this.CloseForcibly0(sb, cb);
         }
 
-        void CloseForcibly(ServerBootstrap sb, Bootstrap cb)
+        void CloseForcibly0(ServerBootstrap sb, Bootstrap cb)
         {
             sb.Handler(new InboundHandler())
               .ChildHandler(new ChannelHandlerAdapter());

--- a/test/DotNetty.Transport.Libuv.Tests/CompositeBufferGatheringWriteTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/CompositeBufferGatheringWriteTests.cs
@@ -38,10 +38,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            this.SingleCompositeBufferWrite(sb, cb);
+            this.SingleCompositeBufferWrite0(sb, cb);
         }
 
-        void SingleCompositeBufferWrite(ServerBootstrap sb, Bootstrap cb)
+        void SingleCompositeBufferWrite0(ServerBootstrap sb, Bootstrap cb)
         {
             sb.ChildHandler(new ActionChannelInitializer<TcpChannel>(channel =>
             {

--- a/test/DotNetty.Transport.Libuv.Tests/ConnectionAttemptTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/ConnectionAttemptTests.cs
@@ -32,10 +32,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            ConnectTimeout(cb);
+            ConnectTimeout0(cb);
         }
 
-        static void ConnectTimeout(Bootstrap cb)
+        static void ConnectTimeout0(Bootstrap cb)
         {
             var handler = new TestHandler();
             cb.Handler(handler)
@@ -58,10 +58,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            ConnectRefused(cb);
+            ConnectRefused0(cb);
         }
 
-        static void ConnectRefused(Bootstrap cb)
+        static void ConnectRefused0(Bootstrap cb)
         {
             var handler = new TestHandler();
             cb.Handler(handler);

--- a/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
+++ b/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
@@ -9,16 +9,11 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Transport.Libuv.Tests/ExceptionHandlingTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/ExceptionHandlingTests.cs
@@ -37,10 +37,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            this.ReadPendingIsResetAfterEachRead(sb, cb);
+            this.ReadPendingIsResetAfterEachRead0(sb, cb);
         }
 
-        void ReadPendingIsResetAfterEachRead(ServerBootstrap sb, Bootstrap cb)
+        void ReadPendingIsResetAfterEachRead0(ServerBootstrap sb, Bootstrap cb)
         {
             var serverInitializer = new MyInitializer();
             sb.Option(ChannelOption.SoBacklog, 1024);

--- a/test/DotNetty.Transport.Libuv.Tests/ReadPendingTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/ReadPendingTests.cs
@@ -37,10 +37,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            this.ReadPendingIsResetAfterEachRead(sb, cb);
+            this.ReadPendingIsResetAfterEachRead0(sb, cb);
         }
 
-        void ReadPendingIsResetAfterEachRead(ServerBootstrap sb, Bootstrap cb)
+        void ReadPendingIsResetAfterEachRead0(ServerBootstrap sb, Bootstrap cb)
         {
             var serverInitializer = new ReadPendingInitializer();
             sb.Option(ChannelOption.SoBacklog, 1024)

--- a/test/DotNetty.Transport.Libuv.Tests/WriteBeforeRegisteredTests.cs
+++ b/test/DotNetty.Transport.Libuv.Tests/WriteBeforeRegisteredTests.cs
@@ -29,10 +29,10 @@ namespace DotNetty.Transport.Libuv.Tests
             Bootstrap cb = new Bootstrap()
                 .Group(this.group)
                 .Channel<TcpChannel>();
-            this.WriteBeforeConnect(cb);
+            this.WriteBeforeConnect0(cb);
         }
 
-        void WriteBeforeConnect(Bootstrap cb)
+        void WriteBeforeConnect0(Bootstrap cb)
         {
             var h = new TestHandler();
             cb.Handler(h);

--- a/test/DotNetty.Transport.Tests/Channel/Sockets/SocketDatagramChannelMulticastTest.cs
+++ b/test/DotNetty.Transport.Tests/Channel/Sockets/SocketDatagramChannelMulticastTest.cs
@@ -77,7 +77,7 @@ namespace DotNetty.Transport.Tests.Channel.Sockets
             }
         }
 
-        static IEnumerable<object[]> GetData()
+        public static IEnumerable<object[]> GetData()
         {
             foreach (AddressFamily addressFamily in NetUtil.AddressFamilyTypes)
             {

--- a/test/DotNetty.Transport.Tests/Channel/Sockets/SocketDatagramChannelUnicastTest.cs
+++ b/test/DotNetty.Transport.Tests/Channel/Sockets/SocketDatagramChannelUnicastTest.cs
@@ -90,7 +90,7 @@ namespace DotNetty.Transport.Tests.Channel.Sockets
         static readonly byte[] Data = { 0, 1, 2, 3 };
         static readonly bool[] BindClientOption = { true, false };
 
-        static IEnumerable<object[]> GetData()
+        public static IEnumerable<object[]> GetData()
         {
             foreach (AddressFamily addressFamily in NetUtil.AddressFamilyTypes)
             {

--- a/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
+++ b/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
@@ -6,22 +6,12 @@
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.99" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />


### PR DESCRIPTION
1. Fix #353, SniHandlerTest timeout in `net452` and `netcoreapp2.1(preview)`.
2. Fix that test for TlsHandlerTest.NoAutoReadHandshakeProgresses never finish in `netcoreapp2.0` and `2.1(preview)`
3. Fix some leak on TlsHandler and EmbeddedChannel.
4. Update xunit from `2.2.0` to `2.3.1`. That greatly improve the test speed of DotNetty.Buffers.Tests in net452.