### PR TITLE
Better inline AbstractByteBuffer.CheckIndex0

### DIFF
--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -1330,7 +1330,7 @@ namespace DotNetty.Buffers
         {
             if (MathUtil.IsOutOfBounds(index, fieldLength, this.Capacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"index: {index}, length: {fieldLength} (expected: range(0, {this.Capacity}))");
+                ThrowHelper.ThrowIndexOutOfRangeException("index: {0}, length: {1} (expected: range(0, {2}))", index, fieldLength, this.Capacity);
             }
         }
 
@@ -1340,7 +1340,7 @@ namespace DotNetty.Buffers
             this.CheckIndex(index, length);
             if (MathUtil.IsOutOfBounds(srcIndex, length, srcCapacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"srcIndex: {srcIndex}, length: {length} (expected: range(0, {srcCapacity}))");
+                ThrowHelper.ThrowIndexOutOfRangeException("srcIndex: {0}, length: {1} (expected: range(0, {2}))", srcIndex, length, srcCapacity);
             }
         }
 
@@ -1350,7 +1350,7 @@ namespace DotNetty.Buffers
             this.CheckIndex(index, length);
             if (MathUtil.IsOutOfBounds(dstIndex, length, dstCapacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"dstIndex: {dstIndex}, length: {length} (expected: range(0, {dstCapacity}))");
+                ThrowHelper.ThrowIndexOutOfRangeException("dstIndex: {0}, length: {1} (expected: range(0, {2}))", dstIndex, length, dstCapacity);
             }
         }
 

--- a/src/DotNetty.Buffers/ThrowHelper.cs
+++ b/src/DotNetty.Buffers/ThrowHelper.cs
@@ -9,6 +9,8 @@ namespace DotNetty.Buffers
     {
         public static void ThrowIndexOutOfRangeException(string message) => throw new IndexOutOfRangeException(message);
 
+        public static void ThrowIndexOutOfRangeException(string format, int index, int length, int capacity) => throw new IndexOutOfRangeException(string.Format(format, index, length, capacity));
+
         public static void ThrowIllegalReferenceCountException(int count = 0) => throw new IllegalReferenceCountException(count);
 
         public static void ThrowArgumentNullException(string message) => throw new ArgumentNullException(message);


### PR DESCRIPTION
That make `Get/Set` about 50% faster in netcoreapp/netfx(RyuJIT only, the old JIT is not tested), and almost the same as it used to be in mono.

Not sure the extra reason, maybe it's too long to be inlined.