### PR TITLE
InliningDiagnoser/Unsafe unaligned.

### DIFF
--- a/src/DotNetty.Buffers/AbstractByteBuffer.cs
+++ b/src/DotNetty.Buffers/AbstractByteBuffer.cs
@@ -72,7 +72,7 @@ namespace DotNetty.Buffers
         {
             if (index < 0 || index > this.writerIndex)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"ReaderIndex: {index} (expected: 0 <= readerIndex <= writerIndex({this.WriterIndex})");
+                ThrowHelper.ThrowIndexOutOfRangeException_ReaderIndex(index, this.WriterIndex);
             }
 
             this.readerIndex = index;
@@ -85,7 +85,7 @@ namespace DotNetty.Buffers
         {
             if (index < this.readerIndex || index > this.Capacity)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"WriterIndex: {index} (expected: 0 <= readerIndex({this.readerIndex}) <= writerIndex <= capacity ({this.Capacity})");
+                ThrowHelper.ThrowIndexOutOfRangeException_WriterIndex(index, this.readerIndex, this.Capacity);
             }
 
             this.SetWriterIndex0(index);
@@ -101,7 +101,7 @@ namespace DotNetty.Buffers
         {
             if (readerIdx < 0 || readerIdx > writerIdx || writerIdx > this.Capacity)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"ReaderIndex: {readerIdx}, WriterIndex: {writerIdx} (expected: 0 <= readerIndex <= writerIndex <= capacity ({this.Capacity})");
+                ThrowHelper.ThrowIndexOutOfRangeException_ReaderWriterIndex(readerIdx, writerIdx, this.Capacity);
             }
 
             this.SetIndex0(readerIdx, writerIdx);
@@ -235,7 +235,7 @@ namespace DotNetty.Buffers
         {
             if (minWritableBytes < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(minWritableBytes), "expected minWritableBytes to be greater than zero");
+                ThrowHelper.ThrowArgumentOutOfRangeException_MinWritableBytes();
             }
 
             this.EnsureWritable0(minWritableBytes);
@@ -253,7 +253,7 @@ namespace DotNetty.Buffers
 
             if (minWritableBytes > this.MaxCapacity - this.writerIndex)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"writerIndex({this.writerIndex}) + minWritableBytes({minWritableBytes}) exceeds maxCapacity({this.MaxCapacity}): {this}");
+                ThrowHelper.ThrowIndexOutOfRangeException_WriterIndex(minWritableBytes, this.writerIndex, this.MaxCapacity, this);
             }
 
             // Normalize the current capacity to the power of 2.
@@ -648,7 +648,7 @@ namespace DotNetty.Buffers
             this.CheckIndex(index, length);
             if (length > src.ReadableBytes)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"length({length}) exceeds src.readableBytes({src.ReadableBytes}) where src is: {src}");
+                ThrowHelper.ThrowIndexOutOfRangeException_ReadableBytes(length, src);
             }
             this.SetBytes(index, src, src.ReaderIndex, length);
             src.SetReaderIndex(src.ReaderIndex + length);
@@ -937,7 +937,7 @@ namespace DotNetty.Buffers
         {
             if (length > dst.WritableBytes)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"length({length}) exceeds destination.WritableBytes({dst.WritableBytes}) where destination is: {dst}");
+                ThrowHelper.ThrowIndexOutOfRangeException_WritableBytes(length, dst);
             }
             this.ReadBytes(dst, dst.WriterIndex, length);
             dst.SetWriterIndex(dst.WriterIndex + length);
@@ -1106,7 +1106,7 @@ namespace DotNetty.Buffers
         {
             if (length > src.ReadableBytes)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"length({length}) exceeds src.readableBytes({src.ReadableBytes}) where src is: {src}");
+                ThrowHelper.ThrowIndexOutOfRangeException_ReadableBytes(length, src);
             }
             this.WriteBytes(src, src.ReaderIndex, length);
             src.SetReaderIndex(src.ReaderIndex + length);
@@ -1330,7 +1330,7 @@ namespace DotNetty.Buffers
         {
             if (MathUtil.IsOutOfBounds(index, fieldLength, this.Capacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"index: {index}, length: {fieldLength} (expected: range(0, {this.Capacity}))");
+                ThrowHelper.ThrowIndexOutOfRangeException_Index(index, fieldLength, this.Capacity);
             }
         }
 
@@ -1340,7 +1340,7 @@ namespace DotNetty.Buffers
             this.CheckIndex(index, length);
             if (MathUtil.IsOutOfBounds(srcIndex, length, srcCapacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"srcIndex: {srcIndex}, length: {length} (expected: range(0, {srcCapacity}))");
+                ThrowHelper.ThrowIndexOutOfRangeException_SrcIndex(srcIndex, length, srcCapacity);
             }
         }
 
@@ -1350,7 +1350,7 @@ namespace DotNetty.Buffers
             this.CheckIndex(index, length);
             if (MathUtil.IsOutOfBounds(dstIndex, length, dstCapacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"dstIndex: {dstIndex}, length: {length} (expected: range(0, {dstCapacity}))");
+                ThrowHelper.ThrowIndexOutOfRangeException_DstIndex(dstIndex, length, dstCapacity);
             }
         }
 
@@ -1358,7 +1358,7 @@ namespace DotNetty.Buffers
         {
             if (minimumReadableBytes < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(minimumReadableBytes), $"minimumReadableBytes: {minimumReadableBytes} (expected: >= 0)");
+                ThrowHelper.ThrowArgumentOutOfRangeException_MinimumReadableBytes(minimumReadableBytes);
             }
 
             this.CheckReadableBytes0(minimumReadableBytes);
@@ -1369,7 +1369,7 @@ namespace DotNetty.Buffers
             this.EnsureAccessible();
             if (newCapacity < 0 || newCapacity > this.MaxCapacity)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(newCapacity), $"newCapacity: {newCapacity} (expected: 0-{this.MaxCapacity})");
+                ThrowHelper.ThrowArgumentOutOfRangeException_Capacity(newCapacity, this.MaxCapacity);
             }
         }
 
@@ -1379,7 +1379,7 @@ namespace DotNetty.Buffers
             this.EnsureAccessible();
             if (this.readerIndex > this.writerIndex - minimumReadableBytes)
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"readerIndex({this.readerIndex}) + length({minimumReadableBytes}) exceeds writerIndex({this.writerIndex}): {this}");
+                ThrowHelper.ThrowIndexOutOfRangeException_ReaderIndex(minimumReadableBytes, this.readerIndex, this.writerIndex, this);
             }
         }
 
@@ -1388,7 +1388,7 @@ namespace DotNetty.Buffers
         {
             if (CheckAccessible && this.ReferenceCount == 0)
             {
-                ThrowHelper.ThrowIllegalReferenceCountException();
+                ThrowHelper.ThrowIllegalReferenceCountException(0);
             }
         }
 

--- a/src/DotNetty.Buffers/AbstractByteBufferAllocator.cs
+++ b/src/DotNetty.Buffers/AbstractByteBufferAllocator.cs
@@ -148,12 +148,12 @@ namespace DotNetty.Buffers
         {
             if (initialCapacity < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(initialCapacity), "initialCapacity must be greater than zero");
+                ThrowHelper.ThrowArgumentOutOfRangeException_InitialCapacity();
             }
 
             if (initialCapacity > maxCapacity)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(initialCapacity), $"initialCapacity ({initialCapacity}) must be greater than maxCapacity ({maxCapacity})");
+                ThrowHelper.ThrowArgumentOutOfRangeException_InitialCapacity(initialCapacity, maxCapacity);
             }
         }
 
@@ -167,11 +167,11 @@ namespace DotNetty.Buffers
         {
             if (minNewCapacity < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(minNewCapacity), $"minNewCapacity: {minNewCapacity} (expected: 0+)");
+                ThrowHelper.ThrowArgumentOutOfRangeException_MinNewCapacity(minNewCapacity);
             }
             if (minNewCapacity > maxCapacity)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(maxCapacity), $"minNewCapacity: {minNewCapacity} (expected: not greater than maxCapacity({maxCapacity})");
+                ThrowHelper.ThrowArgumentOutOfRangeException_MaxCapacity(minNewCapacity, maxCapacity);
             }
 
             const int Threshold = CalculateThreshold; // 4 MiB page

--- a/src/DotNetty.Buffers/ThrowHelper.cs
+++ b/src/DotNetty.Buffers/ThrowHelper.cs
@@ -1,18 +1,234 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// ReSharper disable UseStringInterpolation
+// ReSharper disable UseNameofExpression
+// ReSharper disable NotResolvedInText
 namespace DotNetty.Buffers
 {
     using System;
+    using System.Runtime.CompilerServices;
 
     static class ThrowHelper
     {
-        public static void ThrowIndexOutOfRangeException(string message) => throw new IndexOutOfRangeException(message);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_Index(int index, int length, int capacity)
+        {
+            throw GetIndexOutOfRangeException();
 
-        public static void ThrowIllegalReferenceCountException(int count = 0) => throw new IllegalReferenceCountException(count);
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("index: {0}, length: {1} (expected: range(0, {2}))", index, length, capacity));
+            }
+        }
 
-        public static void ThrowArgumentNullException(string message) => throw new ArgumentNullException(message);
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_SrcIndex(int srcIndex)
+        {
+            throw GetIndexOutOfRangeException();
 
-        public static void ThrowArgumentOutOfRangeException(string name, string message) => throw new ArgumentOutOfRangeException(name, message);
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("srcIndex: {0}", srcIndex));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_SrcIndex(int srcIndex, int length, int srcCapacity)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("srcIndex: {0}, length: {1} (expected: range(0, {2}))", srcIndex, length, srcCapacity));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_DstIndex(int dstIndex)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("dstIndex: {0}", dstIndex));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_DstIndex(int dstIndex, int length,  int dstCapacity)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("dstIndex: {0}, length: {1} (expected: range(0, {2}))", dstIndex, length, dstCapacity));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_ReaderIndex(int index, int writerIndex)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("ReaderIndex: {0} (expected: 0 <= readerIndex <= writerIndex({1})", index, writerIndex));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_ReaderIndex(int minimumReadableBytes, int readerIndex, int writerIndex, AbstractByteBuffer buf)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("readerIndex({0}) + length({1}) exceeds writerIndex({2}): {3}", readerIndex, minimumReadableBytes, writerIndex, buf));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_WriterIndex(int index, int readerIndex, int capacity)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("WriterIndex: {0} (expected: 0 <= readerIndex({1}) <= writerIndex <= capacity ({2})", index, readerIndex, capacity));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_WriterIndex(int minWritableBytes, int writerIndex, int maxCapacity, AbstractByteBuffer buf)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format($"writerIndex({0}) + minWritableBytes({1}) exceeds maxCapacity({2}): {3}", writerIndex, minWritableBytes, maxCapacity, buf));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_ReaderWriterIndex(int readerIndex, int writerIndex, int capacity)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("ReaderIndex: {0}, WriterIndex: {1} (expected: 0 <= readerIndex <= writerIndex <= capacity ({2})", readerIndex, writerIndex, capacity));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_ReadableBytes(int length, IByteBuffer src)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("length({0}) exceeds src.readableBytes({1}) where src is: {2}", length, src.ReadableBytes, src));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIndexOutOfRangeException_WritableBytes(int length, IByteBuffer dst)
+        {
+            throw GetIndexOutOfRangeException();
+
+            IndexOutOfRangeException GetIndexOutOfRangeException()
+            {
+                return new IndexOutOfRangeException(string.Format("length({0}) exceeds destination.WritableBytes({1}) where destination is: {2}", length, dst.WritableBytes, dst));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowIllegalReferenceCountException(int count)
+        {
+            throw GetIllegalReferenceCountException();
+
+            IllegalReferenceCountException GetIllegalReferenceCountException()
+            {
+                return new IllegalReferenceCountException(count);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowArgumentOutOfRangeException_MinimumReadableBytes(int minimumReadableBytes)
+        {
+            throw GetArgumentOutOfRangeException();
+
+            ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+            {
+                return new ArgumentOutOfRangeException("minimumReadableBytes", string.Format("minimumReadableBytes: {0} (expected: >= 0)", minimumReadableBytes));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowArgumentOutOfRangeException_InitialCapacity()
+        {
+            throw GetArgumentOutOfRangeException();
+
+            ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+            {
+                return new ArgumentOutOfRangeException("initialCapacity", "initialCapacity must be greater than zero");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowArgumentOutOfRangeException_InitialCapacity(int initialCapacity, int maxCapacity)
+        {
+            throw GetArgumentOutOfRangeException();
+
+            ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+            {
+                return new ArgumentOutOfRangeException("initialCapacity", string.Format("initialCapacity ({0}) must be greater than maxCapacity ({1})", initialCapacity, maxCapacity));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowArgumentOutOfRangeException_MinWritableBytes()
+        {
+            throw GetArgumentOutOfRangeException();
+
+            ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+            {
+                return new ArgumentOutOfRangeException("minWritableBytes", "expected minWritableBytes to be greater than zero");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowArgumentOutOfRangeException_MinNewCapacity(int minNewCapacity)
+        {
+            throw GetArgumentOutOfRangeException();
+
+            ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+            {
+                return new ArgumentOutOfRangeException("minNewCapacity", string.Format("minNewCapacity: {0} (expected: 0+)", minNewCapacity));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowArgumentOutOfRangeException_MaxCapacity(int minNewCapacity, int maxCapacity)
+        {
+            throw GetArgumentOutOfRangeException();
+
+            ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+            {
+                return new ArgumentOutOfRangeException("maxCapacity", string.Format("minNewCapacity: {0} (expected: not greater than maxCapacity({1})", minNewCapacity, maxCapacity));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void ThrowArgumentOutOfRangeException_Capacity(int newCapacity, int maxCapacity)
+        {
+            throw GetArgumentOutOfRangeException();
+
+            ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+            {
+                return new ArgumentOutOfRangeException("newCapacity", string.Format($"newCapacity: {0} (expected: 0-{1})", newCapacity, maxCapacity));
+            }
+        }
     }
 }

--- a/src/DotNetty.Buffers/UnsafeByteBufferUtil .cs
+++ b/src/DotNetty.Buffers/UnsafeByteBufferUtil .cs
@@ -239,7 +239,7 @@ namespace DotNetty.Buffers
 
             if (MathUtil.IsOutOfBounds(dstIndex, length, dst.Capacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"dstIndex: {dstIndex}");
+                ThrowHelper.ThrowIndexOutOfRangeException_DstIndex(dstIndex);
             }
 
             if (dst.HasMemoryAddress)
@@ -273,7 +273,7 @@ namespace DotNetty.Buffers
 
             if (MathUtil.IsOutOfBounds(dstIndex, length, dst.Length))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"dstIndex: {dstIndex}");
+                ThrowHelper.ThrowIndexOutOfRangeException_DstIndex(dstIndex);
             }
             if (length != 0)
             {
@@ -287,7 +287,7 @@ namespace DotNetty.Buffers
 
             if (MathUtil.IsOutOfBounds(srcIndex, length, src.Capacity))
             {
-                ThrowHelper.ThrowIndexOutOfRangeException($"srcIndex: {srcIndex}");
+                ThrowHelper.ThrowIndexOutOfRangeException_SrcIndex(srcIndex);
             }
 
             if (length != 0)

--- a/src/DotNetty.Common/Internal/PlatformDependent.cs
+++ b/src/DotNetty.Common/Internal/PlatformDependent.cs
@@ -49,13 +49,11 @@ namespace DotNetty.Common.Internal
                     return PlatformDependent0.ByteArrayEquals(array1, startPos1, array2, startPos2, length);
         }
 
-        public static unsafe void CopyMemory(byte[] src, int srcIndex, byte[] dst, int dstIndex, int length)
+        public static void CopyMemory(byte[] src, int srcIndex, byte[] dst, int dstIndex, int length)
         {
             if (length > 0)
             {
-                fixed (byte* source = &src[srcIndex])
-                    fixed (byte* destination = &dst[dstIndex])
-                        Unsafe.CopyBlock(destination, source, unchecked((uint)length));
+                Unsafe.CopyBlockUnaligned(ref dst[dstIndex], ref src[srcIndex], unchecked((uint)length));
             }
         }
 
@@ -63,7 +61,7 @@ namespace DotNetty.Common.Internal
         {
             if (length > 0)
             {
-                Unsafe.CopyBlock(dst, src, unchecked((uint)length));
+                Unsafe.CopyBlockUnaligned(dst, src, unchecked((uint)length));
             }
         }
 
@@ -72,7 +70,7 @@ namespace DotNetty.Common.Internal
             if (length > 0)
             {
                 fixed (byte* destination = &dst[dstIndex])
-                    Unsafe.CopyBlock(destination, src, unchecked((uint)length));
+                    Unsafe.CopyBlockUnaligned(destination, src, unchecked((uint)length));
             }
         }
 
@@ -81,16 +79,15 @@ namespace DotNetty.Common.Internal
             if (length > 0)
             {
                 fixed (byte* source = &src[srcIndex])
-                    Unsafe.CopyBlock(dst, source, unchecked((uint)length));
+                    Unsafe.CopyBlockUnaligned(dst, source, unchecked((uint)length));
             }
         }
 
-        public static unsafe void Clear(byte[] src, int srcIndex, int length)
+        public static void Clear(byte[] src, int srcIndex, int length)
         {
             if (length > 0)
             {
-                fixed (void* source = &src[srcIndex])
-                    Unsafe.InitBlock(source, default(byte), unchecked((uint)length));
+                Unsafe.InitBlockUnaligned(ref src[srcIndex], default(byte), unchecked((uint)length));
             }
         }
 
@@ -98,16 +95,15 @@ namespace DotNetty.Common.Internal
         {
             if (length > 0)
             {
-                Unsafe.InitBlock(src, value, unchecked((uint)length));
+                Unsafe.InitBlockUnaligned(src, value, unchecked((uint)length));
             }
         }
 
-        public static unsafe void SetMemory(byte[] src, int srcIndex, int length, byte value)
+        public static void SetMemory(byte[] src, int srcIndex, int length, byte value)
         {
             if (length > 0)
             {
-                fixed (byte* source = &src[srcIndex])
-                    Unsafe.InitBlock(source, value, unchecked((uint)length));
+                Unsafe.InitBlockUnaligned(ref src[srcIndex], value, unchecked((uint)length));
             }
         }
     }

--- a/src/DotNetty.Common/Internal/PlatformDependent0.cs
+++ b/src/DotNetty.Common/Internal/PlatformDependent0.cs
@@ -21,7 +21,7 @@ namespace DotNetty.Common.Internal
             byte* end = baseOffset1 + remainingBytes;
             for (byte* i = baseOffset1 - 8 + length, j = baseOffset2 - 8 + length; i >= end; i -= 8, j -= 8)
             {
-                if (Unsafe.Read<long>(i) != Unsafe.Read<long>(j))
+                if (Unsafe.ReadUnaligned<long>(i) != Unsafe.ReadUnaligned<long>(j))
                 {
                     return false;
                 }
@@ -30,14 +30,14 @@ namespace DotNetty.Common.Internal
             if (remainingBytes >= 4)
             {
                 remainingBytes -= 4;
-                if (Unsafe.Read<int>(baseOffset1 + remainingBytes) != Unsafe.Read<int>(baseOffset2 + remainingBytes))
+                if (Unsafe.ReadUnaligned<int>(baseOffset1 + remainingBytes) != Unsafe.ReadUnaligned<int>(baseOffset2 + remainingBytes))
                 {
                     return false;
                 }
             }
             if (remainingBytes >= 2)
             {
-                return Unsafe.Read<short>(baseOffset1) == Unsafe.Read<short>(baseOffset2) 
+                return Unsafe.ReadUnaligned<short>(baseOffset1) == Unsafe.ReadUnaligned<short>(baseOffset2) 
                     && (remainingBytes == 2 || *(bytes1 + startPos1 + 2) == *(bytes2 + startPos2 + 2));
             }
             return *baseOffset1 == *baseOffset2;

--- a/test/DotNetty.Microbench/Buffers/ByteBufferBenchmark.cs
+++ b/test/DotNetty.Microbench/Buffers/ByteBufferBenchmark.cs
@@ -8,8 +8,16 @@ namespace DotNetty.Microbench.Buffers
     using BenchmarkDotNet.Attributes.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
+#if NET46
+    using BenchmarkDotNet.Diagnostics.Windows.Configs;
+#endif
 
+#if !NET46
     [CoreJob]
+#else
+    [ClrJob]
+    [InliningDiagnoser]
+#endif
     [BenchmarkCategory("ByteBuffer")]
     public class ByteBufferBenchmark
     {

--- a/test/DotNetty.Microbench/Buffers/PooledByteBufferBenchmark.cs
+++ b/test/DotNetty.Microbench/Buffers/PooledByteBufferBenchmark.cs
@@ -7,8 +7,16 @@ namespace DotNetty.Microbench.Buffers
     using BenchmarkDotNet.Attributes.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
+#if NET46
+    using BenchmarkDotNet.Diagnostics.Windows.Configs;
+#endif
 
+#if !NET46
     [CoreJob]
+#else
+    [ClrJob]
+    [InliningDiagnoser]
+#endif
     [BenchmarkCategory("ByteBuffer")]
     public class PooledByteBufferBenchmark
     {

--- a/test/DotNetty.Microbench/Buffers/UnpooledByteBufferBenchmark.cs
+++ b/test/DotNetty.Microbench/Buffers/UnpooledByteBufferBenchmark.cs
@@ -7,8 +7,16 @@ namespace DotNetty.Microbench.Buffers
     using BenchmarkDotNet.Attributes.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
+#if NET46
+    using BenchmarkDotNet.Diagnostics.Windows.Configs;
+#endif
 
+#if !NET46
     [CoreJob]
+#else
+    [ClrJob]
+    [InliningDiagnoser]
+#endif
     [BenchmarkCategory("ByteBuffer")]
     public class UnpooledByteBufferBenchmark
     {

--- a/test/DotNetty.Microbench/DotNetty.Microbench.csproj
+++ b/test/DotNetty.Microbench/DotNetty.Microbench.csproj
@@ -2,13 +2,20 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
+    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.13" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.13" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />


### PR DESCRIPTION
#371 Unsafe unaligned
#380 ThrowHelper
Added BenchmarkDotNet InliningDiagnoser
@yyjdelete I have changed all ThrowHelper not to do ldstr, you can test it out.
