### PR TITLE
Fix DiskFileUpload

### DIFF
--- a/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
@@ -179,7 +179,6 @@ namespace DotNetty.Codecs.Http.Multipart
                 this.fileStream = null;
                 throw new IOException($"Out of size: {this.Size} > {this.DefinedSize}");
             }
-            this.isRenamed = true;
             this.SetCompleted();
         }
 

--- a/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
@@ -16,6 +16,7 @@ namespace DotNetty.Codecs.Http.Multipart
     {
         static readonly IInternalLogger Logger = InternalLoggerFactory.GetInstance<AbstractDiskHttpData>();
 
+        bool isRenamed;
         FileStream fileStream;
 
         protected AbstractDiskHttpData(string name, Encoding charset, long size) : base(name, charset, size)
@@ -178,24 +179,27 @@ namespace DotNetty.Codecs.Http.Multipart
                 this.fileStream = null;
                 throw new IOException($"Out of size: {this.Size} > {this.DefinedSize}");
             }
-            //isRenamed = true;
+            this.isRenamed = true;
             this.SetCompleted();
         }
 
         public override void Delete()
         {
-            if (this.fileStream != null)
+            if (!this.isRenamed)
             {
-                try
+                if (this.fileStream != null)
                 {
-                    Delete(this.fileStream);
-                }
-                catch (IOException error)
-                {
-                    Logger.Warn("Failed to delete file.", error);
-                }
+                    try
+                    {
+                        Delete(this.fileStream);
+                    }
+                    catch (IOException error)
+                    {
+                        Logger.Warn("Failed to delete file.", error);
+                    }
 
-                this.fileStream = null;
+                    this.fileStream = null;
+                }
             }
         }
 
@@ -300,6 +304,7 @@ namespace DotNetty.Codecs.Http.Multipart
                     Logger.Warn("Failed to delete file.", exception);
                 }
                 this.fileStream = destination;
+                this.isRenamed = true;
                 return true;
             }
             else

--- a/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
@@ -271,27 +271,9 @@ namespace DotNetty.Codecs.Http.Multipart
                 throw new InvalidOperationException("No file defined so cannot be renamed");
             }
 
-            // must copy
-            long chunkSize = 8196;
-            int position = 0;
-            while (position < this.Size)
-            {
-                if (chunkSize < this.Size - position)
-                {
-                    chunkSize = this.Size - position;
-                }
+            this.fileStream.CopyTo(destination, 8196);
 
-                var buffer = new byte[chunkSize];
-                int read = this.fileStream.Read(buffer, 0, (int)chunkSize);
-                if (read <= 0)
-                {
-                    break;
-                }
-
-                destination.Write(buffer, 0, read);
-                position += read;
-            }
-
+            long position = this.fileStream.Position;
             if (position == this.Size)
             {
                 try

--- a/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
@@ -109,7 +109,7 @@ namespace DotNetty.Codecs.Http.Multipart
                     buffer.SetReaderIndex(buffer.ReaderIndex + localsize);
                     this.fileStream.Flush();
 
-                    this.Size += buffer.ReadableBytes;
+                    this.Size += localsize;
                 }
                 finally
                 {
@@ -124,6 +124,7 @@ namespace DotNetty.Codecs.Http.Multipart
                 {
                     this.fileStream = this.TempFile();
                 }
+                this.fileStream.Position = 0;
                 this.SetCompleted();
             }
             else

--- a/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
+++ b/src/DotNetty.Codecs.Http/Multipart/AbstractDiskHttpData.cs
@@ -78,6 +78,7 @@ namespace DotNetty.Codecs.Http.Multipart
                 buffer.GetBytes(buffer.ReaderIndex, this.fileStream, buffer.ReadableBytes);
                 buffer.SetReaderIndex(buffer.ReaderIndex + buffer.ReadableBytes);
                 this.fileStream.Flush();
+                this.fileStream.Position = 0;
                 this.SetCompleted();
             }
             finally


### PR DESCRIPTION
Fixed disk attributes 519f2d7
We should be reset stream position, otherwise DiskAttribute.Value property produces empty array as string.
Similar problem for disk files 34c9a1e
818208b After using RenameTo we don't want that file will be removed when decoder starts cleanup.