### PR TITLE
Convert javadoc to C# xmldoc in the DotNetty.Common project

### DIFF
--- a/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
@@ -147,10 +147,11 @@ namespace DotNetty.Common.Concurrency
                 this.Execute(WAKEUP_TASK);
             }
         }
-        
-        /**
-          * Add a {@link Runnable} which will be executed on shutdown of this instance
-          */
+
+        /// <summary>
+        /// Adds an <see cref="Action"/> which will be executed on shutdown of this instance.
+        /// </summary>
+        /// <param name="action">The <see cref="Action"/> to run on shutdown.</param>
         public void AddShutdownHook(Action action) 
         {
             if (this.InEventLoop) 
@@ -163,9 +164,11 @@ namespace DotNetty.Common.Concurrency
             }
         }
 
-        /**
-         * Remove a previous added {@link Runnable} as a shutdown hook
-         */
+        /// <summary>
+        /// Removes a previously added <see cref="Action"/> from the collection of <see cref="Action"/>s which will be
+        /// executed on shutdown of this instance.
+        /// </summary>
+        /// <param name="action">The <see cref="Action"/> to remove.</param>
         public void RemoveShutdownHook(Action action) 
         {
             if (this.InEventLoop) 

--- a/src/DotNetty.Common/FastThreadLocal.cs
+++ b/src/DotNetty.Common/FastThreadLocal.cs
@@ -11,7 +11,7 @@ namespace DotNetty.Common
         static readonly int VariablesToRemoveIndex = InternalThreadLocalMap.NextVariableIndex();
 
         /// <summary>
-        ///     Removes all {@link FastThreadLocal} variables bound to the current thread.  This operation is useful when you
+        ///     Removes all <see cref="FastThreadLocal"/> variables bound to the current thread.  This operation is useful when you
         ///     are in a container environment, and you don't want to leave the thread local variables in the threads you do not
         ///     manage.
         /// </summary>
@@ -41,10 +41,12 @@ namespace DotNetty.Common
             }
         }
 
-        /// Destroys the data structure that keeps all {@link FastThreadLocal} variables accessed from
-        /// non-{@link FastThreadLocalThread}s.  This operation is useful when you are in a container environment, and you
-        /// do not want to leave the thread local variables in the threads you do not manage.  Call this method when your
-        /// application is being unloaded from the container.
+        /// <summary>
+        /// Destroys the data structure that keeps all <see cref="FastThreadLocal"/> variables accessed from
+        /// non-<see cref="FastThreadLocal"/>s.  This operation is useful when you are in a container environment, and
+        /// you do not want to leave the thread local variables in the threads you do not manage.  Call this method when
+        /// your application is being unloaded from the container.
+        /// </summary>
         public static void Destroy() => InternalThreadLocalMap.Destroy();
 
         protected static void AddToVariablesToRemove(InternalThreadLocalMap threadLocalMap, FastThreadLocal variable)
@@ -135,7 +137,7 @@ namespace DotNetty.Common
         }
 
         /// <summary>
-        ///     Set the value for the specified thread local map. The specified thread local map must be for the current thread.
+        /// Set the value for the specified thread local map. The specified thread local map must be for the current thread.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Set(InternalThreadLocalMap threadLocalMap, T value)
@@ -147,27 +149,32 @@ namespace DotNetty.Common
         }
 
         /// <summary>
-        ///     Returns {@code true} if and only if this thread-local variable is set.
+        /// Returns <c>true</c> if and only if this thread-local variable is set.
         /// </summary>
         public bool IsSet() => this.IsSet(InternalThreadLocalMap.GetIfSet());
 
         /// <summary>
-        ///     Returns {@code true} if and only if this thread-local variable is set.
-        ///     The specified thread local map must be for the current thread.
+        /// Returns <c>true</c> if and only if this thread-local variable is set.
+        /// The specified thread local map must be for the current thread.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsSet(InternalThreadLocalMap threadLocalMap) => threadLocalMap != null && threadLocalMap.IsIndexedVariableSet(this.index);
 
         /// <summary>
-        ///     Returns the initial value for this thread-local variable.
+        /// Returns the initial value for this thread-local variable.
         /// </summary>
         protected virtual T GetInitialValue() => null;
 
         public void Remove() => this.Remove(InternalThreadLocalMap.GetIfSet());
 
+        /// <summary>
         /// Sets the value to uninitialized for the specified thread local map;
-        /// a proceeding call to get() will trigger a call to GetInitialValue().
+        /// a proceeding call to <see cref="Get"/> will trigger a call to <see cref="GetInitialValue"/>.
         /// The specified thread local map must be for the current thread.
+        /// </summary>
+        /// <param name="threadLocalMap">
+        /// The <see cref="InternalThreadLocalMap"/> from which this <see cref="FastThreadLocal"/> should be removed.
+        /// </param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public sealed override void Remove(InternalThreadLocalMap threadLocalMap)
         {
@@ -186,7 +193,7 @@ namespace DotNetty.Common
         }
 
         /// <summary>
-        ///     Invoked when this thread local variable is removed by {@link #remove()}.
+        /// Invoked when this thread local variable is removed by <see cref="Remove()"/>.
         /// </summary>
         protected virtual void OnRemoval(T value)
         {

--- a/src/DotNetty.Common/Internal/AppendableCharSequence.cs
+++ b/src/DotNetty.Common/Internal/AppendableCharSequence.cs
@@ -176,8 +176,10 @@ namespace DotNetty.Common.Internal
             return this;
         }
 
-        // Reset the {@link AppendableCharSequence}. Be aware this will only reset the current internal position and not
-        // shrink the internal char array.
+        /// <summary>
+        /// Resets the <see cref="AppendableCharSequence"/>. Be aware this will only reset the current internal
+        /// position and not shrink the internal char array.
+        /// </summary>
         public void Reset() => this.pos = 0;
 
         public string ToString(int start)
@@ -190,8 +192,10 @@ namespace DotNetty.Common.Internal
 
         public AsciiString ToAsciiString() => this.pos == 0 ? AsciiString.Empty : new AsciiString(this.chars, 0, this.pos, true);
 
-        // Create a new ascii string, this method assumes all chars has been sanitized
-        // to ascii chars when appending to the array
+        /// <summary>
+        /// Create a new ascii string, this method assumes all chars has been sanitized to ascii chars when appending
+        /// to the array.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe AsciiString SubStringUnsafe(int start, int end)
         {

--- a/src/DotNetty.Common/Internal/ConcurrentCircularArrayQueue.cs
+++ b/src/DotNetty.Common/Internal/ConcurrentCircularArrayQueue.cs
@@ -34,28 +34,39 @@ namespace DotNetty.Common.Internal
             this.Buffer = new T[actualCapacity + RefArrayAccessUtil.RefBufferPad * 2];
         }
 
-        /// @param index desirable element index
-        /// @return the offset in bytes within the array for a given index.
+        /// <summary>
+        /// Calculates an element offset based on a given array index.
+        /// </summary>
+        /// <param name="index">The desirable element index.</param>
+        /// <returns>The offset in bytes within the array for a given index.</returns>
         protected long CalcElementOffset(long index) => RefArrayAccessUtil.CalcElementOffset(index, this.Mask);
 
-        /// A plain store (no ordering/fences) of an element to a given offset
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @param e a kitty
+        /// <summary>
+        /// A plain store (no ordering/fences) of an element to a given offset.
+        /// </summary>
+        /// <param name="offset">Computed via <see cref="CalcElementOffset"/>.</param>
+        /// <param name="e">A kitty.</param>
         protected void SpElement(long offset, T e) => RefArrayAccessUtil.SpElement(this.Buffer, offset, e);
 
-        /// An ordered store(store + StoreStore barrier) of an element to a given offset
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @param e an orderly kitty
+        /// <summary>
+        /// An ordered store(store + StoreStore barrier) of an element to a given offset.
+        /// </summary>
+        /// <param name="offset">Computed via <see cref="CalcElementOffset"/>.</param>
+        /// <param name="e">An orderly kitty.</param>
         protected void SoElement(long offset, T e) => RefArrayAccessUtil.SoElement(this.Buffer, offset, e);
 
+        /// <summary>
         /// A plain load (no ordering/fences) of an element from a given offset.
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @return the element at the offset
+        /// </summary>
+        /// <param name="offset">Computed via <see cref="CalcElementOffset"/>.</param>
+        /// <returns>The element at the offset.</returns>
         protected T LpElement(long offset) => RefArrayAccessUtil.LpElement(this.Buffer, offset);
 
+        /// <summary>
         /// A volatile load (load + LoadLoad barrier) of an element from a given offset.
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @return the element at the offset
+        /// </summary>
+        /// <param name="offset">Computed via <see cref="CalcElementOffset"/>.</param>
+        /// <returns>The element at the offset.</returns>
         protected T LvElement(long offset) => RefArrayAccessUtil.LvElement(this.Buffer, offset);
 
         public override void Clear()

--- a/src/DotNetty.Common/Internal/Logging/AbstractInternalLogger.cs
+++ b/src/DotNetty.Common/Internal/Logging/AbstractInternalLogger.cs
@@ -7,18 +7,18 @@ namespace DotNetty.Common.Internal.Logging
     using System.Diagnostics.Contracts;
 
     /// <summary>
-    ///     A skeletal implementation of {@link IInternalLogger}.  This class implements
-    ///     all methods that have a { @link InternalLogLevel } parameter by default to call
-    ///     specific logger methods such as {@link #Info(String)} or {@link #isInfoEnabled()}.
+    /// A skeletal implementation of <see cref="IInternalLogger"/>. This class implements
+    /// all methods that have a <see cref="InternalLogLevel"/> parameter by default to call
+    /// specific logger methods such as <see cref="Info(string)"/> or <see cref="InfoEnabled"/>.
     /// </summary>
     public abstract class AbstractInternalLogger : IInternalLogger
     {
         static readonly string EXCEPTION_MESSAGE = "Unexpected exception:";
 
         /// <summary>
-        ///     Creates a new instance.
+        /// Creates a new instance.
         /// </summary>
-        /// <param name="name"></param>
+        /// <param name="name">A friendly name for the new logger instance.</param>
         protected AbstractInternalLogger(string name)
         {
             Contract.Requires(name != null);

--- a/src/DotNetty.Common/Internal/Logging/FormattingTuple.cs
+++ b/src/DotNetty.Common/Internal/Logging/FormattingTuple.cs
@@ -7,7 +7,7 @@ namespace DotNetty.Common.Internal.Logging
     using System.Diagnostics.Contracts;
 
     /// <summary>
-    ///     Holds the results of formatting done by {@link MessageFormatter}.
+    /// Holds the results of formatting done by <see cref="MessageFormatter"/>.
     /// </summary>
     public struct FormattingTuple
     {

--- a/src/DotNetty.Common/Internal/Logging/IInternalLogger.cs
+++ b/src/DotNetty.Common/Internal/Logging/IInternalLogger.cs
@@ -32,10 +32,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level TRACE according to the specified format and
         ///     argument.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level TRACE.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arg">the argument</param>
@@ -44,10 +44,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level TRACE according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level TRACE.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="argA">the first argument</param>
@@ -57,7 +57,7 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level TRACE according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level TRACE. However, this variant incurs the hidden
         ///         (and relatively small) cost of creating an <c>object[]</c>
@@ -65,7 +65,7 @@ namespace DotNetty.Common.Internal.Logging
         ///         even if this logger is disabled for TRACE. The variants
         ///         <see cref="Trace(string, object)" /> and <see cref="Trace(string, object, object)" />
         ///         arguments exist solely to avoid this hidden cost.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arguments">an array of arguments</param>
@@ -99,10 +99,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level DEBUG according to the specified format and
         ///     argument.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level DEBUG.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arg">the argument</param>
@@ -111,10 +111,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level DEBUG according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level DEBUG.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="argA">the first argument</param>
@@ -124,7 +124,7 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level DEBUG according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level DEBUG. However, this variant incurs the hidden
         ///         (and relatively small) cost of creating an <c>object[]</c>
@@ -132,7 +132,7 @@ namespace DotNetty.Common.Internal.Logging
         ///         even if this logger is disabled for DEBUG. The variants
         ///         <see cref="Debug(string, object)" /> and <see cref="Debug(string, object, object)" />
         ///         arguments exist solely to avoid this hidden cost.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arguments">an array of arguments</param>
@@ -166,10 +166,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level INFO according to the specified format and
         ///     argument.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level INFO.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arg">the argument</param>
@@ -178,10 +178,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level INFO according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level INFO.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="argA">the first argument</param>
@@ -191,7 +191,7 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level INFO according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level INFO. However, this variant incurs the hidden
         ///         (and relatively small) cost of creating an <c>object[]</c>
@@ -199,7 +199,7 @@ namespace DotNetty.Common.Internal.Logging
         ///         even if this logger is disabled for INFO. The variants
         ///         <see cref="Info(string, object)" /> and <see cref="Info(string, object, object)" />
         ///         arguments exist solely to avoid this hidden cost.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arguments">an array of arguments</param>
@@ -233,10 +233,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level WARN according to the specified format and
         ///     argument.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level WARN.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arg">the argument</param>
@@ -245,7 +245,7 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level WARN according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level WARN. However, this variant incurs the hidden
         ///         (and relatively small) cost of creating an <c>object[]</c>
@@ -253,7 +253,7 @@ namespace DotNetty.Common.Internal.Logging
         ///         even if this logger is disabled for WARN. The variants
         ///         <see cref="Warn(string, object)" /> and <see cref="Warn(string, object, object)" />
         ///         arguments exist solely to avoid this hidden cost.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arguments">an array of arguments</param>
@@ -262,10 +262,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level WARN according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level WARN.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="argA">the first argument</param>
@@ -300,10 +300,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level ERROR according to the specified format and
         ///     argument.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level ERROR.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arg">the argument</param>
@@ -312,10 +312,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level ERROR according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level ERROR.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="argA">the first argument</param>
@@ -325,7 +325,7 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at level ERROR according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for level ERROR. However, this variant incurs the hidden
         ///         (and relatively small) cost of creating an <c>object[]</c>
@@ -333,7 +333,7 @@ namespace DotNetty.Common.Internal.Logging
         ///         even if this logger is disabled for ERROR. The variants
         ///         <see cref="Error(string, object)" /> and <see cref="Error(string, object, object)" />
         ///         arguments exist solely to avoid this hidden cost.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="format">the format string</param>
         /// <param name="arguments">an array of arguments</param>
@@ -353,10 +353,10 @@ namespace DotNetty.Common.Internal.Logging
         void Error(Exception t);
 
         /// <summary>
-        ///     Is the logger instance enabled for the specified {@code level}?
+        ///     Is the logger instance enabled for the specified <paramref name="level"/>?
         /// </summary>
         /// <param name="level">log level</param>
-        /// <returns>true if this Logger is enabled for the specified {@code level}, false otherwise.</returns>
+        /// <returns>true if this Logger is enabled for the specified <paramref name="level"/>, false otherwise.</returns>
         bool IsEnabled(InternalLogLevel level);
 
         /// <summary>
@@ -369,10 +369,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at a specified <see cref="InternalLogLevel" /> according to the specified format and
         ///     argument.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for the specified <see cref="InternalLogLevel" />.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="level">log level</param>
         /// <param name="format">the format string</param>
@@ -382,10 +382,10 @@ namespace DotNetty.Common.Internal.Logging
         /// <summary>
         ///     Log a message at a specified <see cref="InternalLogLevel" /> according to the specified format and
         ///     arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous object creation when the logger is disabled
         ///         for the specified <see cref="InternalLogLevel" />.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="level">log level</param>
         /// <param name="format">the format string</param>
@@ -394,17 +394,17 @@ namespace DotNetty.Common.Internal.Logging
         void Log(InternalLogLevel level, string format, object argA, object argB);
 
         /// <summary>
-        ///     Log a message at the specified {@code level} according to the specified format
+        ///     Log a message at the specified <paramref name="level"/> according to the specified format
         ///     and arguments.
-        ///     <p>
+        ///     <para>
         ///         This form avoids superfluous string concatenation when the logger
-        ///         is disabled for the specified {@code level}. However, this variant incurs the hidden
-        ///         (and relatively small) cost of creating an {@code Object[]} before invoking the method,
-        ///         even if this logger is disabled for the specified {@code level}. The variants
+        ///         is disabled for the specified <paramref name="level"/>. However, this variant incurs the hidden
+        ///         (and relatively small) cost of creating an <c>object[]</c> before invoking the method,
+        ///         even if this logger is disabled for the specified <paramref name="level"/>. The variants
         ///         <see cref="Log(InternalLogLevel, string, object)" /> and
         ///         <see cref="Log(InternalLogLevel, string, object, object)" /> arguments exist solely
         ///         in order to avoid this hidden cost.
-        ///     </p>
+        ///     </para>
         /// </summary>
         /// <param name="level">log level</param>
         /// <param name="format">the format string</param>

--- a/src/DotNetty.Common/Internal/Logging/InternalLogLevel.cs
+++ b/src/DotNetty.Common/Internal/Logging/InternalLogLevel.cs
@@ -3,7 +3,9 @@
 
 namespace DotNetty.Common.Internal.Logging
 {
-    /// <summary>The log level that {@link IInternalLogger} can log at.</summary>
+    /// <summary>
+    /// The log level that <see cref="IInternalLogger"/> can log at.
+    /// </summary>
     public enum InternalLogLevel
     {
         /// <summary>

--- a/src/DotNetty.Common/Internal/Logging/MessageFormatter.cs
+++ b/src/DotNetty.Common/Internal/Logging/MessageFormatter.cs
@@ -8,66 +8,51 @@ namespace DotNetty.Common.Internal.Logging
     using System.Text;
 
     /// <summary>
-    ///     Formats messages according to very simple substitution rules. Substitutions
-    ///     can be made 1, 2 or more arguments.
-    ///     <p />
-    ///     <p />
-    ///     For example,
-    ///     <p />
-    ///     <pre>
-    ///         MessageFormatter.Format(&quot;Hi {}.&quot;, &quot;there&quot;)
-    ///     </pre>
-    ///     <p />
-    ///     will return the string "Hi there.".
-    ///     <p />
-    ///     The {} pair is called the <em>formatting anchor</em>. It serves to designate
-    ///     the location where arguments need to be substituted within the message
-    ///     pattern.
-    ///     <p />
-    ///     In case your message contains the '{' or the '}' character, you do not have
-    ///     to do anything special unless the '}' character immediately follows '{'. For
-    ///     example,
-    ///     <p />
-    ///     <pre>
-    ///         MessageFormatter.Format(&quot;Set {1,2,3} is not equal to {}.&quot;, &quot;1,2&quot;);
-    ///     </pre>
-    ///     <p />
-    ///     will return the string "Set {1,2,3} is not equal to 1,2.".
-    ///     <p />
-    ///     <p />
-    ///     If for whatever reason you need to place the string "{}" in the message
-    ///     without its <em>formatting anchor</em> meaning, then you need to escape the
-    ///     '{' character with '\', that is the backslash character. Only the '{'
-    ///     character should be escaped. There is no need to escape the '}' character.
-    ///     For example,
-    ///     <p />
-    ///     <pre>
-    ///         MessageFormatter.Format(&quot;Set \\{} is not equal to {}.&quot;, &quot;1,2&quot;);
-    ///     </pre>
-    ///     <p />
-    ///     will return the string "Set {} is not equal to 1,2.".
-    ///     <p />
-    ///     <p />
-    ///     The escaping behavior just described can be overridden by escaping the escape
-    ///     character '\'. Calling
-    ///     <p />
-    ///     <pre>
-    ///         MessageFormatter.Format(&quot;File name is C:\\\\{}.&quot;, &quot;file.zip&quot;);
-    ///     </pre>
-    ///     <p />
-    ///     will return the string "File name is C:\file.zip".
-    ///     <p />
-    ///     <p />
-    ///     The formatting conventions are different than those of {@link MessageFormat}
-    ///     which ships with the Java platform. This is justified by the fact that
-    ///     SLF4J's implementation is 10 times faster than that of {@link MessageFormat}.
-    ///     This local performance difference is both measurable and significant in the
-    ///     larger context of the complete logging processing chain.
-    ///     <p />
-    ///     <p />
-    ///     <seealso cref="Format(string, object)" />
-    ///     <seealso cref="Format(string, object, object)" />
-    ///     <seealso cref="ArrayFormat(string, object[])" />
+    /// Formats messages according to very simple substitution rules. Substitutions can be made 1, 2 or more arguments.
+    /// <para>For example,</para>
+    /// <code>
+    /// MessageFormatter.Format(&quot;Hi {}.&quot;, &quot;there&quot;)
+    /// </code>
+    /// <para>
+    /// will return the string "Hi there.".
+    /// </para>
+    /// <para>
+    /// The {} pair is called the <em>formatting anchor</em>. It serves to designate the location where arguments need
+    /// to be substituted within the message pattern.
+    /// </para>
+    /// <para>
+    /// In case your message contains the '{' or the '}' character, you do not have to do anything special unless the
+    /// '}' character immediately follows '{'. For example,
+    /// </para>
+    /// <code>
+    /// MessageFormatter.Format(&quot;Set {1,2,3} is not equal to {}.&quot;, &quot;1,2&quot;);
+    /// </code>
+    /// <para>
+    /// will return the string "Set {1,2,3} is not equal to 1,2.".
+    /// </para>
+    /// <para>
+    /// If for whatever reason you need to place the string "{}" in the message without its <em>formatting anchor</em>
+    /// meaning, then you need to escape the '{' character with '\', that is the backslash character. Only the '{'
+    /// character should be escaped. There is no need to escape the '}' character. For example,
+    /// </para>
+    /// <code>
+    /// MessageFormatter.Format(&quot;Set \\{} is not equal to {}.&quot;, &quot;1,2&quot;);
+    /// </code>
+    /// <para>
+    /// will return the string "Set {} is not equal to 1,2.".
+    /// </para>
+    /// <para>
+    /// The escaping behavior just described can be overridden by escaping the escape character '\'. Calling
+    /// </para>
+    /// <code>
+    /// MessageFormatter.Format(&quot;File name is C:\\\\{}.&quot;, &quot;file.zip&quot;);
+    /// </code>
+    /// <para>
+    /// will return the string "File name is C:\file.zip".
+    /// </para>
+    /// <seealso cref="Format(string, object)" />
+    /// <seealso cref="Format(string, object, object)" />
+    /// <seealso cref="ArrayFormat(string, object[])" />
     /// </summary>
     public static class MessageFormatter
     {
@@ -76,17 +61,16 @@ namespace DotNetty.Common.Internal.Logging
         static readonly char ESCAPE_CHAR = '\\';
 
         /// <summary>
-        ///     Performs single argument substitution for the 'messagePattern' passed as
-        ///     parameter.
-        ///     <p />
-        ///     For example,
-        ///     <p />
-        ///     <pre>
-        ///         MessageFormatter.Format(&quot;Hi {}.&quot;, &quot;there&quot;);
-        ///     </pre>
-        ///     <p />
-        ///     will return the string "Hi there.".
-        ///     <p />
+        /// Performs single argument substitution for the given <paramref name="messagePattern"/>.
+        /// <para>
+        /// For example,
+        /// </para>
+        /// <code>
+        /// MessageFormatter.Format(&quot;Hi {}.&quot;, &quot;there&quot;);
+        /// </code>
+        /// <para>
+        /// will return the string "Hi there.".
+        /// </para>
         /// </summary>
         /// <param name="messagePattern">The message pattern which will be parsed and formatted</param>
         /// <param name="arg">The argument to be substituted in place of the formatting anchor</param>
@@ -94,16 +78,16 @@ namespace DotNetty.Common.Internal.Logging
         public static FormattingTuple Format(string messagePattern, object arg) => ArrayFormat(messagePattern, new[] { arg });
 
         /// <summary>
-        ///     Performs a two argument substitution for the 'messagePattern' passed as
-        ///     parameter.
-        ///     <p />
-        ///     For example,
-        ///     <p />
-        ///     <pre>
-        ///         MessageFormatter.Format(&quot;Hi {}. My name is {}.&quot;, &quot;Alice&quot;, &quot;Bob&quot;);
-        ///     </pre>
-        ///     <p />
-        ///     will return the string "Hi Alice. My name is Bob.".
+        /// Performs a two argument substitution for the given <paramref name="messagePattern"/>.
+        /// <para>
+        /// For example,
+        /// </para>
+        /// <code>
+        /// MessageFormatter.Format(&quot;Hi {}. My name is {}.&quot;, &quot;Alice&quot;, &quot;Bob&quot;);
+        /// </code>
+        /// <para>
+        /// will return the string "Hi Alice. My name is Bob.".
+        /// </para>
         /// </summary>
         /// <param name="messagePattern">The message pattern which will be parsed and formatted</param>
         /// <param name="argA">The argument to be substituted in place of the first formatting anchor</param>
@@ -122,9 +106,8 @@ namespace DotNetty.Common.Internal.Logging
         }
 
         /// <summary>
-        ///     Same principle as the {@link #Format(String, Object)} and
-        ///     {@link #Format(String, Object, Object)} methods except that any number of
-        ///     arguments can be passed in an array.
+        /// Same principle as the <see cref="Format(string,object)"/> and <see cref="Format(string,object,object)"/>
+        /// methods, except that any number of arguments can be passed in an array.
         /// </summary>
         /// <param name="messagePattern">The message pattern which will be parsed and formatted</param>
         /// <param name="argArray">An array of arguments to be substituted in place of formatting anchors</param>

--- a/src/DotNetty.Common/Internal/MpscArrayQueue.cs
+++ b/src/DotNetty.Common/Internal/MpscArrayQueue.cs
@@ -6,20 +6,21 @@ namespace DotNetty.Common.Internal
     using System.Diagnostics.Contracts;
     using System.Threading;
 
-    /// Forked from
-    /// <a href="https://github.com/JCTools/JCTools">JCTools</a>
-    /// .
-    /// A Multi-Producer-Single-Consumer queue based on a {@link ConcurrentCircularArrayQueue}. This implies that
-    /// any thread may call the offer method, but only a single thread may call poll/peek for correctness to
+    /// <summary>
+    /// Forked from <a href="https://github.com/JCTools/JCTools">JCTools</a>.
+    /// A Multi-Producer-Single-Consumer queue based on a <see cref="ConcurrentCircularArrayQueue{T}"/>. This implies
+    /// that any thread may call the Enqueue methods, but only a single thread may call poll/peek for correctness to
     /// maintained.
-    /// <br />
+    /// <para>
     /// This implementation follows patterns documented on the package level for False Sharing protection.
-    /// <br />
-    /// This implementation is using the
-    /// <a href="http://sourceforge.net/projects/mc-fastflow/">Fast Flow</a>
+    /// </para>
+    /// <para>
+    /// This implementation is using the <a href="http://sourceforge.net/projects/mc-fastflow/">Fast Flow</a>
     /// method for polling from the queue (with minor change to correctly publish the index) and an extension of
     /// the Leslie Lamport concurrent queue algorithm (originated by Martin Thompson) on the producer side.
-    /// <br />
+    /// </para>
+    /// </summary>
+    /// <typeparam name="T">The type of each item in the queue.</typeparam>
     sealed class MpscArrayQueue<T> : MpscArrayQueueConsumerField<T>
         where T : class
     {
@@ -33,13 +34,13 @@ namespace DotNetty.Common.Internal
         {
         }
 
-        /// {@inheritDoc}
-        /// <br />
-        /// IMPLEMENTATION NOTES:
-        /// <br />
-        /// Lock free offer using a single CAS. As class name suggests access is permitted to many threads
-        /// concurrently.
-        /// @see java.util.Queue#offer(java.lang.Object)
+        /// <summary>
+        /// Lock free Enqueue operation, using a single compare-and-swap. As the class name suggests, access is
+        /// permitted to many threads concurrently.
+        /// </summary>
+        /// <param name="e">The item to enqueue.</param>
+        /// <returns><c>true</c> if the item was added successfully, otherwise <c>false</c>.</returns>
+        /// <seealso cref="IQueue{T}.TryEnqueue"/>
         public override bool TryEnqueue(T e)
         {
             Contract.Requires(e != null);
@@ -80,9 +81,11 @@ namespace DotNetty.Common.Internal
             return true; // AWESOME :)
         }
 
-        /// A wait free alternative to offer which fails on CAS failure.
-        /// @param e new element, not null
-        /// @return 1 if next element cannot be filled, -1 if CAS failed, 0 if successful
+        /// <summary>
+        /// A wait-free alternative to <see cref="TryEnqueue"/>, which fails on compare-and-swap failure.
+        /// </summary>
+        /// <param name="e">The item to enqueue.</param>
+        /// <returns><c>1</c> if next element cannot be filled, <c>-1</c> if CAS failed, and <c>0</c> if successful.</returns>
         public int WeakEnqueue(T e)
         {
             Contract.Requires(e != null);
@@ -117,12 +120,12 @@ namespace DotNetty.Common.Internal
             return 0; // AWESOME :)
         }
 
-        /// {@inheritDoc}
-        /// <p />
-        /// IMPLEMENTATION NOTES:
-        /// <br />
-        /// Lock free poll using ordered loads/stores. As class name suggests access is limited to a single thread.
-        /// @see java.util.Queue#poll()
+        /// <summary>
+        /// Lock free poll using ordered loads/stores. As class name suggests, access is limited to a single thread.
+        /// </summary>
+        /// <param name="item">The dequeued item.</param>
+        /// <returns><c>true</c> if an item was retrieved, otherwise <c>false</c>.</returns>
+        /// <seealso cref="IQueue{T}.TryDequeue"/>
         public override bool TryDequeue(out T item)
         {
             long consumerIndex = this.ConsumerIndex; // LoadLoad
@@ -159,12 +162,12 @@ namespace DotNetty.Common.Internal
             return true;
         }
 
-        /// {@inheritDoc}
-        /// <p />
-        /// IMPLEMENTATION NOTES:
-        /// <br />
+        /// <summary>
         /// Lock free peek using ordered loads. As class name suggests access is limited to a single thread.
-        /// @see java.util.Queue#poll()
+        /// </summary>
+        /// <param name="item">The peeked item.</param>
+        /// <returns><c>true</c> if an item was retrieved, otherwise <c>false</c>.</returns>
+        /// <seealso cref="IQueue{T}.TryPeek"/>
         public override bool TryPeek(out T item)
         {
             // Copy field to avoid re-reading after volatile load
@@ -194,10 +197,13 @@ namespace DotNetty.Common.Internal
                 }
             }
             item = e;
+
             return true;
         }
 
-        /// {@inheritDoc}
+        /// <summary>
+        /// Returns the number of items in this <see cref="MpscArrayQueue{T}"/>.
+        /// </summary>
         public override int Count
         {
             get

--- a/src/DotNetty.Common/Internal/RefArrayAccessUtil.cs
+++ b/src/DotNetty.Common/Internal/RefArrayAccessUtil.cs
@@ -7,33 +7,48 @@
     {
         public static readonly int RefBufferPad = 64 * 2 / IntPtr.Size;
 
-        /// A plain store (no ordering/fences) of an element to a given offset
-        /// @param buffer this.buffer
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @param e an orderly kitty
+        /// <summary>
+        /// A plain store (no ordering/fences) of an element to a given offset.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="buffer">The source buffer.</param>
+        /// <param name="offset">Computed via <see cref="ConcurrentCircularArrayQueue{T}.CalcElementOffset"/></param>
+        /// <param name="e">An orderly kitty.</param>
         public static void SpElement<T>(T[] buffer, long offset, T e) => buffer[offset] = e;
 
-        /// An ordered store(store + StoreStore barrier) of an element to a given offset
-        /// @param buffer this.buffer
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @param e an orderly kitty
+        /// <summary>
+        /// An ordered store(store + StoreStore barrier) of an element to a given offset.
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="buffer">The source buffer.</param>
+        /// <param name="offset">Computed via <see cref="ConcurrentCircularArrayQueue{T}.CalcElementOffset"/></param>
+        /// <param name="e"></param>
         public static void SoElement<T>(T[] buffer, long offset, T e) where T : class => Volatile.Write(ref buffer[offset], e);
 
+        /// <summary>
         /// A plain load (no ordering/fences) of an element from a given offset.
-        /// @param buffer this.buffer
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @return the element at the offset
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="buffer">The source buffer.</param>
+        /// <param name="offset">Computed via <see cref="ConcurrentCircularArrayQueue{T}.CalcElementOffset"/></param>
+        /// <returns>The element at the given <paramref name="offset"/> in the given <paramref name="buffer"/>.</returns>
         public static T LpElement<T>(T[] buffer, long offset) => buffer[offset];
 
+        /// <summary>
         /// A volatile load (load + LoadLoad barrier) of an element from a given offset.
-        /// @param buffer this.buffer
-        /// @param offset computed via {@link ConcurrentCircularArrayQueue#calcElementOffset(long)}
-        /// @return the element at the offset
+        /// </summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <param name="buffer">The source buffer.</param>
+        /// <param name="offset">Computed via <see cref="ConcurrentCircularArrayQueue{T}.CalcElementOffset"/></param>
+        /// <returns>The element at the given <paramref name="offset"/> in the given <paramref name="buffer"/>.</returns>
         public static T LvElement<T>(T[] buffer, long offset) where T : class => Volatile.Read(ref buffer[offset]);
 
-        /// @param index desirable element index
-        /// @param mask
-        /// @return the offset in bytes within the array for a given index.
+        /// <summary>
+        /// Gets the offset in bytes within the array for a given index.
+        /// </summary>
+        /// <param name="index">The desired element index.</param>
+        /// <param name="mask">Mask for the index.</param>
+        /// <returns>The offset (in bytes) within the array for a given index.</returns>
         public static long CalcElementOffset(long index, long mask) => RefBufferPad + (index & mask);
     }
 }

--- a/src/DotNetty.Common/Internal/SpscLinkedQueue.cs
+++ b/src/DotNetty.Common/Internal/SpscLinkedQueue.cs
@@ -149,19 +149,26 @@ namespace DotNetty.Common.Internal
         long p10, p11, p12, p13, p14, p15, p16;
 #pragma warning restore 169
 
-        // Called from a producer thread subject to the restrictions appropriate to the implementation and
-        // according to the {@link Queue#offer(Object)} interface. return true if element was inserted 
-        // into the queue, false iff full
+        /// <summary>
+        /// Called from a producer thread subject to the restrictions appropriate to the implementation and
+        /// according to the <see cref="ILinkedQueue{T}.Offer"/> interface.
+        /// </summary>
+        /// <param name="e">The element to enqueue.</param>
+        /// <returns><c>true</c> if the element was inserted, <c>false</c> iff the queue is full.</returns>
         public abstract bool Offer(T e);
 
-        // Called from the consumer thread subject to the restrictions appropriate to the implementation and
-        // according to the {@link Queue#poll()} interface.
-        // return a message from the queue if one is available, null iff empty
+        /// <summary>
+        /// Called from the consumer thread subject to the restrictions appropriate to the implementation and
+        /// according to the <see cref="ILinkedQueue{T}.Poll"/> interface.
+        /// </summary>
+        /// <returns>A message from the queue if one is available, <c>null</c> iff the queue is empty.</returns>
         public abstract T Poll();
 
-        // Called from the consumer thread subject to the restrictions appropriate to the implementation and
-        // according to the {@link Queue#peek()} interface.
-        // return a message from the queue if one is available, null iff empty
+        /// <summary>
+        /// Called from the consumer thread subject to the restrictions appropriate to the implementation and
+        /// according to the <see cref="ILinkedQueue{T}.Peek"/> interface.
+        /// </summary>
+        /// <returns>A message from the queue if one is available, <c>null</c> iff the queue is empty.</returns>
         public abstract T Peek();
 
         public abstract int Count { get; }

--- a/src/DotNetty.Common/InternalThreadLocalMap.cs
+++ b/src/DotNetty.Common/InternalThreadLocalMap.cs
@@ -11,9 +11,9 @@ namespace DotNetty.Common
     using DotNetty.Common.Utilities;
 
     /// <summary>
-    ///     The internal data structure that stores the thread-local variables for Netty and all {@link FastThreadLocal}s.
-    ///     Note that this class is for internal use only and is subject to change at any time.  Use {@link FastThreadLocal}
-    ///     unless you know what you are doing.
+    /// The internal data structure that stores the thread-local variables for DotNetty and all
+    /// <see cref="FastThreadLocal"/>s. Note that this class is for internal use only and is subject to change at any
+    /// time. Use <see cref="FastThreadLocal"/> unless you know what you are doing.
     /// </summary>
     public sealed class InternalThreadLocalMap
     {
@@ -25,7 +25,9 @@ namespace DotNetty.Common
 
         static int nextIndex;
 
-        /// Used by {@link FastThreadLocal}
+        /// <summary>
+        /// Used by <see cref="FastThreadLocal"/>.
+        /// </summary>
         object[] indexedVariables;
 
         // Core thread-locals
@@ -186,9 +188,12 @@ namespace DotNetty.Common
             return index < lookup.Length ? lookup[index] : Unset;
         }
 
-        /**
-          * @return {@code true} if and only if a new thread-local variable has been created
-         */
+        /// <summary>
+        /// Sets a value at the given index in this <see cref="InternalThreadLocalMap"/>.
+        /// </summary>
+        /// <param name="index">The desired index at which a value should be set.</param>
+        /// <param name="value">The value to set at the given index.</param>
+        /// <returns><c>true</c> if and only if a new thread-local variable has been created.</returns>
         public bool SetIndexedVariable(int index, object value)
         {
             object[] lookup = this.indexedVariables;

--- a/src/DotNetty.Common/ThreadDeathWatcher.cs
+++ b/src/DotNetty.Common/ThreadDeathWatcher.cs
@@ -31,12 +31,9 @@ namespace DotNetty.Common
             }
         }
 
-        /// Schedules the specified {@code task} to run when the specified {@code thread} dies.
-        /// 
-        /// @param thread the {@link Thread} to watch
-        /// @param task the {@link Runnable} to run when the {@code thread} dies
-        /// 
-        /// @throws IllegalArgumentException if the specified {@code thread} is not alive
+        /// <summary>
+        /// Schedules the specified <see cref="Action"/> to run when the specified <see cref="Thread"/> dies.
+        /// </summary>
         public static void Watch(Thread thread, Action task)
         {
             Contract.Requires(thread != null);
@@ -46,7 +43,9 @@ namespace DotNetty.Common
             Schedule(thread, task, true);
         }
 
-        /// Cancels the task scheduled via {@link #watch(Thread, Runnable)}.
+        /// <summary>
+        /// Cancels the task scheduled via <see cref="Watch"/>.
+        /// </summary>
         public static void Unwatch(Thread thread, Action task)
         {
             Contract.Requires(thread != null);
@@ -67,14 +66,15 @@ namespace DotNetty.Common
             }
         }
 
+        /// <summary>
         /// Waits until the thread of this watcher has no threads to watch and terminates itself.
-        /// Because a new watcher thread will be started again on {@link #watch(Thread, Runnable)},
+        /// Because a new watcher thread will be started again on <see cref="Watch"/>,
         /// this operation is only useful when you want to ensure that the watcher thread is terminated
-        /// <strong>after</strong>
-        /// your application is shut down and there's no chance of calling
-        /// {@link #watch(Thread, Runnable)} afterwards.
-        /// 
-        /// @return {@code true} if and only if the watcher thread has been terminated
+        /// <strong>after</strong> your application is shut down and there's no chance of calling <see cref="Watch"/>
+        /// afterwards.
+        /// </summary>
+        /// <param name="timeout"></param>
+        /// <returns><c>true</c> if and only if the watcher thread has been terminated.</returns>
         public static bool AwaitInactivity(TimeSpan timeout)
         {
             Thread watcherThread = ThreadDeathWatcher.watcherThread;

--- a/src/DotNetty.Common/Utilities/ByteProcessor.cs
+++ b/src/DotNetty.Common/Utilities/ByteProcessor.cs
@@ -59,62 +59,62 @@ namespace DotNetty.Common.Utilities
         public static IByteProcessor FindNul = new IndexOfProcessor(0);
 
         /// <summary>
-        ///     Aborts on a non-{@code NUL (0x00)}.
+        ///     Aborts on a non-<c>NUL (0x00)</c>.
         /// </summary>
         public static IByteProcessor FindNonNul = new IndexNotOfProcessor(0);
 
         /// <summary>
-        ///     Aborts on a {@code CR ('\r')}.
+        ///     Aborts on a <c>CR ('\r')</c>.
         /// </summary>
         public static IByteProcessor FindCR = new IndexOfProcessor(CarriageReturn);
 
         /// <summary>
-        ///     Aborts on a non-{@code CR ('\r')}.
+        ///     Aborts on a non-<c>CR ('\r')</c>.
         /// </summary>
         public static IByteProcessor FindNonCR = new IndexNotOfProcessor(CarriageReturn);
 
         /// <summary>
-        ///     Aborts on a {@code LF ('\n')}.
+        ///     Aborts on a <c>LF ('\n')</c>.
         /// </summary>
         public static IByteProcessor FindLF = new IndexOfProcessor(LineFeed);
 
         /// <summary>
-        ///     Aborts on a non-{@code LF ('\n')}.
+        ///     Aborts on a non-<c>LF ('\n')</c>.
         /// </summary>
         public static IByteProcessor FindNonLF = new IndexNotOfProcessor(LineFeed);
 
         /// <summary>
-        ///     Aborts on a {@code CR (';')}.
+        ///     Aborts on a <c>CR (';')</c>.
         /// </summary>
         public static IByteProcessor FindSemicolon = new IndexOfProcessor((byte)';');
 
         /// <summary>
-        ///     Aborts on a comma {@code (',')}.
+        ///     Aborts on a comma <c>(',')</c>.
         /// </summary>
         public static IByteProcessor FindComma = new IndexOfProcessor((byte)',');
 
         /// <summary>
-        ///     Aborts on a ascii space character ({@code ' '}).
+        ///     Aborts on a ascii space character (<c>' '</c>).
         /// </summary>
         public static IByteProcessor FindAsciiSpace = new IndexOfProcessor(Space);
 
         /// <summary>
-        ///     Aborts on a {@code CR ('\r')} or a {@code LF ('\n')}.
+        ///     Aborts on a <c>CR ('\r')</c> or a <c>LF ('\n')</c>.
         /// </summary>
         public static IByteProcessor FindCrlf = new ByteProcessor(new Func<byte, bool>(value => value != CarriageReturn && value != LineFeed));
 
         /// <summary>
-        ///     Aborts on a byte which is neither a {@code CR ('\r')} nor a {@code LF ('\n')}.
+        ///     Aborts on a byte which is neither a <c>CR ('\r')</c> nor a <c>LF ('\n')</c>.
         /// </summary>
         public static IByteProcessor FindNonCrlf = new ByteProcessor(new Func<byte, bool>(value => value == CarriageReturn || value == LineFeed));
 
         /// <summary>
-        ///     Aborts on a linear whitespace (a ({@code ' '} or a {@code '\t'}).
+        ///     Aborts on a linear whitespace (a <c>' '</c> or a <c>'\t'</c>).
         /// </summary>
         public static IByteProcessor FindLinearWhitespace = new ByteProcessor(new Func<byte, bool>(value => value != Space && value != HTab));
 
         /// <summary>
-        ///     Aborts on a byte which is not a linear whitespace (neither {@code ' '} nor {@code '\t'}).
+        ///     Aborts on a byte which is not a linear whitespace (neither <c>' '</c> nor <c>'\t'</c>).
         /// </summary>
         public static IByteProcessor FindNonLinearWhitespace = new ByteProcessor(new Func<byte, bool>(value => value == Space || value == HTab));
     }

--- a/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
+++ b/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
@@ -574,7 +574,7 @@ namespace DotNetty.Common.Utilities
             HashedWheelTimeout tail;
 
             /// <summary>
-            /// Add {@link HashedWheelTimeout} to this bucket.
+            /// Add a <see cref="HashedWheelTimeout"/> to this bucket.
             /// </summary>
             public void AddTimeout(HashedWheelTimeout timeout)
             {

--- a/src/DotNetty.Common/Utilities/ITimeout.cs
+++ b/src/DotNetty.Common/Utilities/ITimeout.cs
@@ -20,7 +20,7 @@ namespace DotNetty.Common.Utilities
         ITimerTask Task { get; }
 
         /// <summary>
-        /// Returns {@code true} if and only if the <see cref="ITimerTask"/> associated
+        /// Returns <c>true</c> if and only if the <see cref="ITimerTask"/> associated
         /// with this handle has been expired.
         /// </summary>
         bool Expired { get; }
@@ -35,9 +35,8 @@ namespace DotNetty.Common.Utilities
         /// Attempts to cancel the <see cref="ITimerTask"/> associated with this handle.
         /// If the task has been executed or canceled already, it will return with
         /// no side effect.
-        ///
-        /// @return True if the cancellation completed successfully, otherwise false
         /// </summary>
+        /// <returns><c>true</c> if the cancellation completed successfully, otherwise <c>false</c>.</returns>
         bool Cancel();
     }
 }

--- a/src/DotNetty.Common/Utilities/ITimer.cs
+++ b/src/DotNetty.Common/Utilities/ITimer.cs
@@ -24,7 +24,7 @@ namespace DotNetty.Common.Utilities
         ITimeout NewTimeout(ITimerTask task, TimeSpan delay);
 
         /// <summary>
-        /// Releases all resources acquired by this {@link Timer} and cancels all
+        /// Releases all resources acquired by this <see cref="ITimer"/> and cancels all
         /// tasks which were scheduled but not executed yet.
         /// </summary>
         /// <returns>the handles associated with the tasks which were canceled by

--- a/src/DotNetty.Common/Utilities/ReferenceCountUtil.cs
+++ b/src/DotNetty.Common/Utilities/ReferenceCountUtil.cs
@@ -13,8 +13,9 @@ namespace DotNetty.Common.Utilities
         static readonly IInternalLogger Logger = InternalLoggerFactory.GetInstance(typeof(ReferenceCountUtil));
 
         /// <summary>
-        ///     Try to call {@link ReferenceCounted#retain()} if the specified message implements {@link ReferenceCounted}.
-        ///     If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+        /// Tries to call <see cref="IReferenceCounted.Retain()"/> if the specified message implements
+        /// <see cref="IReferenceCounted"/>. If the specified message doesn't implement
+        /// <see cref="IReferenceCounted"/>, this method does nothing.
         /// </summary>
         public static T Retain<T>(T msg)
         {
@@ -27,8 +28,9 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Try to call {@link ReferenceCounted#retain(int)} if the specified message implements {@link ReferenceCounted}.
-        ///     If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+        /// Tries to call <see cref="IReferenceCounted.Retain(int)"/> if the specified message implements
+        /// <see cref="IReferenceCounted"/>. If the specified message doesn't implement
+        /// <see cref="IReferenceCounted"/>, this method does nothing.
         /// </summary>
         public static T Retain<T>(T msg, int increment)
         {
@@ -41,9 +43,9 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Tries to call <see cref="IReferenceCounted.Touch()" /> if the specified message implements
-        ///     <see cref="IReferenceCounted" />.
-        ///     If the specified message doesn't implement <see cref="IReferenceCounted" />, this method does nothing.
+        /// Tries to call <see cref="IReferenceCounted.Touch()" /> if the specified message implements
+        /// <see cref="IReferenceCounted" />.
+        /// If the specified message doesn't implement <see cref="IReferenceCounted" />, this method does nothing.
         /// </summary>
         public static T Touch<T>(T msg)
         {
@@ -56,9 +58,9 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Tries to call <see cref="IReferenceCounted.Touch(object)" /> if the specified message implements
-        ///     <see cref="IReferenceCounted" />. If the specified message doesn't implement <see cref="IReferenceCounted" />,
-        ///     this method does nothing.
+        /// Tries to call <see cref="IReferenceCounted.Touch(object)" /> if the specified message implements
+        /// <see cref="IReferenceCounted" />. If the specified message doesn't implement
+        /// <see cref="IReferenceCounted" />, this method does nothing.
         /// </summary>
         public static T Touch<T>(T msg, object hint)
         {
@@ -71,8 +73,9 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
-        ///     If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+        /// Tries to call <see cref="IReferenceCounted.Release()" /> if the specified message implements
+        /// <see cref="IReferenceCounted"/>. If the specified message doesn't implement
+        /// <see cref="IReferenceCounted"/>, this method does nothing.
         /// </summary>
         public static bool Release(object msg)
         {
@@ -85,8 +88,9 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Try to call {@link ReferenceCounted#release(int)} if the specified message implements {@link ReferenceCounted}.
-        ///     If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+        /// Tries to call <see cref="IReferenceCounted.Release(int)" /> if the specified message implements
+        /// <see cref="IReferenceCounted"/>. If the specified message doesn't implement
+        /// <see cref="IReferenceCounted"/>, this method does nothing.
         /// </summary>
         public static bool Release(object msg, int decrement)
         {
@@ -99,11 +103,12 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
-        ///     If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
-        ///     Unlike {@link #release(Object)} this method catches an exception raised by {@link ReferenceCounted#release()}
-        ///     and logs it, rather than rethrowing it to the caller.  It is usually recommended to use {@link #release(Object)}
-        ///     instead, unless you absolutely need to swallow an exception.
+        /// Tries to call <see cref="IReferenceCounted.Release()" /> if the specified message implements
+        /// <see cref="IReferenceCounted"/>. If the specified message doesn't implement
+        /// <see cref="IReferenceCounted"/>, this method does nothing. Unlike <see cref="Release(object)"/>, this
+        /// method catches an exception raised by <see cref="IReferenceCounted.Release()" /> and logs it, rather than
+        /// rethrowing it to the caller. It is usually recommended to use <see cref="Release(object)"/> instead, unless
+        /// you absolutely need to swallow an exception.
         /// </summary>
         public static void SafeRelease(object msg)
         {
@@ -118,11 +123,12 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Try to call {@link ReferenceCounted#release(int)} if the specified message implements {@link ReferenceCounted}.
-        ///     If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
-        ///     Unlike {@link #release(Object)} this method catches an exception raised by {@link ReferenceCounted#release(int)}
-        ///     and logs it, rather than rethrowing it to the caller.  It is usually recommended to use
-        ///     {@link #release(Object, int)} instead, unless you absolutely need to swallow an exception.
+        /// Tries to call <see cref="IReferenceCounted.Release(int)" /> if the specified message implements
+        /// <see cref="IReferenceCounted"/>. If the specified message doesn't implement
+        /// <see cref="IReferenceCounted"/>, this method does nothing. Unlike <see cref="Release(object)"/>, this
+        /// method catches an exception raised by <see cref="IReferenceCounted.Release(int)" /> and logs it, rather
+        /// than rethrowing it to the caller. It is usually recommended to use <see cref="Release(object, int)"/>
+        /// instead, unless you absolutely need to swallow an exception.
         /// </summary>
         public static void SafeRelease(object msg, int decrement)
         {
@@ -164,16 +170,16 @@ namespace DotNetty.Common.Utilities
         }
 
         /// <summary>
-        ///     Schedules the specified object to be released when the caller thread terminates. Note that this operation is
-        ///     intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
-        ///     intended use case.
+        /// Schedules the specified object to be released when the caller thread terminates. Note that this operation
+        /// is intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
+        /// intended use case.
         /// </summary>
         public static T ReleaseLater<T>(T msg) => ReleaseLater(msg, 1);
 
         /// <summary>
-        ///     Schedules the specified object to be released when the caller thread terminates. Note that this operation is
-        ///     intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
-        ///     intended use case.
+        /// Schedules the specified object to be released when the caller thread terminates. Note that this operation
+        /// is intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
+        /// intended use case.
         /// </summary>
         public static T ReleaseLater<T>(T msg, int decrement)
         {


### PR DESCRIPTION
This is a progressive commit towards completing #386.

No code changes have been made, only changes to comments.

These changes to comments include:
- Transforming `{@link Symbol}` occurrences to `<see cref="Symbol"/>`
- Updating Java example code in comments with C# equivalents
- Translating/removing comments that do not apply to .NET generally
- Removing Netty-specific comments that do not yet apply to this port
- Various grammar and typo corrections

Files whose comments did not contain javadoc syntax, or already appeared to have been converted to xmldoc, were not changed.