### PR TITLE
Fix socket connecting synchronously

### DIFF
--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketChannel.cs
@@ -318,16 +318,6 @@ namespace DotNetty.Transport.Channels.Sockets
 
             void FulfillConnectPromise(bool wasActive)
             {
-                TaskCompletionSource promise = this.Channel.connectPromise;
-                if (promise == null)
-                {
-                    // Closed via cancellation and the promise has been notified already.
-                    return;
-                }
-
-                // trySuccess() will return false if a user cancelled the connection attempt.
-                bool promiseSet = promise.TryComplete();
-
                 // Regardless if the connection attempt was cancelled, channelActive() event should be triggered,
                 // because what happened is what happened.
                 if (!wasActive && this.channel.Active)
@@ -335,10 +325,19 @@ namespace DotNetty.Transport.Channels.Sockets
                     this.channel.Pipeline.FireChannelActive();
                 }
 
-                // If a user cancelled the connection attempt, close the channel, which is followed by channelInactive().
-                if (!promiseSet)
+                TaskCompletionSource promise = this.Channel.connectPromise;
+                // If promise is null, then it the channel was Closed via cancellation and the promise has been notified already.
+                if (promise != null)
                 {
-                    this.CloseSafe();
+                    // trySuccess() will return false if a user cancelled the connection attempt.
+                    bool promiseSet = promise.TryComplete();
+
+                    // If a user cancelled the connection attempt, close the channel, which is followed by channelInactive().
+                    if (!promiseSet)
+                    {
+                        this.CloseSafe();
+                    }
+
                 }
             }
 

--- a/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
@@ -126,6 +126,10 @@ namespace DotNetty.Transport.Channels.Sockets
                 var eventPayload = new SocketChannelAsyncOperation(this, false);
                 eventPayload.RemoteEndPoint = remoteAddress;
                 bool connected = !this.Socket.ConnectAsync(eventPayload);
+                if(connected)
+                {
+                    this.DoFinishConnect(eventPayload);
+                }
                 success = true;
                 return connected;
             }


### PR DESCRIPTION
This PR fixes 2 issues - 
1. If Socket.ConnectAsync returns synchronously, then we cannot assume that the connection succeeded. The connection needs to be validated. 
2. When Fulfilling the connect promise FireChannelActive should be called irrespective of whether the Promise is set. This is because the Promise is set only if the Socket.ConnectAsync returns asynchronously.