### PR TITLE
Fixed typo in .sln

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -66,7 +66,7 @@ Task("Compile")
   .Does(() =>
 {
 
-  int result = StartProcess("dotnet", new ProcessSettings { Arguments = "msbuild dotnetty.sln /p:Configuration=" + configuration } );
+  int result = StartProcess("dotnet", new ProcessSettings { Arguments = "msbuild DotNetty.sln /p:Configuration=" + configuration } );
   if (result != 0)
   {
     throw new CakeException($"Compilation failed.");


### PR DESCRIPTION
The name of the .sln file does not match the filesystem name because of the case: this prevents the build to succeed in Linux systems.