### PR TITLE
Transfer timeouts to the right buckets and update the build.cake to support the configuration parameter

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -13,9 +13,10 @@ var version = Argument<string>("targetversion", $"{releaseNote.Version}.{buildNu
 var skipClean = Argument<bool>("skipclean", false);
 var skipTests = Argument<bool>("skiptests", false);
 var nogit = Argument<bool>("nogit", false);
+var config =  Argument<string>("configuration", "Release");
 
 // Variables
-var configuration = IsRunningOnWindows() ? "Release" : "MonoRelease";
+var configuration = IsRunningOnWindows() ? config : "MonoRelease";
 var csProjectFiles = GetFiles("./src/**/*.csproj");
 
 // Directories

--- a/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
+++ b/src/DotNetty.Common/Utilities/HashedWheelTimer.cs
@@ -353,7 +353,7 @@ namespace DotNetty.Common.Utilities
                         continue;
                     }
 
-                    long calculated = (timeout.Deadline.Ticks + this.owner.tickDuration - 1) / this.owner.tickDuration; // ceiling to timeout later rather than earlier
+                    long calculated = timeout.Deadline.Ticks / this.owner.tickDuration;
                     timeout.RemainingRounds = (calculated - this.tick) / this.owner.wheel.Length;
 
                     long ticks = Math.Max(calculated, this.tick); // Ensure we don't schedule for past.


### PR DESCRIPTION
https://github.com/Azure/DotNetty/blob/dev/src/DotNetty.Common/Utilities/HashedWheelTimer.cs#L356
It will add the timeout to the next of the right bucket, the timeout will be executed after one more tick.

Code in netty:
https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/HashedWheelTimer.java#L508

Also update the build.cake to support the configuration parameter.