### PR TITLE
fixed null and empty fullbulkstring encoding in redis encoder

### DIFF
--- a/src/DotNetty.Codecs.Redis/Messages/FullBulkStringRedisMessage.cs
+++ b/src/DotNetty.Codecs.Redis/Messages/FullBulkStringRedisMessage.cs
@@ -10,15 +10,21 @@ namespace DotNetty.Codecs.Redis.Messages
 
     public sealed class FullBulkStringRedisMessage : DefaultByteBufferHolder, IFullBulkStringRedisMessage
     {
-        public static readonly IFullBulkStringRedisMessage Null = new NullFullBulkStringRedisMessage();
-        public static readonly IFullBulkStringRedisMessage Empty = new EmptyFullBulkStringRedisMessage();
+        public static readonly FullBulkStringRedisMessage Null = new FullBulkStringRedisMessage(true);
+        public static readonly FullBulkStringRedisMessage Empty = new FullBulkStringRedisMessage(false);
 
         public FullBulkStringRedisMessage(IByteBuffer content)
             : base(content)
         {
         }
+  
 
-        public bool IsNull => false;
+        public FullBulkStringRedisMessage(bool isNull)
+        : base(Unpooled.Empty)
+        {
+            this.IsNull = isNull;
+        }
+        public bool IsNull { get; private set; }
 
         public override string ToString() => 
             new StringBuilder(StringUtil.SimpleClassName(this))
@@ -27,66 +33,6 @@ namespace DotNetty.Codecs.Redis.Messages
             .Append(this.Content)
             .Append(']')
             .ToString();
-
-        sealed class NullFullBulkStringRedisMessage : IFullBulkStringRedisMessage
-        {
-            public bool IsNull => true;
-
-            public IByteBuffer Content => Unpooled.Empty;
-
-            public IByteBufferHolder Copy() => this;
-
-            public IByteBufferHolder Duplicate() => this;
-
-            public IByteBufferHolder RetainedDuplicate() => this;
-
-            public int ReferenceCount => 1;
-
-            public IReferenceCounted Retain() => this;
-
-            public IReferenceCounted Retain(int increment) => this;
-
-
-            public IByteBufferHolder Replace(IByteBuffer content) => this;
-
-            public IReferenceCounted Touch() => this;
-
-            public IReferenceCounted Touch(object hint) => this;
-
-            public bool Release() => false;
-
-            public bool Release(int decrement) => false;
-        }
-
-        sealed class EmptyFullBulkStringRedisMessage : IFullBulkStringRedisMessage
-        {
-            public bool IsNull => false;
-
-            public IByteBuffer Content => Unpooled.Empty;
-
-            public IByteBufferHolder Copy() => this;
-
-            public IByteBufferHolder Duplicate() => this;
-
-            public IByteBufferHolder RetainedDuplicate() => this;
-
-            public int ReferenceCount => 1;
-
-            public IReferenceCounted Retain() => this;
-
-            public IReferenceCounted Retain(int increment) => this;
-
-
-            public IByteBufferHolder Replace(IByteBuffer content) => this;
-
-            public IReferenceCounted Touch() => this;
-
-            public IReferenceCounted Touch(object hint) => this;
-
-            public bool Release() => false;
-
-            public bool Release(int decrement) => false;
-        }
 
         public override IByteBufferHolder Replace(IByteBuffer content) => new FullBulkStringRedisMessage(content);
     }

--- a/test/DotNetty.Codecs.Redis.Tests/RedisEncoderTests.cs
+++ b/test/DotNetty.Codecs.Redis.Tests/RedisEncoderTests.cs
@@ -94,6 +94,20 @@ namespace DotNetty.Codecs.Redis.Tests
         }
 
         [Fact]
+        public void EncodeNullFullBulkString()
+        {
+            
+            
+            var msg = FullBulkStringRedisMessage.Null;
+            Assert.True(this.channel.WriteOutbound(msg));
+
+            IByteBuffer written = ReadAll(this.channel);
+            Assert.Equal(BytesOf("$-1\r\n"), BytesOf(written));
+            
+        }
+
+
+        [Fact]
         public void EncodeSimpleArray()
         {
             var children = new List<IRedisMessage>();


### PR DESCRIPTION
Hey,

We are writing a server that will expose our datasets over redis apis and decided to use DotNetty.  Sending back nulls and empty bulk strings results in protocol errors because the redis encoder mis treats those objects. We fixed the bug and implemented a unit test.

Thanks