### PR TITLE
Fix ParseMachineId (#459)

### DIFF
--- a/src/DotNetty.Transport/Channels/DefaultChannelId.cs
+++ b/src/DotNetty.Transport/Channels/DefaultChannelId.cs
@@ -123,7 +123,7 @@ namespace DotNetty.Transport.Channels
             var machineId = new byte[MachineIdLen];
             for (int i = 0; i < value.Length; i += 2)
             {
-                machineId[i] = (byte)int.Parse(value.Substring(i, i + 2), NumberStyles.AllowHexSpecifier);
+                machineId[i] = (byte)int.Parse(value.Substring(i, 2), NumberStyles.AllowHexSpecifier);
             }
             return machineId;
         }


### PR DESCRIPTION
Fix issue parsing manual machine id; fixes #458 - second parameter of `Substring` is 'length' not 'index'