### PR TITLE
fix issue #490(task start without specify TaskScheduler will deadlock)

### DIFF
--- a/src/DotNetty.Common/Concurrency/ExecutorTaskScheduler.cs
+++ b/src/DotNetty.Common/Concurrency/ExecutorTaskScheduler.cs
@@ -5,6 +5,7 @@ namespace DotNetty.Common.Concurrency
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using DotNetty.Common.Utilities;
 
     public sealed class ExecutorTaskScheduler : TaskScheduler
     {
@@ -18,7 +19,11 @@ namespace DotNetty.Common.Concurrency
 
         protected override void QueueTask(Task task)
         {
-            if (this.started)
+            if (!TaskEx.IsNettyTask(task))
+            {
+                TaskEx.DefaultQueueTask(task);
+            }
+            else if (this.started)
             {
                 this.executor.Execute(new TaskQueueNode(this, task));
             }

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -42,4 +42,9 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="System.Reflection.TypeExtensions">
+      <Version>4.3.0</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
In `ExecutorTaskScheduler.QueueTask` method check task delegate declaring type and call `TaskScheduler.Current.QueueTask` if from DotNetty. See code as detail.