### PR TITLE
Port all properties io.netty.recycler.* and related logic

### DIFF
--- a/src/DotNetty.Common/ThreadLocalPool.cs
+++ b/src/DotNetty.Common/ThreadLocalPool.cs
@@ -3,7 +3,10 @@
 
 namespace DotNetty.Common
 {
+    using DotNetty.Common.Internal;
+    using DotNetty.Common.Internal.Logging;
     using System;
+    using System.Diagnostics;
     using System.Diagnostics.Contracts;
     using System.Runtime.CompilerServices;
     using System.Threading;
@@ -11,113 +14,230 @@ namespace DotNetty.Common
 
     public class ThreadLocalPool
     {
-        public sealed class Handle
+        public abstract class Handle
+        {
+            public abstract void Release<T>(T value)
+                where T : class;
+        }
+
+        protected sealed class NoopHandle : Handle
+        {
+            public static readonly NoopHandle Instance = new NoopHandle();
+
+            NoopHandle()
+            {
+            }
+
+            public override void Release<T>(T value)
+            {
+            }
+        }
+
+        protected sealed class DefaultHandle : Handle
         {
             internal int lastRecycledId;
             internal int recycleId;
 
-            public object Value;
+            internal bool hasBeenRecycled;
+
+            internal object Value;
             internal Stack Stack;
 
-            internal Handle(Stack stack)
+            internal DefaultHandle(Stack stack)
             {
                 this.Stack = stack;
             }
 
-            public void Release<T>(T value)
-                where T : class
+            public override void Release<T>(T value)
             {
                 Contract.Requires(value == this.Value, "value differs from one backed by this handle.");
 
                 Stack stack = this.Stack;
-                Thread thread = Thread.CurrentThread;
-                if (stack.Thread == thread)
+                if (lastRecycledId != recycleId || stack == null)
                 {
-                    stack.Push(this);
-                    return;
+                    throw new InvalidOperationException("recycled already");
                 }
-
-                ConditionalWeakTable<Stack, WeakOrderQueue> queueDictionary = DelayedPool.Value;
-                WeakOrderQueue delayedRecycled;
-                if (!queueDictionary.TryGetValue(stack, out delayedRecycled))
-                {
-                    var newQueue = new WeakOrderQueue(stack, thread);
-                    delayedRecycled = newQueue;
-                    queueDictionary.Add(stack, delayedRecycled);
-                }
-                delayedRecycled.Add(this);
+                stack.Push(this);
             }
         }
 
-        internal sealed class WeakOrderQueue
+        // a queue that makes only moderate guarantees about visibility: items are seen in the correct order,
+        // but we aren't absolutely guaranteed to ever see anything at all, thereby keeping the queue cheap to maintain
+        protected sealed class WeakOrderQueue
         {
-            const int LinkCapacity = 16;
+            internal static readonly WeakOrderQueue Dummy = new WeakOrderQueue();
 
             sealed class Link
             {
-                int writeIndex;
+                private int writeIndex;
 
-                internal readonly Handle[] elements;
+                internal readonly DefaultHandle[] elements = new DefaultHandle[LinkCapacity];
                 internal Link next;
 
                 internal int ReadIndex { get; set; }
 
                 internal int WriteIndex
                 {
-                    get { return Volatile.Read(ref this.writeIndex); }
-                    set { Volatile.Write(ref this.writeIndex, value); }
+                    get => Volatile.Read(ref writeIndex);
+                    set => Volatile.Write(ref writeIndex, value);
                 }
 
-                internal Link()
+                internal void LazySetWriteIndex(int value) => writeIndex = value;
+            }
+
+            // This act as a place holder for the head Link but also will reclaim space once finalized.
+            // Its important this does not hold any reference to either Stack or WeakOrderQueue.
+            sealed class Head
+            {
+                readonly StrongBox<int> availableSharedCapacity;
+                readonly StrongBox<int> weakTableCounter;
+
+                internal Link link;
+
+                internal Head(StrongBox<int> availableSharedCapacity, StrongBox<int> weakTableCounter)
                 {
-                    this.elements = new Handle[LinkCapacity];
+                    this.availableSharedCapacity = availableSharedCapacity;
+                    this.weakTableCounter = weakTableCounter;
+                    if (weakTableCounter != null)
+                        Interlocked.Increment(ref weakTableCounter.Value);
+                }
+
+                ~Head()
+                {
+                    if (this.weakTableCounter != null)
+                    {
+                        Interlocked.Decrement(ref this.weakTableCounter.Value);
+                    }
+                    if (this.availableSharedCapacity == null)
+                    {
+                        return;
+                    }
+
+                    Link head = this.link;
+                    this.link = null;
+                    while (head != null)
+                    {
+                        ReclaimSpace(LinkCapacity);
+                        Link next = head.next;
+                        // Unlink to help GC and guard against GC nepotism.
+                        head.next = null;
+                        head = next;
+                    }
+                }
+
+                internal void ReclaimSpace(int space)
+                {
+                    Debug.Assert(space >= 0);
+                    Interlocked.Add(ref availableSharedCapacity.Value, space);
+                }
+
+                internal bool ReserveSpace(int space)
+                {
+                    return ReserveSpace(availableSharedCapacity, space);
+                }
+
+                internal static bool ReserveSpace(StrongBox<int> availableSharedCapacity, int space)
+                {
+                    Debug.Assert(space >= 0);
+                    for (; ; )
+                    {
+                        int available = Volatile.Read(ref availableSharedCapacity.Value);
+                        if (available < space)
+                        {
+                            return false;
+                        }
+                        if (Interlocked.CompareExchange(ref availableSharedCapacity.Value, available - space, available) == available)
+                        {
+                            return true;
+                        }
+                    }
                 }
             }
 
-            Link head, tail;
+            // chain of data items
+            readonly Head head;
+            Link tail;
+            // pointer to another queue of delayed items for the same stack
             internal WeakOrderQueue next;
-            internal WeakReference<Thread> ownerThread;
+            internal readonly WeakReference<Thread> owner;
             readonly int id = Interlocked.Increment(ref idSource);
 
-            internal bool IsEmpty => this.tail.ReadIndex == this.tail.WriteIndex;
-
-            internal WeakOrderQueue(Stack stack, Thread thread)
+            WeakOrderQueue()
             {
-                Contract.Requires(stack != null);
+                owner = null;
+                head = new Head(null, null);
+            }
 
-                this.ownerThread = new WeakReference<Thread>(thread);
-                this.head = this.tail = new Link();
-                lock (stack)
+            WeakOrderQueue(Stack stack, Thread thread, DelayedThreadLocal.CountedWeakTable countedWeakTable)
+            {
+                this.tail = new Link();
+
+                // Its important that we not store the Stack itself in the WeakOrderQueue as the Stack also is used in
+                // the WeakHashMap as key. So just store the enclosed AtomicInteger which should allow to have the
+                // Stack itself GCed.
+                this.head = new Head(stack.availableSharedCapacity, countedWeakTable.Counter);
+                this.head.link = tail;
+                this.owner = new WeakReference<Thread>(thread);
+            }
+
+            static WeakOrderQueue NewQueue(Stack stack, Thread thread, DelayedThreadLocal.CountedWeakTable countedWeakTable)
+            {
+                WeakOrderQueue queue = new WeakOrderQueue(stack, thread, countedWeakTable);
+                // Done outside of the constructor to ensure WeakOrderQueue.this does not escape the constructor and so
+                // may be accessed while its still constructed.
+                stack.Head = queue;
+
+                return queue;
+            }
+
+            internal WeakOrderQueue Next
+            {
+                set
                 {
-                    this.next = stack.HeadQueue;
-                    stack.HeadQueue = this;
+                    Debug.Assert(value != this);
+                    this.next = value;
                 }
             }
 
-            internal void Add(Handle handle)
+            /// <summary>
+            /// Allocate a new <see cref="WeakOrderQueue"/> or return <code>null</code> if not possible.
+            /// </summary>
+            internal static WeakOrderQueue Allocate(Stack stack, Thread thread, DelayedThreadLocal.CountedWeakTable countedWeakTable)
             {
-                Contract.Requires(handle != null);
+                // We allocated a Link so reserve the space
+                return Head.ReserveSpace(stack.availableSharedCapacity, LinkCapacity) ? NewQueue(stack, thread, countedWeakTable) : null;
+            }
 
+            internal void Add(DefaultHandle handle)
+            {
                 handle.lastRecycledId = this.id;
 
                 Link tail = this.tail;
                 int writeIndex = tail.WriteIndex;
                 if (writeIndex == LinkCapacity)
                 {
+                    if (!head.ReserveSpace(LinkCapacity))
+                    {
+                        // Drop it.
+                        return;
+                    }
+                    // We allocate a Link so reserve the space
                     this.tail = tail = tail.next = new Link();
                     writeIndex = tail.WriteIndex;
                 }
                 tail.elements[writeIndex] = handle;
                 handle.Stack = null;
-                tail.WriteIndex = writeIndex + 1;
+                // we lazy set to ensure that setting stack to null appears before we unnull it in the owning thread;
+                // this also means we guarantee visibility of an element in the queue if we see the index updated
+                tail.LazySetWriteIndex(writeIndex + 1);
             }
 
+            internal bool HasFinalData => this.tail.ReadIndex != this.tail.WriteIndex;
+
+            // transfer as many items as we can from this queue to the stack, returning true if any were transferred
             internal bool Transfer(Stack dst)
             {
-                // This method must be called by owner thread.
-                Contract.Requires(dst != null);
-
-                Link head = this.head;
+                Link head = this.head.link;
                 if (head == null)
                 {
                     return false;
@@ -129,7 +249,7 @@ namespace DotNetty.Common
                     {
                         return false;
                     }
-                    this.head = head = head.next;
+                    this.head.link = head = head.next;
                 }
 
                 int srcStart = head.ReadIndex;
@@ -151,12 +271,12 @@ namespace DotNetty.Common
 
                 if (srcStart != srcEnd)
                 {
-                    Handle[] srcElems = head.elements;
-                    Handle[] dstElems = dst.elements;
+                    DefaultHandle[] srcElems = head.elements;
+                    DefaultHandle[] dstElems = dst.elements;
                     int newDstSize = dstSize;
                     for (int i = srcStart; i < srcEnd; i++)
                     {
-                        Handle element = srcElems[i];
+                        DefaultHandle element = srcElems[i];
                         if (element.recycleId == 0)
                         {
                             element.recycleId = element.lastRecycledId;
@@ -165,18 +285,30 @@ namespace DotNetty.Common
                         {
                             throw new InvalidOperationException("recycled already");
                         }
+                        srcElems[i] = null;
+
+                        if (dst.DropHandle(element))
+                        {
+                            // Drop the object.
+                            continue;
+                        }
                         element.Stack = dst;
                         dstElems[newDstSize++] = element;
-                        srcElems[i] = null;
                     }
-                    dst.size = newDstSize;
 
                     if (srcEnd == LinkCapacity && head.next != null)
                     {
-                        this.head = head.next;
+                        // Add capacity back as the Link is GCed.
+                        this.head.ReclaimSpace(LinkCapacity);
+                        this.head.link = head.next;
                     }
 
                     head.ReadIndex = srcEnd;
+                    if (dst.size == newDstSize)
+                    {
+                        return false;
+                    }
+                    dst.size = newDstSize;
                     return true;
                 }
                 else
@@ -187,35 +319,54 @@ namespace DotNetty.Common
             }
         }
 
-        internal sealed class Stack
+        protected sealed class Stack
         {
-            internal readonly ThreadLocalPool Parent;
-            internal readonly Thread Thread;
+            // we keep a queue of per-thread queues, which is appended to once only, each time a new thread other
+            // than the stack owner recycles: when we run out of items in our stack we iterate this collection
+            // to scavenge those that can be reused. this permits us to incur minimal thread synchronisation whilst
+            // still recycling all items.
+            internal readonly ThreadLocalPool parent;
 
-            internal Handle[] elements;
+            // We store the Thread in a WeakReference as otherwise we may be the only ones that still hold a strong
+            // Reference to the Thread itself after it died because DefaultHandle will hold a reference to the Stack.
+            //
+            // The biggest issue is if we do not use a WeakReference the Thread may not be able to be collected at all if
+            // the user will store a reference to the DefaultHandle somewhere and never clear this reference (or not clear
+            // it in a timely manner).
+            internal readonly WeakReference<Thread> threadRef;
+            internal readonly StrongBox<int> availableSharedCapacity;
+            internal readonly int maxDelayedQueues;
 
             readonly int maxCapacity;
+            readonly int ratioMask;
+            internal DefaultHandle[] elements;
             internal int size;
+            int handleRecycleCount = -1; // Start with -1 so the first one will be recycled.
+            WeakOrderQueue cursorQueue, prevQueue;
+            volatile WeakOrderQueue headQueue;
 
-            WeakOrderQueue headQueue;
-            WeakOrderQueue cursorQueue;
-            WeakOrderQueue prevQueue;
-
-            internal WeakOrderQueue HeadQueue
+            internal Stack(ThreadLocalPool parent, Thread thread, int maxCapacity, int maxSharedCapacityFactor,
+                int ratioMask, int maxDelayedQueues)
             {
-                get { return Volatile.Read(ref this.headQueue); }
-                set { Volatile.Write(ref this.headQueue, value); }
+                this.parent = parent;
+                this.threadRef = new WeakReference<Thread>(thread);
+                this.maxCapacity = maxCapacity;
+                this.availableSharedCapacity = new StrongBox<int>(Math.Max(maxCapacity / maxSharedCapacityFactor, LinkCapacity));
+                this.elements = new DefaultHandle[Math.Min(DefaultInitialCapacity, maxCapacity)];
+                this.ratioMask = ratioMask;
+                this.maxDelayedQueues = maxDelayedQueues;
             }
 
-            internal int Size => this.size;
-
-            internal Stack(int maxCapacity, ThreadLocalPool parent, Thread thread)
+            internal WeakOrderQueue Head
             {
-                this.maxCapacity = maxCapacity;
-                this.Parent = parent;
-                this.Thread = thread;
-
-                this.elements = new Handle[Math.Min(InitialCapacity, maxCapacity)];
+                set
+                {
+                    lock (this)
+                    {
+                        value.next = headQueue;
+                        headQueue = value;
+                    }
+                }
             }
 
             internal int IncreaseCapacity(int expectedCapacity)
@@ -237,9 +388,25 @@ namespace DotNetty.Common
                 return newCapacity;
             }
 
-            internal void Push(Handle item)
+            internal void Push(DefaultHandle item)
             {
-                Contract.Requires(item != null);
+                Thread currentThread = Thread.CurrentThread;
+                if (threadRef.TryGetTarget(out Thread thread) && thread == currentThread)
+                {
+                    // The current Thread is the thread that belongs to the Stack, we can try to push the object now.
+                    PushNow(item);
+                }
+                else
+                {
+                    // The current Thread is not the one that belongs to the Stack
+                    // (or the Thread that belonged to the Stack was collected already), we need to signal that the push
+                    // happens later.
+                    PushLater(item, currentThread);
+                }
+            }
+
+            void PushNow(DefaultHandle item)
+            {
                 if ((item.recycleId | item.lastRecycledId) != 0)
                 {
                     throw new InvalidOperationException("released already");
@@ -247,7 +414,7 @@ namespace DotNetty.Common
                 item.recycleId = item.lastRecycledId = ownThreadId;
 
                 int size = this.size;
-                if (size >= this.maxCapacity)
+                if (size >= this.maxCapacity || DropHandle(item))
                 {
                     // Hit the maximum capacity - drop the possibly youngest object.
                     return;
@@ -261,7 +428,56 @@ namespace DotNetty.Common
                 this.size = size + 1;
             }
 
-            internal bool TryPop(out Handle item)
+            void PushLater(DefaultHandle item, Thread thread)
+            {
+                // we don't want to have a ref to the queue as the value in our weak map
+                // so we null it out; to ensure there are no races with restoring it later
+                // we impose a memory ordering here (no-op on x86)
+                DelayedThreadLocal.CountedWeakTable countedWeakTable = DelayedPool.Value;
+                ConditionalWeakTable<Stack, WeakOrderQueue> delayedRecycled = countedWeakTable.WeakTable;
+                delayedRecycled.TryGetValue(this, out WeakOrderQueue queue);
+                if (queue == null)
+                {
+                    if (Volatile.Read(ref countedWeakTable.Counter.Value) >= maxDelayedQueues)
+                    {
+                        // Add a dummy queue so we know we should drop the object
+                        delayedRecycled.Add(this, WeakOrderQueue.Dummy);
+                        return;
+                    }
+                    // Check if we already reached the maximum number of delayed queues and if we can allocate at all.
+                    if ((queue = WeakOrderQueue.Allocate(this, thread, countedWeakTable)) == null)
+                    {
+                        // drop object
+                        return;
+                    }
+                    delayedRecycled.Add(this, queue);
+                }
+                else if (queue == WeakOrderQueue.Dummy)
+                {
+                    // drop object
+                    return;
+                }
+
+                queue.Add(item);
+            }
+
+            internal bool DropHandle(DefaultHandle handle)
+            {
+                if (!handle.hasBeenRecycled)
+                {
+                    if ((++handleRecycleCount & ratioMask) != 0)
+                    {
+                        // Drop the object.
+                        return true;
+                    }
+                    handle.hasBeenRecycled = true;
+                }
+                return false;
+            }
+
+            internal DefaultHandle NewHandle() => new DefaultHandle(this);
+
+            internal bool TryPop(out DefaultHandle item)
             {
                 int size = this.size;
                 if (size == 0)
@@ -274,16 +490,17 @@ namespace DotNetty.Common
                     size = this.size;
                 }
                 size--;
-                Handle ret = this.elements[size];
+                DefaultHandle ret = this.elements[size];
+                elements[size] = null;
                 if (ret.lastRecycledId != ret.recycleId)
                 {
                     throw new InvalidOperationException("recycled multiple times");
                 }
                 ret.recycleId = 0;
                 ret.lastRecycledId = 0;
-                item = ret;
                 this.size = size;
 
+                item = ret;
                 return true;
             }
 
@@ -297,24 +514,29 @@ namespace DotNetty.Common
 
                 // reset our scavenge cursor
                 this.prevQueue = null;
-                this.cursorQueue = this.HeadQueue;
+                this.cursorQueue = this.headQueue;
                 return false;
             }
 
             bool ScavengeSome()
             {
+                WeakOrderQueue prev;
                 WeakOrderQueue cursor = this.cursorQueue;
                 if (cursor == null)
                 {
-                    cursor = this.HeadQueue;
+                    prev = null;
+                    cursor = this.headQueue;
                     if (cursor == null)
                     {
                         return false;
                     }
                 }
+                else
+                {
+                    prev = this.prevQueue;
+                }
 
                 bool success = false;
-                WeakOrderQueue prev = this.prevQueue;
                 do
                 {
                     if (cursor.Transfer(this))
@@ -324,13 +546,12 @@ namespace DotNetty.Common
                     }
 
                     WeakOrderQueue next = cursor.next;
-                    Thread ownerThread;
-                    if (!cursor.ownerThread.TryGetTarget(out ownerThread))
+                    if (!cursor.owner.TryGetTarget(out _))
                     {
                         // If the thread associated with the queue is gone, unlink it, after
                         // performing a volatile read to confirm there is no data left to collect.
                         // We never unlink the first queue, as we don't want to synchronize on updating the head.
-                        if (!cursor.IsEmpty)
+                        if (cursor.HasFinalData)
                         {
                             for (;;)
                             {
@@ -346,7 +567,7 @@ namespace DotNetty.Common
                         }
                         if (prev != null)
                         {
-                            prev.next = next;
+                            prev.Next = next;
                         }
                     }
                     else
@@ -364,46 +585,143 @@ namespace DotNetty.Common
             }
         }
 
-        internal static readonly int DefaultMaxCapacity = 262144;
-        internal static readonly int InitialCapacity = Math.Min(256, DefaultMaxCapacity);
+        const int DefaultInitialMaxCapacityPerThread = 4 * 1024; // Use 4k instances as default.
+        protected static readonly int DefaultMaxCapacityPerThread;
+        protected static readonly int DefaultInitialCapacity;
+        protected static readonly int DefaultMaxSharedCapacityFactor;
+        protected static readonly int DefaultMaxDelayedQueuesPerThread;
+        protected static readonly int LinkCapacity;
+        protected static readonly int DefaultRatio;
         static int idSource = int.MinValue;
         static readonly int ownThreadId = Interlocked.Increment(ref idSource);
 
-        internal static readonly DelayedThreadLocal DelayedPool = new DelayedThreadLocal();
+        protected static readonly DelayedThreadLocal DelayedPool = new DelayedThreadLocal();
 
-        internal sealed class DelayedThreadLocal : FastThreadLocal<ConditionalWeakTable<Stack, WeakOrderQueue>>
+        protected sealed class DelayedThreadLocal : FastThreadLocal<DelayedThreadLocal.CountedWeakTable>
         {
-            protected override ConditionalWeakTable<Stack, WeakOrderQueue> GetInitialValue() => new ConditionalWeakTable<Stack, WeakOrderQueue>();
+            public class CountedWeakTable
+            {
+                internal readonly ConditionalWeakTable<Stack, WeakOrderQueue> WeakTable = new ConditionalWeakTable<Stack, WeakOrderQueue>();
+
+                internal readonly StrongBox<int> Counter = new StrongBox<int>();
+            }
+            protected override CountedWeakTable GetInitialValue() => new CountedWeakTable();
         }
 
-        public ThreadLocalPool(int maxCapacity)
+        static ThreadLocalPool()
         {
-            Contract.Requires(maxCapacity > 0);
-            this.MaxCapacity = maxCapacity;
+            // In the future, we might have different maxCapacity for different object types.
+            // e.g. io.netty.recycler.maxCapacity.writeTask
+            //      io.netty.recycler.maxCapacity.outboundBuffer
+            int maxCapacityPerThread = SystemPropertyUtil.GetInt("io.netty.recycler.maxCapacityPerThread",
+                    SystemPropertyUtil.GetInt("io.netty.recycler.maxCapacity", DefaultInitialMaxCapacityPerThread));
+            if (maxCapacityPerThread < 0)
+            {
+                maxCapacityPerThread = DefaultInitialMaxCapacityPerThread;
+            }
+
+            DefaultMaxCapacityPerThread = maxCapacityPerThread;
+
+            DefaultMaxSharedCapacityFactor = Math.Max(2,
+                    SystemPropertyUtil.GetInt("io.netty.recycler.maxSharedCapacityFactor",
+                            2));
+
+            DefaultMaxDelayedQueuesPerThread = Math.Max(0,
+                    SystemPropertyUtil.GetInt("io.netty.recycler.maxDelayedQueuesPerThread",
+                            // We use the same value as default EventLoop number
+                            Environment.ProcessorCount * 2));
+
+            LinkCapacity = MathUtil.SafeFindNextPositivePowerOfTwo(
+                    Math.Max(SystemPropertyUtil.GetInt("io.netty.recycler.linkCapacity", 16), 16));
+
+            // By default we allow one push to a Recycler for each 8th try on handles that were never recycled before.
+            // This should help to slowly increase the capacity of the recycler while not be too sensitive to allocation
+            // bursts.
+            DefaultRatio = MathUtil.SafeFindNextPositivePowerOfTwo(SystemPropertyUtil.GetInt("io.netty.recycler.ratio", 8));
+
+            IInternalLogger logger = InternalLoggerFactory.GetInstance(typeof(ThreadLocalPool));
+            if (logger.DebugEnabled)
+            {
+                if (DefaultMaxCapacityPerThread == 0)
+                {
+                    logger.Debug("-Dio.netty.recycler.maxCapacityPerThread: disabled");
+                    logger.Debug("-Dio.netty.recycler.maxSharedCapacityFactor: disabled");
+                    logger.Debug("-Dio.netty.recycler.maxDelayedQueuesPerThread: disabled");
+                    logger.Debug("-Dio.netty.recycler.linkCapacity: disabled");
+                    logger.Debug("-Dio.netty.recycler.ratio: disabled");
+                }
+                else
+                {
+                    logger.Debug("-Dio.netty.recycler.maxCapacityPerThread: {}", DefaultMaxCapacityPerThread);
+                    logger.Debug("-Dio.netty.recycler.maxSharedCapacityFactor: {}", DefaultMaxSharedCapacityFactor);
+                    logger.Debug("-Dio.netty.recycler.maxDelayedQueuesPerThread: {}", DefaultMaxDelayedQueuesPerThread);
+                    logger.Debug("-Dio.netty.recycler.linkCapacity: {}", LinkCapacity);
+                    logger.Debug("-Dio.netty.recycler.ratio: {}", DefaultRatio);
+                }
+            }
+
+            DefaultInitialCapacity = Math.Min(DefaultMaxCapacityPerThread, 256);
         }
 
-        public int MaxCapacity { get; }
+        public ThreadLocalPool(int maxCapacityPerThread)
+            : this (maxCapacityPerThread, DefaultMaxSharedCapacityFactor, DefaultRatio, DefaultMaxDelayedQueuesPerThread)
+        {
+        }
+
+        public ThreadLocalPool(int maxCapacityPerThread, int maxSharedCapacityFactor,
+                       int ratio, int maxDelayedQueuesPerThread)
+        {
+            this.ratioMask = MathUtil.SafeFindNextPositivePowerOfTwo(ratio) - 1;
+            if (maxCapacityPerThread <= 0)
+            {
+                this.maxCapacityPerThread = 0;
+                this.maxSharedCapacityFactor = 1;
+                this.maxDelayedQueuesPerThread = 0;
+            }
+            else
+            {
+                this.maxCapacityPerThread = maxCapacityPerThread;
+                this.maxSharedCapacityFactor = Math.Max(1, maxSharedCapacityFactor);
+                this.maxDelayedQueuesPerThread = Math.Max(0, maxDelayedQueuesPerThread);
+            }
+        }
+
+        protected readonly int maxCapacityPerThread;
+        protected readonly int ratioMask;
+        protected readonly int maxSharedCapacityFactor;
+        protected readonly int maxDelayedQueuesPerThread;
     }
 
     public sealed class ThreadLocalPool<T> : ThreadLocalPool
         where T : class
     {
         readonly ThreadLocalStack threadLocal;
-        readonly Func<Handle, T> valueFactory;
         readonly bool preCreate;
+        readonly Func<Handle, T> valueFactory;
 
         public ThreadLocalPool(Func<Handle, T> valueFactory)
-            : this(valueFactory, DefaultMaxCapacity)
+            : this(valueFactory, DefaultMaxCapacityPerThread)
         {
         }
 
-        public ThreadLocalPool(Func<Handle, T> valueFactory, int maxCapacity)
-            : this(valueFactory, maxCapacity, false)
+        public ThreadLocalPool(Func<Handle, T> valueFactory, int maxCapacityPerThread)
+            : this(valueFactory, maxCapacityPerThread, DefaultMaxCapacityPerThread, DefaultRatio, DefaultMaxCapacityPerThread, false)
         {
         }
 
-        public ThreadLocalPool(Func<Handle, T> valueFactory, int maxCapacity, bool preCreate)
-            : base(maxCapacity)
+        public ThreadLocalPool(Func<Handle, T> valueFactory, int maxCapacityPerThread, bool preCreate)
+            : this(valueFactory, maxCapacityPerThread, DefaultMaxCapacityPerThread, DefaultRatio, DefaultMaxCapacityPerThread, false)
+        {
+        }
+
+        public ThreadLocalPool(Func<Handle, T> valueFactory, int maxCapacityPerThread, int maxSharedCapacityFactor)
+            : this(valueFactory, maxCapacityPerThread, maxSharedCapacityFactor, DefaultRatio, DefaultMaxCapacityPerThread, false)
+        {
+        }
+
+        public ThreadLocalPool(Func<Handle, T> valueFactory, int maxCapacityPerThread, int maxSharedCapacityFactor,
+                       int ratio, int maxDelayedQueuesPerThread, bool preCreate = false)
+            : base(maxCapacityPerThread, maxSharedCapacityFactor, ratio, maxDelayedQueuesPerThread)
         {
             Contract.Requires(valueFactory != null);
 
@@ -415,26 +733,30 @@ namespace DotNetty.Common
 
         public T Take()
         {
+            if (maxCapacityPerThread == 0)
+            {
+                return this.valueFactory(NoopHandle.Instance);
+            }
+
             Stack stack = this.threadLocal.Value;
-            Handle handle;
+            DefaultHandle handle;
             if (!stack.TryPop(out handle))
             {
-                handle = this.CreateValue(stack);
+                handle = CreateValue(stack);
             }
             return (T)handle.Value;
         }
 
-        Handle CreateValue(Stack stack)
+        DefaultHandle CreateValue(Stack stack)
         {
-            var handle = new Handle(stack);
-            T value = this.valueFactory(handle);
-            handle.Value = value;
+            var handle = stack.NewHandle();
+            handle.Value = this.valueFactory(handle);
             return handle;
         }
 
         internal int ThreadLocalCapacity => this.threadLocal.Value.elements.Length;
 
-        internal int ThreadLocalSize => this.threadLocal.Value.Size;
+        internal int ThreadLocalSize => this.threadLocal.Value.size;
 
         sealed class ThreadLocalStack : FastThreadLocal<Stack>
         {
@@ -447,15 +769,28 @@ namespace DotNetty.Common
 
             protected override Stack GetInitialValue()
             {
-                var stack = new Stack(this.owner.MaxCapacity, this.owner, Thread.CurrentThread);
+                var stack = new Stack(this.owner, Thread.CurrentThread, this.owner.maxCapacityPerThread,
+                        this.owner.maxSharedCapacityFactor, this.owner.ratioMask, this.owner.maxDelayedQueuesPerThread);
                 if (this.owner.preCreate)
                 {
-                    for (int i = 0; i < this.owner.MaxCapacity; i++)
+                    for (int i = 0; i < this.owner.maxCapacityPerThread; i++)
                     {
                         stack.Push(this.owner.CreateValue(stack));
                     }
                 }
                 return stack;
+            }
+
+            protected override void OnRemoval(Stack value)
+            {
+                // Let us remove the WeakOrderQueue from the WeakHashMap directly if its safe to remove some overhead
+                if (value.threadRef.TryGetTarget(out Thread valueThread) && valueThread == Thread.CurrentThread)
+                {
+                    if (DelayedPool.IsSet())
+                    {
+                        DelayedPool.Value.WeakTable.Remove(value);
+                    }
+                }
             }
         }
     }

--- a/test/DotNetty.Common.Tests/ThreadLocalPoolTest.cs
+++ b/test/DotNetty.Common.Tests/ThreadLocalPoolTest.cs
@@ -3,60 +3,128 @@
 
 namespace DotNetty.Common.Tests
 {
+    using DotNetty.Common.Concurrency;
     using System;
+    using System.Runtime.ExceptionServices;
+    using System.Threading;
     using System.Threading.Tasks;
     using Xunit;
 
     public class ThreadLocalPoolTest
     {
+        private static ThreadLocalPool<HandledObject> NewPool(int max)
+            => new ThreadLocalPool<HandledObject>(handle => new HandledObject(handle), max);
+
+        //Not use Task to do all `AtDifferentThreadTest`, because can't promise Task won't be run inline.
+
+        [Fact]
+        public void ThreadCanBeCollectedEvenIfHandledObjectIsReferencedTest()
+        {
+            ThreadLocalPool<HandledObject> pool = NewPool(1024);
+            HandledObject reference = null;
+            WeakReference<Thread> threadRef = null;
+            WeakReference<XThread> xThreadRef = null;
+
+            var thread1 = new Thread(() =>
+            {
+                //Don't know the reason, but thread2 will not be collected without wrapped with thread1
+                var thread2 = new Thread(() =>
+                {
+                    Volatile.Write(ref xThreadRef, new WeakReference<XThread>(XThread.CurrentThread));
+                    HandledObject data = pool.Take();
+                    // Store a reference to the HandledObject to ensure it is not collected when the run method finish.
+                    Volatile.Write(ref reference, data);
+                });
+                Volatile.Write(ref threadRef, new WeakReference<Thread>(thread2));
+                thread2.Start();
+                thread2.Join();
+                Assert.True(Volatile.Read(ref threadRef)?.TryGetTarget(out _));
+                Assert.True(Volatile.Read(ref xThreadRef)?.TryGetTarget(out _));
+
+                GC.KeepAlive(thread2);
+                // Null out so it can be collected.
+                thread2 = null;
+            });
+            thread1.Start();
+            thread1.Join();
+
+            for (int i = 0; i < 5; ++i)
+            {
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
+                GC.WaitForPendingFinalizers();
+
+                if (Volatile.Read(ref threadRef)?.TryGetTarget(out _) == true || Volatile.Read(ref xThreadRef)?.TryGetTarget(out _) == true)
+                    Thread.Sleep(100);
+            }
+
+            Assert.False(Volatile.Read(ref threadRef)?.TryGetTarget(out _));
+            Assert.False(Volatile.Read(ref xThreadRef)?.TryGetTarget(out _));
+
+            // Now call recycle after the Thread was collected to ensure this still works...
+            reference.Release();
+            reference = null;
+        }
+
         [Fact]
         public void MultipleReleaseTest()
         {
-            RecyclableObject obj = RecyclableObject.NewInstance();
+            ThreadLocalPool<HandledObject> pool = NewPool(1024);
+            HandledObject obj = pool.Take();
             obj.Release();
             var exception = Assert.ThrowsAny<InvalidOperationException>(() => obj.Release());
+            Assert.True(exception != null);
+        }
+        [Fact]
+        public void MultipleReleaseAtDifferentThreadTest()
+        {
+            ThreadLocalPool<HandledObject> pool = NewPool(1024);
+            HandledObject obj = pool.Take();
+
+            Thread thread = new Thread(() =>
+            {
+                obj.Release();
+            });
+            thread.Start();
+            thread.Join();
+
+            ExceptionDispatchInfo exceptionDispatchInfo = null;
+            Thread thread2 = new Thread(() =>
+            {
+                try
+                {
+                    obj.Release();
+                }
+                catch (Exception ex)
+                {
+                    Volatile.Write(ref exceptionDispatchInfo, ExceptionDispatchInfo.Capture(ex));
+                }
+            });
+            thread2.Start();
+            thread2.Join();
+            var exception = Assert.ThrowsAny<InvalidOperationException>(() => Volatile.Read(ref exceptionDispatchInfo)?.Throw());
             Assert.True(exception != null);
         }
 
         [Fact]
         public void ReleaseTest()
         {
-            RecyclableObject obj = RecyclableObject.NewInstance();
+            ThreadLocalPool<HandledObject> pool = NewPool(1024);
+            HandledObject obj = pool.Take();
             obj.Release();
-            RecyclableObject obj2 = RecyclableObject.NewInstance();
+            HandledObject obj2 = pool.Take();
             Assert.Same(obj, obj2);
             obj2.Release();
         }
 
         [Fact]
-        public void RecycleAtDifferentThreadTest()
+        public void ReleaseDisableTest()
         {
-            RecyclableObject obj = RecyclableObject.NewInstance();
-
-            RecyclableObject prevObject = obj;
-            Task.Run(() => { obj.Release(); }).Wait();
-            obj = RecyclableObject.NewInstance();
-
-            Assert.True(obj == prevObject);
+            ThreadLocalPool<HandledObject> pool = NewPool(-1);
+            HandledObject obj = pool.Take();
             obj.Release();
-        }
-
-        class RecyclableObject
-        {
-            internal static readonly ThreadLocalPool<RecyclableObject> pool =
-                new ThreadLocalPool<RecyclableObject>(handle =>
-                    new RecyclableObject(handle), 1, true);
-
-            readonly ThreadLocalPool.Handle handle;
-
-            public RecyclableObject(ThreadLocalPool.Handle handle)
-            {
-                this.handle = handle;
-            }
-
-            public static RecyclableObject NewInstance() => pool.Take();
-
-            public void Release() => handle.Release(this);
+            HandledObject obj2 = pool.Take();
+            Assert.NotSame(obj, obj2);
+            obj2.Release();
         }
 
         class HandledObject
@@ -74,17 +142,17 @@ namespace DotNetty.Common.Tests
         [Fact]
         public void MaxCapacityTest()
         {
-            this.MaxCapacityTest0(300);
+            MaxCapacityTest0(300);
             var rand = new Random();
             for (int i = 0; i < 50; i++)
             {
-                this.MaxCapacityTest0(rand.Next(1000) + 256); // 256 - 1256
+                MaxCapacityTest0(rand.Next(1000) + 256); // 256 - 1256
             }
         }
 
-        void MaxCapacityTest0(int maxCapacity)
+        static void MaxCapacityTest0(int maxCapacity)
         {
-            var recycler = new ThreadLocalPool<HandledObject>(handle => new HandledObject(handle), maxCapacity);
+            var recycler = NewPool(maxCapacity);
 
             var objects = new HandledObject[maxCapacity * 3];
             for (int i = 0; i < objects.Length; i++)
@@ -97,14 +165,36 @@ namespace DotNetty.Common.Tests
                 objects[i].Release();
                 objects[i] = null;
             }
-            Assert.Equal(maxCapacity, recycler.ThreadLocalCapacity);
+            Assert.True(maxCapacity >= recycler.ThreadLocalCapacity,
+                "The threadLocalCapacity (" + recycler.ThreadLocalCapacity + ") must be <= maxCapacity ("
+                + maxCapacity + ") as we not pool all new handles internally");
         }
 
         [Fact]
-        public void MaxCapacityWithRecycleAtDifferentThreadTest()
+        public void ReleaseAtDifferentThreadTest()
+        {
+            ThreadLocalPool<HandledObject> pool = new ThreadLocalPool<HandledObject>(handle => new HandledObject(handle),
+                256, 10, 2, 10);
+
+            HandledObject obj = pool.Take();
+            HandledObject obj2 = pool.Take();
+            Thread thread = new Thread(() =>
+            {
+                obj.Release();
+                obj2.Release();
+            });
+            thread.Start();
+            thread.Join();
+
+            Assert.Same(pool.Take(), obj);
+            Assert.NotSame(pool.Take(), obj2);
+        }
+
+        [Fact]
+        public void MaxCapacityWithReleaseAtDifferentThreadTest()
         {
             const int maxCapacity = 4; // Choose the number smaller than WeakOrderQueue.LINK_CAPACITY
-            var recycler = new ThreadLocalPool<HandledObject>(handle => new HandledObject(handle), maxCapacity);
+            var pool = NewPool(maxCapacity);
 
             // Borrow 2 * maxCapacity objects.
             // Return the half from the same thread.
@@ -113,7 +203,7 @@ namespace DotNetty.Common.Tests
             var array = new HandledObject[maxCapacity * 3];
             for (int i = 0; i < array.Length; i++)
             {
-                array[i] = recycler.Take();
+                array[i] = pool.Take();
             }
 
             for (int i = 0; i < maxCapacity; i++)
@@ -121,24 +211,76 @@ namespace DotNetty.Common.Tests
                 array[i].Release();
             }
 
-            Task.Run(() =>
+            Thread thread = new Thread(() =>
             {
                 for (int i = maxCapacity; i < array.Length; i++)
                 {
                     array[i].Release();
                 }
-            }).Wait();
+            });
+            thread.Start();
+            thread.Join();
 
-            Assert.Equal(recycler.ThreadLocalCapacity, maxCapacity);
-            Assert.Equal(recycler.ThreadLocalSize, maxCapacity);
+            Assert.Equal(maxCapacity, pool.ThreadLocalCapacity);
+            Assert.Equal(1, pool.ThreadLocalSize);
 
             for (int i = 0; i < array.Length; i++)
             {
-                recycler.Take();
+                pool.Take();
             }
 
-            Assert.Equal(maxCapacity, recycler.ThreadLocalCapacity);
-            Assert.Equal(0, recycler.ThreadLocalSize);
+            Assert.Equal(maxCapacity, pool.ThreadLocalCapacity);
+            Assert.Equal(0, pool.ThreadLocalSize);
+        }
+
+        [Fact]
+        public void DiscardingExceedingElementsWithReleaseAtDifferentThreadTest()
+        {
+            int maxCapacity = 32;
+            int instancesCount = 0;
+
+            ThreadLocalPool<HandledObject> pool = new ThreadLocalPool<HandledObject>(handle =>
+            {
+                Interlocked.Increment(ref instancesCount);
+                return new HandledObject(handle);
+            }, maxCapacity, 2);
+
+            // Borrow 2 * maxCapacity objects.
+            HandledObject[] array = new HandledObject[maxCapacity * 2];
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = pool.Take();
+            }
+
+            Assert.Equal(array.Length, Volatile.Read(ref instancesCount));
+            // Reset counter.
+            Volatile.Write(ref instancesCount, 0);
+
+            // Release from other thread.
+            Thread thread = new Thread(() =>
+            {
+                for (int i = 0; i < array.Length; i++)
+                {
+                    array[i].Release();
+                }
+            });
+            thread.Start();
+            thread.Join();
+
+            Assert.Equal(0, Volatile.Read(ref instancesCount));
+
+            // Borrow 2 * maxCapacity objects. Half of them should come from
+            // the recycler queue, the other half should be freshly allocated.
+            for (int i = 0; i < array.Length; i++)
+            {
+                array[i] = pool.Take();
+            }
+
+            // The implementation uses maxCapacity / 2 as limit per WeakOrderQueue
+            Assert.True(array.Length - maxCapacity / 2 <= Volatile.Read(ref instancesCount),
+                "The instances count (" + Volatile.Read(ref instancesCount) + ") must be <= array.length (" + array.Length
+                + ") - maxCapacity (" + maxCapacity + ") / 2 as we not pool all new handles" +
+                " internally");
         }
     }
 }


### PR DESCRIPTION
That help `ThreadLocalPool` not cache too much objects when huge sudden transfer, or when alloc and release happen on different thread.

The PR is already finished and no test failed. But I'm not sure the mean of comments below, and not sure whether it also works or not for dotnet.
https://github.com/Azure/DotNetty/pull/497/commits/3840311361fb42974f4f63387b265011014ee018#diff-629c893e2d4b4fee364a76632af183b6R230