### PR TITLE
Avoid throw SocketException(10057) in TcpSocketChannel.DoClose when t…

### DIFF
--- a/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
@@ -170,9 +170,12 @@ namespace DotNetty.Transport.Channels.Sockets
         {
             try
             {
-                if (this.TryResetState(StateFlags.Open | StateFlags.Active))
+                if (this.TryResetState(StateFlags.Open))
                 {
-                    this.Socket.Shutdown(SocketShutdown.Both);
+                    if (this.TryResetState(StateFlags.Active))
+                    {
+                        this.Socket.Shutdown(SocketShutdown.Both);
+                    }
                     this.Socket.Dispose();
                 }
             }


### PR DESCRIPTION
…he Socket is not connected

That make the first one no longer throw, and the second one not throw an strange `SocketException(10057): socket is not connected` when connecting is failed with any reason.

```csharp

            var bootstrap = new Bootstrap()
                .Group(new MultithreadEventLoopGroup())
                .Channel<TcpSocketChannel>()
                .Handler(new ActionChannelInitializer<IChannel>(_ => { }));
            try
            {
                var channel = await bootstrap.BindAsync(0);
                await channel.CloseAsync();
            }
            catch (Exception ex)
            {
            }
            try
            {
                var channel = await bootstrap.ConnectAsync(new IPEndPoint(IPAddress.Any, 0));
                await channel.CloseAsync();
            }
            catch (Exception ex)
            {
            }
```