### PR TITLE
Don't pool buffer objects

### DIFF
--- a/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
+++ b/src/DotNetty.Buffers/PooledHeapByteBuffer.cs
@@ -7,22 +7,17 @@ namespace DotNetty.Buffers
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
-    using DotNetty.Common;
     using DotNetty.Common.Internal;
 
     sealed class PooledHeapByteBuffer : PooledByteBuffer<byte[]>
     {
-        static readonly ThreadLocalPool<PooledHeapByteBuffer> Recycler = new ThreadLocalPool<PooledHeapByteBuffer>(handle => new PooledHeapByteBuffer(handle, 0));
-
         internal static PooledHeapByteBuffer NewInstance(int maxCapacity)
         {
-            PooledHeapByteBuffer buf = Recycler.Take();
-            buf.Reuse(maxCapacity);
-            return buf;
+            return new PooledHeapByteBuffer(maxCapacity);
         }
 
-        internal PooledHeapByteBuffer(ThreadLocalPool.Handle recyclerHandle, int maxCapacity)
-            : base(recyclerHandle, maxCapacity)
+        internal PooledHeapByteBuffer(int maxCapacity)
+            : base(maxCapacity)
         {
         }
 
@@ -108,6 +103,11 @@ namespace DotNetty.Buffers
 
         public override async Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken)
         {
+            if (length == 0)
+            {
+                return 0;
+            }
+
             int readTotal = 0;
             int read;
             int offset = this.ArrayOffset + index;

--- a/src/DotNetty.Buffers/PooledUnsafeDirectByteBuffer.cs
+++ b/src/DotNetty.Buffers/PooledUnsafeDirectByteBuffer.cs
@@ -8,23 +8,18 @@ namespace DotNetty.Buffers
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
-    using DotNetty.Common;
 
     sealed unsafe class PooledUnsafeDirectByteBuffer : PooledByteBuffer<byte[]>
     {
-        static readonly ThreadLocalPool<PooledUnsafeDirectByteBuffer> Recycler = new ThreadLocalPool<PooledUnsafeDirectByteBuffer>(handle => new PooledUnsafeDirectByteBuffer(handle, 0));
-
         byte* memoryAddress;
 
         internal static PooledUnsafeDirectByteBuffer NewInstance(int maxCapacity)
         {
-            PooledUnsafeDirectByteBuffer buf = Recycler.Take();
-            buf.Reuse(maxCapacity);
-            return buf;
+            return new PooledUnsafeDirectByteBuffer(maxCapacity);
         }
 
-        PooledUnsafeDirectByteBuffer(ThreadLocalPool.Handle recyclerHandle, int maxCapacity)
-            : base(recyclerHandle, maxCapacity)
+        PooledUnsafeDirectByteBuffer(int maxCapacity)
+            : base(maxCapacity)
         {
         }
 
@@ -47,6 +42,14 @@ namespace DotNetty.Buffers
         }
 
         public override bool IsDirect => true;
+
+        internal void Reuse(int maxCapacity)
+        {
+            this.SetMaxCapacity(maxCapacity);
+            this.SetReferenceCount(1);
+            this.SetIndex0(0, 0);
+            this.DiscardMarks();
+        }
 
         protected internal override byte _GetByte(int index) => *(this.memoryAddress + index);
 
@@ -121,8 +124,7 @@ namespace DotNetty.Buffers
         public override Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken)
         {
             this.CheckIndex(index, length);
-            int read = UnsafeByteBufferUtil.SetBytes(this, this.Addr(index), index, src, length);
-            return Task.FromResult(read);
+            return UnsafeByteBufferUtil.SetBytesAsync(this, this.Addr(index), index, src, length);
         }
 
         public override IByteBuffer Copy(int index, int length)

--- a/src/DotNetty.Buffers/PooledUnsafeDirectByteBuffer.cs
+++ b/src/DotNetty.Buffers/PooledUnsafeDirectByteBuffer.cs
@@ -124,7 +124,7 @@ namespace DotNetty.Buffers
         public override Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken)
         {
             this.CheckIndex(index, length);
-            return UnsafeByteBufferUtil.SetBytesAsync(this, this.Addr(index), index, src, length);
+            return UnsafeByteBufferUtil.SetBytesAsync(this, this.Addr(index), index, src, length, cancellationToken);
         }
 
         public override IByteBuffer Copy(int index, int length)

--- a/src/DotNetty.Buffers/UnpooledUnsafeDirectByteBuffer.cs
+++ b/src/DotNetty.Buffers/UnpooledUnsafeDirectByteBuffer.cs
@@ -296,31 +296,8 @@ namespace DotNetty.Buffers
         public override Task<int> SetBytesAsync(int index, Stream src, int length, CancellationToken cancellationToken)
         {
             this.CheckIndex(index, length);
-            int read;
-            if (length == 0)
-            {
-                return TaskEx.Zero;
-            }
-            IByteBuffer tmpBuf = this.Allocator.HeapBuffer(length);
-            tmpBuf.WriteBytesAsync(src, length, cancellationToken);
-            try
-            {
-                byte[] tmp = tmpBuf.Array;
-                int offset = tmpBuf.ArrayOffset;
-                int readBytes = input.Read(tmp, offset, length);
-                if (readBytes > 0)
-                {
-                    PlatformDependent.CopyMemory(tmp, offset, addr, readBytes);
-                }
-
-                return readBytes;
-            }
-
             fixed (byte* addr = &this.Addr(index))
-            {
-                read = UnsafeByteBufferUtil.SetBytes(this, addr, index, src, length);
-            }
-            return Task.FromResult(read);
+                return UnsafeByteBufferUtil.SetBytesAsync(this, addr, index, src, length, cancellationToken);
         }
 
         public override int IoBufferCount => 1;

--- a/src/DotNetty.Buffers/UnsafeByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/UnsafeByteBufferUtil.cs
@@ -241,7 +241,7 @@ namespace DotNetty.Buffers
             }
         }
 
-        internal static Task<int> SetBytesAsync(AbstractByteBuffer buf, byte* addr, int index, Stream input, int length)
+        internal static Task<int> SetBytesAsync(AbstractByteBuffer buf, byte* addr, int index, Stream input, int length, CancellationToken cancellationToken)
         {
             if (length == 0)
             {
@@ -249,7 +249,7 @@ namespace DotNetty.Buffers
             }
 
             IByteBuffer tmpBuf = buf.Allocator.HeapBuffer(length);
-            return tmpBuf.SetBytesAsync(0, input, length, CancellationToken.None)
+            return tmpBuf.SetBytesAsync(0, input, length, cancellationToken)
                 .ContinueWith(t => {
                     try
                     {

--- a/src/DotNetty.Buffers/UnsafeByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/UnsafeByteBufferUtil.cs
@@ -8,7 +8,10 @@ namespace DotNetty.Buffers
     using System.IO;
     using System.Runtime.CompilerServices;
     using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
     using DotNetty.Common.Internal;
+    using DotNetty.Common.Utilities;
 
     static unsafe class UnsafeByteBufferUtil
     {
@@ -214,6 +217,11 @@ namespace DotNetty.Buffers
 
         internal static int SetBytes(AbstractByteBuffer buf, byte* addr, int index, Stream input, int length)
         {
+            if (length == 0)
+            {
+                return 0;
+            }
+
             IByteBuffer tmpBuf = buf.Allocator.HeapBuffer(length);
             try
             {
@@ -231,6 +239,32 @@ namespace DotNetty.Buffers
             {
                 tmpBuf.Release();
             }
+        }
+
+        internal static Task<int> SetBytesAsync(AbstractByteBuffer buf, byte* addr, int index, Stream input, int length)
+        {
+            if (length == 0)
+            {
+                return TaskEx.Zero;
+            }
+
+            IByteBuffer tmpBuf = buf.Allocator.HeapBuffer(length);
+            return tmpBuf.SetBytesAsync(0, input, length, CancellationToken.None)
+                .ContinueWith(t => {
+                    try
+                    {
+                        var read = t.Result;
+                        if (read > 0)
+                        {
+                            PlatformDependent.CopyMemory(tmpBuf.Array, tmpBuf.ArrayOffset, addr, read);
+                        }
+                        return read;
+                    }
+                    finally
+                    {
+                        tmpBuf.Release();
+                    }
+                });
         }
 
         internal static void GetBytes(AbstractByteBuffer buf, byte* addr, int index, IByteBuffer dst, int dstIndex, int length)


### PR DESCRIPTION
- removing pooling of pooled buffers themselves (keeping memory pooling only)
- fixing SetBytesAsync impl for unsafe direct buffers