### PR TITLE
Update to NetStandard 2.0

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,16 +1,18 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "dotnet",
-    "isShellCommand": true,
     "args": [],
     "tasks": [
         {
-            "taskName": "msbuild",
+            "label": "msbuild",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
+                "msbuild",
                 "dotnetty.sln"
             ],
-            "isBuildCommand": true,
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": "build"
         }
     ]
 }

--- a/appveyor.yaml
+++ b/appveyor.yaml
@@ -1,5 +1,5 @@
 version: 0.4.{build}
-image: Visual Studio 2017 RC
+image: Visual Studio 2019
 pull_requests:
   do_not_increment_build_number: true
 build_script:

--- a/build.cake
+++ b/build.cake
@@ -23,8 +23,7 @@ var csProjectFiles = GetFiles("./src/**/*.csproj");
 var nuget = Directory("tools");
 var output = Directory("build");
 var outputBinaries = output + Directory("binaries");
-var outputBinariesNet45 = outputBinaries + Directory("net45");
-var outputBinariesNetstandard = outputBinaries + Directory("netstandard1.3");
+var outputBinariesNetstandard = outputBinaries + Directory("netstandard2.0");
 var outputPackages = output + Directory("packages");
 var outputNuGet = output + Directory("nuget");
 var outputPerfResults = Directory("perfResults");
@@ -37,7 +36,7 @@ Task("Clean")
   // Clean artifact directories.
   CleanDirectories(new DirectoryPath[] {
     output, outputBinaries, outputPackages, outputNuGet,
-    outputBinariesNet45, outputBinariesNetstandard
+    outputBinariesNetstandard
   });
 
   if(!skipClean) {
@@ -104,24 +103,12 @@ Task("Test")
 
     //   // DotNetCoreTest(project.GetDirectory().FullPath, new DotNetCoreTestSettings {
     //   //   Configuration = configuration,
-    //   //   Framework = "netstandard1.3",
+    //   //   Framework = "netstandard2.0",
     //   //   Runtime = "unix-64"
     //   // });
 
     //   var dirPath = project.GetDirectory().FullPath;
     //   var testFile = project.GetFilenameWithoutExtension();
-
-    //   using(var process = StartAndReturnProcess("mono", new ProcessSettings{Arguments =
-    //     dirPath + "/bin/" + configuration + "/net451/unix-x64/dotnet-test-xunit.exe" + " " +
-    //     dirPath + "/bin/" + configuration + "/net451/unix-x64/" + testFile + ".dll"}))
-    //   {
-    //     process.WaitForExit();
-    //     if (process.GetExitCode() != 0)
-    //     {
-    //       throw new Exception("Mono tests failed");
-    //     }
-    //   }
-    // }
   }
 });
 

--- a/build.ps1
+++ b/build.ps1
@@ -33,7 +33,7 @@ Param(
 
 $CakeVersion = "0.27.1"
 $DotNetChannel = "Current";
-$DotNetVersion = "3.1.1402";
+$DotNetVersion = "3.1.402";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 # Temporarily skip verification of addins.

--- a/build.ps1
+++ b/build.ps1
@@ -33,7 +33,7 @@ Param(
 
 $CakeVersion = "0.27.1"
 $DotNetChannel = "Current";
-$DotNetVersion = "2.1.101";
+$DotNetVersion = "3.1.1402";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 # Temporarily skip verification of addins.

--- a/build.ps1
+++ b/build.ps1
@@ -74,17 +74,17 @@ if (Get-Command dotnet -ErrorAction SilentlyContinue) {
     $FoundDotNetCliVersion = dotnet --version;
 }
 
-if($FoundDotNetCliVersion -ne $DotNetVersion) {
-    $InstallPath = Join-Path $PSScriptRoot ".dotnet"
-    if (!(Test-Path $InstallPath)) {
-        mkdir -Force $InstallPath | Out-Null;
-    }
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
-    & $InstallPath\dotnet-install.ps1 -Channel $DotNetChannel -Version $DotNetVersion -InstallDir $InstallPath;
+# if($FoundDotNetCliVersion -ne $DotNetVersion) {
+#     $InstallPath = Join-Path $PSScriptRoot ".dotnet"
+#     if (!(Test-Path $InstallPath)) {
+#         mkdir -Force $InstallPath | Out-Null;
+#     }
+#     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
+#     & $InstallPath\dotnet-install.ps1 -Channel $DotNetChannel -Version $DotNetVersion -InstallDir $InstallPath;
 
-    Remove-PathVariable "$InstallPath"
-    $env:PATH = "$InstallPath;$env:PATH"
-}
+#     Remove-PathVariable "$InstallPath"
+#     $env:PATH = "$InstallPath;$env:PATH"
+# }
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/examples/Discard.Client/Discard.Client.csproj
+++ b/examples/Discard.Client/Discard.Client.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Discard.Server/Discard.Server.csproj
+++ b/examples/Discard.Server/Discard.Server.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Echo.Client/Echo.Client.csproj
+++ b/examples/Echo.Client/Echo.Client.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Echo.Server/Echo.Server.csproj
+++ b/examples/Echo.Server/Echo.Server.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Examples.Common/ExampleHelper.cs
+++ b/examples/Examples.Common/ExampleHelper.cs
@@ -6,8 +6,8 @@ namespace Examples.Common
     using System;
     using DotNetty.Common.Internal.Logging;
     using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.Logging.Console;
-
+    using Microsoft.Extensions.Logging;
+ 
     public static class ExampleHelper
     {
         static ExampleHelper()
@@ -22,16 +22,12 @@ namespace Examples.Common
         {
             get
             {
-#if NETSTANDARD1_3
                 return AppContext.BaseDirectory;
-#else
-                return AppDomain.CurrentDomain.BaseDirectory;
-#endif
             }
         }
 
         public static IConfigurationRoot Configuration { get; }
 
-        public static void SetConsoleLogger() => InternalLoggerFactory.DefaultFactory.AddProvider(new ConsoleLoggerProvider((s, level) => true, false));
+        public static void SetConsoleLogger() => InternalLoggerFactory.DefaultFactory = LoggerFactory.Create(builder => builder.AddConsole());
     }
 }

--- a/examples/Examples.Common/Examples.Common.csproj
+++ b/examples/Examples.Common/Examples.Common.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/examples/Factorial.Client/Factorial.Client.csproj
+++ b/examples/Factorial.Client/Factorial.Client.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Factorial.Server/Factorial.Server.csproj
+++ b/examples/Factorial.Server/Factorial.Server.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Factorial/Factorial.csproj
+++ b/examples/Factorial/Factorial.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/examples/HttpServer/HttpServer.csproj
+++ b/examples/HttpServer/HttpServer.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/QuoteOfTheMoment.Client/QuoteOfTheMoment.Client.csproj
+++ b/examples/QuoteOfTheMoment.Client/QuoteOfTheMoment.Client.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/QuoteOfTheMoment.Server/QuoteOfTheMoment.Server.csproj
+++ b/examples/QuoteOfTheMoment.Server/QuoteOfTheMoment.Server.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/SecureChat.Client/SecureChat.Client.csproj
+++ b/examples/SecureChat.Client/SecureChat.Client.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/SecureChat.Server/SecureChat.Server.csproj
+++ b/examples/SecureChat.Server/SecureChat.Server.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Telnet.Client/Telnet.Client.csproj
+++ b/examples/Telnet.Client/Telnet.Client.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/Telnet.Server/Telnet.Server.csproj
+++ b/examples/Telnet.Server/Telnet.Server.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/WebSockets.Client/WebSockets.Client.csproj
+++ b/examples/WebSockets.Client/WebSockets.Client.csproj
@@ -2,12 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/examples/WebSockets.Server/WebSockets.Server.csproj
+++ b/examples/WebSockets.Server/WebSockets.Server.csproj
@@ -2,13 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\shared\dotnetty.com.pfx" Link="dotnetty.com.pfx">

--- a/src/DotNetty.Buffers/DotNetty.Buffers.csproj
+++ b/src/DotNetty.Buffers/DotNetty.Buffers.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: buffer management</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/DotNetty.Buffers/DotNetty.Buffers.csproj
+++ b/src/DotNetty.Buffers/DotNetty.Buffers.csproj
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>Buffer management in DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: buffer management</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -22,22 +22,18 @@
     <PackageLicenseUrl>https://github.com/Azure/DotNetty/blob/master/LICENSE.txt</PackageLicenseUrl>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotNetty.Common\DotNetty.Common.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Buffers/UnsafeByteBufferUtil.cs
+++ b/src/DotNetty.Buffers/UnsafeByteBufferUtil.cs
@@ -386,14 +386,7 @@ namespace DotNetty.Buffers
 
         internal static string GetString(byte* src, int length, Encoding encoding)
         {
-#if NETSTANDARD1_3
             return encoding.GetString(src, length);
-#else
-            int charCount = encoding.GetCharCount(src, length);
-            char* chars = stackalloc char[charCount];
-            encoding.GetChars(src, length, chars, charCount);
-            return new string(chars, 0, charCount);
-#endif
         }
 
         internal static UnpooledUnsafeDirectByteBuffer NewUnsafeDirectByteBuffer(IByteBufferAllocator alloc, int initialCapacity, int maxCapacity) =>  

--- a/src/DotNetty.Codecs.Http/DotNetty.Codecs.Http.csproj
+++ b/src/DotNetty.Codecs.Http/DotNetty.Codecs.Http.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Http</PackageId>
     <Description>Http codec for DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: Http codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -24,13 +24,13 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotNetty.Common\DotNetty.Common.csproj" />
@@ -39,11 +39,7 @@
     <ProjectReference Include="..\DotNetty.Handlers\DotNetty.Handlers.csproj" />
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Codecs.Http/DotNetty.Codecs.Http.csproj
+++ b/src/DotNetty.Codecs.Http/DotNetty.Codecs.Http.csproj
@@ -8,7 +8,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: Http codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
+++ b/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: MQTT codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
+++ b/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Mqtt</PackageId>
     <Description>MQTT codec for DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: MQTT codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -22,7 +22,7 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
@@ -33,11 +33,7 @@
     <ProjectReference Include="..\DotNetty.Codecs\DotNetty.Codecs.csproj" />
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
+++ b/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Protobuf</PackageId>
     <Description>Protobuf Proto3 codec for DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: Protobuf Proto3 codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -22,7 +22,7 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
@@ -34,13 +34,7 @@
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="Google.Protobuf" Version="3.17.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
+++ b/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: Protobuf Proto3 codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
+++ b/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
@@ -34,7 +34,7 @@
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.17.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.17.1" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Codecs.ProtocolBuffers/DotNetty.Codecs.ProtocolBuffers.csproj
+++ b/src/DotNetty.Codecs.ProtocolBuffers/DotNetty.Codecs.ProtocolBuffers.csproj
@@ -8,7 +8,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: ProtocolBuffers Proto2 codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/DotNetty.Codecs.ProtocolBuffers/DotNetty.Codecs.ProtocolBuffers.csproj
+++ b/src/DotNetty.Codecs.ProtocolBuffers/DotNetty.Codecs.ProtocolBuffers.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.ProtocolBuffers</PackageId>
     <Description>ProtocolBuffers Proto2 codec for DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: ProtocolBuffers Proto2 codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -23,8 +23,7 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
@@ -37,13 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Google.ProtocolBuffers" Version="2.4.1.555" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Codecs.Redis/DotNetty.Codecs.Redis.csproj
+++ b/src/DotNetty.Codecs.Redis/DotNetty.Codecs.Redis.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: Redis codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/DotNetty.Codecs.Redis/DotNetty.Codecs.Redis.csproj
+++ b/src/DotNetty.Codecs.Redis/DotNetty.Codecs.Redis.csproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Redis</PackageId>
     <Description>Redis codec for DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: Redis codec</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -22,7 +22,7 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
@@ -33,11 +33,7 @@
     <ProjectReference Include="..\DotNetty.Codecs\DotNetty.Codecs.csproj" />
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Codecs/DotNetty.Codecs.csproj
+++ b/src/DotNetty.Codecs/DotNetty.Codecs.csproj
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs</PackageId>
     <Description>General purpose codecs for DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: codecs</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -24,24 +24,20 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DotNetty.Common\DotNetty.Common.csproj" />
     <ProjectReference Include="..\DotNetty.Buffers\DotNetty.Buffers.csproj" />
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Codecs/DotNetty.Codecs.csproj
+++ b/src/DotNetty.Codecs/DotNetty.Codecs.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: codecs</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Common</PackageId>
     <Description>DotNetty common routines</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: common routines</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -24,22 +24,15 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Runtime" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -8,7 +8,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: common routines</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -8,7 +8,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: handlers</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Handlers</PackageId>
     <Description>Application handlers for DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: handlers</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -23,7 +23,7 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
@@ -34,13 +34,9 @@
     <ProjectReference Include="..\DotNetty.Codecs\DotNetty.Codecs.csproj" />
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup>
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Handlers/Tls/SniHandler.cs
+++ b/src/DotNetty.Handlers/Tls/SniHandler.cs
@@ -214,12 +214,8 @@ namespace DotNetty.Handlers.Tls
                                                 };
 
                                                 hostname = idn.GetAscii(hostname);
-#if NETSTANDARD1_3
                                                 // TODO: netcore does not have culture sensitive tolower()
                                                 hostname = hostname.ToLowerInvariant();
-#else
-                                                hostname = hostname.ToLower(new CultureInfo("en-US"));
-#endif
                                                 this.Select(context, hostname);
                                                 return;
                                             }

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -674,14 +674,7 @@ namespace DotNetty.Handlers.Tls
             int inputLength;
             TaskCompletionSource<int> readCompletionSource;
             ArraySegment<byte> sslOwnedBuffer;
-#if NETSTANDARD1_3
             int readByteCount;
-#else
-            SynchronousAsyncResult<int> syncReadResult;
-            AsyncCallback readCallback;
-            TaskCompletionSource writeCompletion;
-            AsyncCallback writeCallback;
-#endif
 
             public MediationStream(TlsHandler owner)
             {
@@ -718,7 +711,6 @@ namespace DotNetty.Handlers.Tls
                 }
                 this.sslOwnedBuffer = default(ArraySegment<byte>);
 
-#if NETSTANDARD1_3
                 this.readByteCount = this.ReadFromInput(sslBuffer.Array, sslBuffer.Offset, sslBuffer.Count);
                 // hack: this tricks SslStream's continuation to run synchronously instead of dispatching to TP. Remove once Begin/EndRead are available. 
                 new Task(
@@ -731,20 +723,8 @@ namespace DotNetty.Handlers.Tls
                     },
                     this)
                     .RunSynchronously(TaskScheduler.Default);
-#else
-                int read = this.ReadFromInput(sslBuffer.Array, sslBuffer.Offset, sslBuffer.Count);
-
-                TaskCompletionSource<int> promise = this.readCompletionSource;
-                this.readCompletionSource = null;
-                promise.TrySetResult(read);
-
-                AsyncCallback callback = this.readCallback;
-                this.readCallback = null;
-                callback?.Invoke(promise.Task);
-#endif
             }
 
-#if NETSTANDARD1_3
             public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 if (this.SourceReadableBytes > 0)
@@ -760,140 +740,11 @@ namespace DotNetty.Handlers.Tls
                 this.readCompletionSource = new TaskCompletionSource<int>();
                 return this.readCompletionSource.Task;
             }
-#else
-            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-            {
-                if (this.SourceReadableBytes > 0)
-                {
-                    // we have the bytes available upfront - write out synchronously
-                    int read = this.ReadFromInput(buffer, offset, count);
-                    var res = this.PrepareSyncReadResult(read, state);
-                    callback?.Invoke(res);
-                    return res;
-                }
-
-                Contract.Assert(this.sslOwnedBuffer.Array == null);
-                // take note of buffer - we will pass bytes there once available
-                this.sslOwnedBuffer = new ArraySegment<byte>(buffer, offset, count);
-                this.readCompletionSource = new TaskCompletionSource<int>(state);
-                this.readCallback = callback;
-                return this.readCompletionSource.Task;
-            }
-
-            public override int EndRead(IAsyncResult asyncResult)
-            {
-                SynchronousAsyncResult<int> syncResult = this.syncReadResult;
-                if (ReferenceEquals(asyncResult, syncResult))
-                {
-                    return syncResult.Result;
-                }
-
-                Debug.Assert(this.readCompletionSource == null || this.readCompletionSource.Task == asyncResult);
-                Contract.Assert(!((Task<int>)asyncResult).IsCanceled);
-
-                try
-                {
-                    return ((Task<int>)asyncResult).Result;
-                }
-                catch (AggregateException ex)
-                {
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    throw; // unreachable
-                }
-            }
-
-            IAsyncResult PrepareSyncReadResult(int readBytes, object state)
-            {
-                // it is safe to reuse sync result object as it can't lead to leak (no way to attach to it via handle)
-                SynchronousAsyncResult<int> result = this.syncReadResult ?? (this.syncReadResult = new SynchronousAsyncResult<int>());
-                result.Result = readBytes;
-                result.AsyncState = state;
-                return result;
-            }
-#endif
 
             public override void Write(byte[] buffer, int offset, int count) => this.owner.FinishWrap(buffer, offset, count);
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
                 => this.owner.FinishWrapNonAppDataAsync(buffer, offset, count);
-
-#if !NETSTANDARD1_3
-            static readonly Action<Task, object> WriteCompleteCallback = HandleChannelWriteComplete;
-
-            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-            {
-                Task task = this.WriteAsync(buffer, offset, count);
-                switch (task.Status)
-                {
-                    case TaskStatus.RanToCompletion:
-                        // write+flush completed synchronously (and successfully)
-                        var result = new SynchronousAsyncResult<int>();
-                        result.AsyncState = state;
-                        callback?.Invoke(result);
-                        return result;
-                    default:
-                        if (callback != null || state != task.AsyncState)
-                        {
-                            Contract.Assert(this.writeCompletion == null);
-                            this.writeCallback = callback;
-                            var tcs = new TaskCompletionSource(state);
-                            this.writeCompletion = tcs;
-                            task.ContinueWith(WriteCompleteCallback, this, TaskContinuationOptions.ExecuteSynchronously);
-                            return tcs.Task;
-                        }
-                        else
-                        {
-                            return task;
-                        }
-                }
-            }
-
-            static void HandleChannelWriteComplete(Task writeTask, object state)
-            {
-                var self = (MediationStream)state;
-
-                AsyncCallback callback = self.writeCallback;
-                self.writeCallback = null;
-
-                var promise = self.writeCompletion;
-                self.writeCompletion = null;
-
-                switch (writeTask.Status)
-                {
-                    case TaskStatus.RanToCompletion:
-                        promise.TryComplete();
-                        break;
-                    case TaskStatus.Canceled:
-                        promise.TrySetCanceled();
-                        break;
-                    case TaskStatus.Faulted:
-                        promise.TrySetException(writeTask.Exception);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException("Unexpected task status: " + writeTask.Status);
-                }
-
-                callback?.Invoke(promise.Task);
-            }
-
-            public override void EndWrite(IAsyncResult asyncResult)
-            {
-                if (asyncResult is SynchronousAsyncResult<int>)
-                {
-                    return;
-                }
-
-                try
-                {
-                    ((Task)asyncResult).Wait();
-                }
-                catch (AggregateException ex)
-                {
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    throw;
-                }
-            }
-#endif
 
             int ReadFromInput(byte[] destination, int destinationOffset, int destinationCapacity)
             {

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -59,8 +59,8 @@ namespace DotNetty.Handlers.Tls
 
         public static TlsHandler Client(string targetHost) => new TlsHandler(new ClientTlsSettings(targetHost));
 
-        public static TlsHandler Client(string targetHost, X509Certificate clientCertificate) => new TlsHandler(new ClientTlsSettings(targetHost, new List<X509Certificate>{ clientCertificate }));
- 
+        public static TlsHandler Client(string targetHost, X509Certificate clientCertificate) => new TlsHandler(new ClientTlsSettings(targetHost, new List<X509Certificate> { clientCertificate }));
+
         public static TlsHandler Server(X509Certificate certificate) => new TlsHandler(new ServerTlsSettings(certificate));
 
         // using workaround mentioned here: https://github.com/dotnet/corefx/issues/4510
@@ -674,10 +674,7 @@ namespace DotNetty.Handlers.Tls
             int inputLength;
             TaskCompletionSource<int> readCompletionSource;
             ArraySegment<byte> sslOwnedBuffer;
-            SynchronousAsyncResult<int> syncReadResult;
-            AsyncCallback readCallback;
-            TaskCompletionSource writeCompletion;
-            AsyncCallback writeCallback;
+            int readByteCount;
 
             public MediationStream(TlsHandler owner)
             {
@@ -714,147 +711,40 @@ namespace DotNetty.Handlers.Tls
                 }
                 this.sslOwnedBuffer = default(ArraySegment<byte>);
 
-                int read = this.ReadFromInput(sslBuffer.Array, sslBuffer.Offset, sslBuffer.Count);
-
-                TaskCompletionSource<int> promise = this.readCompletionSource;
-                this.readCompletionSource = null;
-                promise.TrySetResult(read);
-
-                AsyncCallback callback = this.readCallback;
-                this.readCallback = null;
-                callback?.Invoke(promise.Task);
+                this.readByteCount = this.ReadFromInput(sslBuffer.Array, sslBuffer.Offset, sslBuffer.Count);
+                // hack: this tricks SslStream's continuation to run synchronously instead of dispatching to TP. Remove once Begin/EndRead are available. 
+                new Task(
+                    ms =>
+                    {
+                        var self = (MediationStream)ms;
+                        TaskCompletionSource<int> p = self.readCompletionSource;
+                        self.readCompletionSource = null;
+                        p.TrySetResult(self.readByteCount);
+                    },
+                    this)
+                    .RunSynchronously(TaskScheduler.Default);
             }
 
-            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 if (this.SourceReadableBytes > 0)
                 {
                     // we have the bytes available upfront - write out synchronously
                     int read = this.ReadFromInput(buffer, offset, count);
-                    var res = this.PrepareSyncReadResult(read, state);
-                    callback?.Invoke(res);
-                    return res;
+                    return Task.FromResult(read);
                 }
 
                 Contract.Assert(this.sslOwnedBuffer.Array == null);
                 // take note of buffer - we will pass bytes there once available
                 this.sslOwnedBuffer = new ArraySegment<byte>(buffer, offset, count);
-                this.readCompletionSource = new TaskCompletionSource<int>(state);
-                this.readCallback = callback;
+                this.readCompletionSource = new TaskCompletionSource<int>();
                 return this.readCompletionSource.Task;
-            }
-
-            public override int EndRead(IAsyncResult asyncResult)
-            {
-                SynchronousAsyncResult<int> syncResult = this.syncReadResult;
-                if (ReferenceEquals(asyncResult, syncResult))
-                {
-                    return syncResult.Result;
-                }
-
-                Debug.Assert(this.readCompletionSource == null || this.readCompletionSource.Task == asyncResult);
-                Contract.Assert(!((Task<int>)asyncResult).IsCanceled);
-
-                try
-                {
-                    return ((Task<int>)asyncResult).Result;
-                }
-                catch (AggregateException ex)
-                {
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    throw; // unreachable
-                }
-            }
-
-            IAsyncResult PrepareSyncReadResult(int readBytes, object state)
-            {
-                // it is safe to reuse sync result object as it can't lead to leak (no way to attach to it via handle)
-                SynchronousAsyncResult<int> result = this.syncReadResult ?? (this.syncReadResult = new SynchronousAsyncResult<int>());
-                result.Result = readBytes;
-                result.AsyncState = state;
-                return result;
             }
 
             public override void Write(byte[] buffer, int offset, int count) => this.owner.FinishWrap(buffer, offset, count);
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
                 => this.owner.FinishWrapNonAppDataAsync(buffer, offset, count);
-
-            static readonly Action<Task, object> WriteCompleteCallback = HandleChannelWriteComplete;
-
-            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-            {
-                Task task = this.WriteAsync(buffer, offset, count);
-                switch (task.Status)
-                {
-                    case TaskStatus.RanToCompletion:
-                        // write+flush completed synchronously (and successfully)
-                        var result = new SynchronousAsyncResult<int>();
-                        result.AsyncState = state;
-                        callback?.Invoke(result);
-                        return result;
-                    default:
-                        if (callback != null || state != task.AsyncState)
-                        {
-                            Contract.Assert(this.writeCompletion == null);
-                            this.writeCallback = callback;
-                            var tcs = new TaskCompletionSource(state);
-                            this.writeCompletion = tcs;
-                            task.ContinueWith(WriteCompleteCallback, this, TaskContinuationOptions.ExecuteSynchronously);
-                            return tcs.Task;
-                        }
-                        else
-                        {
-                            return task;
-                        }
-                }
-            }
-
-            static void HandleChannelWriteComplete(Task writeTask, object state)
-            {
-                var self = (MediationStream)state;
-
-                AsyncCallback callback = self.writeCallback;
-                self.writeCallback = null;
-
-                var promise = self.writeCompletion;
-                self.writeCompletion = null;
-
-                switch (writeTask.Status)
-                {
-                    case TaskStatus.RanToCompletion:
-                        promise.TryComplete();
-                        break;
-                    case TaskStatus.Canceled:
-                        promise.TrySetCanceled();
-                        break;
-                    case TaskStatus.Faulted:
-                        promise.TrySetException(writeTask.Exception);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException("Unexpected task status: " + writeTask.Status);
-                }
-
-                callback?.Invoke(promise.Task);
-            }
-
-            public override void EndWrite(IAsyncResult asyncResult)
-            {
-                if (asyncResult is SynchronousAsyncResult<int>)
-                {
-                    return;
-                }
-
-                try
-                {
-                    ((Task)asyncResult).Wait();
-                }
-                catch (AggregateException ex)
-                {
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    throw;
-                }
-            }
 
             int ReadFromInput(byte[] destination, int destinationOffset, int destinationCapacity)
             {
@@ -887,7 +777,7 @@ namespace DotNetty.Handlers.Tls
                 }
             }
 
-#region plumbing
+            #region plumbing
 
             public override long Seek(long offset, SeekOrigin origin)
             {
@@ -921,9 +811,9 @@ namespace DotNetty.Handlers.Tls
                 set { throw new NotSupportedException(); }
             }
 
-#endregion
+            #endregion
 
-#region sync result
+            #region sync result
             sealed class SynchronousAsyncResult<T> : IAsyncResult
             {
                 public T Result { get; set; }
@@ -940,7 +830,7 @@ namespace DotNetty.Handlers.Tls
                 public bool CompletedSynchronously => true;
             }
 
-#endregion
+            #endregion
         }
     }
 

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -674,7 +674,10 @@ namespace DotNetty.Handlers.Tls
             int inputLength;
             TaskCompletionSource<int> readCompletionSource;
             ArraySegment<byte> sslOwnedBuffer;
-            int readByteCount;
+            SynchronousAsyncResult<int> syncReadResult;
+            AsyncCallback readCallback;
+            TaskCompletionSource writeCompletion;
+            AsyncCallback writeCallback;
 
             public MediationStream(TlsHandler owner)
             {
@@ -711,40 +714,147 @@ namespace DotNetty.Handlers.Tls
                 }
                 this.sslOwnedBuffer = default(ArraySegment<byte>);
 
-                this.readByteCount = this.ReadFromInput(sslBuffer.Array, sslBuffer.Offset, sslBuffer.Count);
-                // hack: this tricks SslStream's continuation to run synchronously instead of dispatching to TP. Remove once Begin/EndRead are available. 
-                new Task(
-                    ms =>
-                    {
-                        var self = (MediationStream)ms;
-                        TaskCompletionSource<int> p = self.readCompletionSource;
-                        self.readCompletionSource = null;
-                        p.TrySetResult(self.readByteCount);
-                    },
-                    this)
-                    .RunSynchronously(TaskScheduler.Default);
+                int read = this.ReadFromInput(sslBuffer.Array, sslBuffer.Offset, sslBuffer.Count);
+
+                TaskCompletionSource<int> promise = this.readCompletionSource;
+                this.readCompletionSource = null;
+                promise.TrySetResult(read);
+
+                AsyncCallback callback = this.readCallback;
+                this.readCallback = null;
+                callback?.Invoke(promise.Task);
             }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
             {
                 if (this.SourceReadableBytes > 0)
                 {
                     // we have the bytes available upfront - write out synchronously
                     int read = this.ReadFromInput(buffer, offset, count);
-                    return Task.FromResult(read);
+                    var res = this.PrepareSyncReadResult(read, state);
+                    callback?.Invoke(res);
+                    return res;
                 }
 
                 Contract.Assert(this.sslOwnedBuffer.Array == null);
                 // take note of buffer - we will pass bytes there once available
                 this.sslOwnedBuffer = new ArraySegment<byte>(buffer, offset, count);
-                this.readCompletionSource = new TaskCompletionSource<int>();
+                this.readCompletionSource = new TaskCompletionSource<int>(state);
+                this.readCallback = callback;
                 return this.readCompletionSource.Task;
+            }
+
+            public override int EndRead(IAsyncResult asyncResult)
+            {
+                SynchronousAsyncResult<int> syncResult = this.syncReadResult;
+                if (ReferenceEquals(asyncResult, syncResult))
+                {
+                    return syncResult.Result;
+                }
+
+                Debug.Assert(this.readCompletionSource == null || this.readCompletionSource.Task == asyncResult);
+                Contract.Assert(!((Task<int>)asyncResult).IsCanceled);
+
+                try
+                {
+                    return ((Task<int>)asyncResult).Result;
+                }
+                catch (AggregateException ex)
+                {
+                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                    throw; // unreachable
+                }
+            }
+
+            IAsyncResult PrepareSyncReadResult(int readBytes, object state)
+            {
+                // it is safe to reuse sync result object as it can't lead to leak (no way to attach to it via handle)
+                SynchronousAsyncResult<int> result = this.syncReadResult ?? (this.syncReadResult = new SynchronousAsyncResult<int>());
+                result.Result = readBytes;
+                result.AsyncState = state;
+                return result;
             }
 
             public override void Write(byte[] buffer, int offset, int count) => this.owner.FinishWrap(buffer, offset, count);
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
                 => this.owner.FinishWrapNonAppDataAsync(buffer, offset, count);
+
+            static readonly Action<Task, object> WriteCompleteCallback = HandleChannelWriteComplete;
+
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+            {
+                Task task = this.WriteAsync(buffer, offset, count);
+                switch (task.Status)
+                {
+                    case TaskStatus.RanToCompletion:
+                        // write+flush completed synchronously (and successfully)
+                        var result = new SynchronousAsyncResult<int>();
+                        result.AsyncState = state;
+                        callback?.Invoke(result);
+                        return result;
+                    default:
+                        if (callback != null || state != task.AsyncState)
+                        {
+                            Contract.Assert(this.writeCompletion == null);
+                            this.writeCallback = callback;
+                            var tcs = new TaskCompletionSource(state);
+                            this.writeCompletion = tcs;
+                            task.ContinueWith(WriteCompleteCallback, this, TaskContinuationOptions.ExecuteSynchronously);
+                            return tcs.Task;
+                        }
+                        else
+                        {
+                            return task;
+                        }
+                }
+            }
+
+            static void HandleChannelWriteComplete(Task writeTask, object state)
+            {
+                var self = (MediationStream)state;
+
+                AsyncCallback callback = self.writeCallback;
+                self.writeCallback = null;
+
+                var promise = self.writeCompletion;
+                self.writeCompletion = null;
+
+                switch (writeTask.Status)
+                {
+                    case TaskStatus.RanToCompletion:
+                        promise.TryComplete();
+                        break;
+                    case TaskStatus.Canceled:
+                        promise.TrySetCanceled();
+                        break;
+                    case TaskStatus.Faulted:
+                        promise.TrySetException(writeTask.Exception);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Unexpected task status: " + writeTask.Status);
+                }
+
+                callback?.Invoke(promise.Task);
+            }
+
+            public override void EndWrite(IAsyncResult asyncResult)
+            {
+                if (asyncResult is SynchronousAsyncResult<int>)
+                {
+                    return;
+                }
+
+                try
+                {
+                    ((Task)asyncResult).Wait();
+                }
+                catch (AggregateException ex)
+                {
+                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                    throw;
+                }
+            }
 
             int ReadFromInput(byte[] destination, int destinationOffset, int destinationCapacity)
             {

--- a/src/DotNetty.Transport.Libuv/DotNetty.Transport.Libuv.csproj
+++ b/src/DotNetty.Transport.Libuv/DotNetty.Transport.Libuv.csproj
@@ -8,7 +8,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: libuv transport model Experimental</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/DotNetty.Transport.Libuv/DotNetty.Transport.Libuv.csproj
+++ b/src/DotNetty.Transport.Libuv/DotNetty.Transport.Libuv.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Transport.Libuv</PackageId>
     <Description>Libuv transport model in DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: libuv transport model Experimental</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -24,7 +24,7 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,11 +38,8 @@
     <ProjectReference Include="..\DotNetty.Common\DotNetty.Common.csproj" />
     <ProjectReference Include="..\DotNetty.Buffers\DotNetty.Buffers.csproj" />
     <ProjectReference Include="..\DotNetty.Transport\DotNetty.Transport.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/DotNetty.Transport.Libuv/Native/NativeMethods.cs
+++ b/src/DotNetty.Transport.Libuv/Native/NativeMethods.cs
@@ -331,11 +331,7 @@ namespace DotNetty.Transport.Libuv.Native
         {
             Debug.Assert(handle != IntPtr.Zero);
 
-#if NETSTANDARD1_3
             int namelen = Marshal.SizeOf<sockaddr>();
-#else
-            int namelen = Marshal.SizeOf(typeof(sockaddr));
-#endif
             uv_tcp_getsockname(handle, out sockaddr sockaddr, ref namelen);
             return sockaddr.GetIPEndPoint();
         }
@@ -344,25 +340,15 @@ namespace DotNetty.Transport.Libuv.Native
         {
             Debug.Assert(handle != IntPtr.Zero);
 
-#if NETSTANDARD1_3
             int namelen = Marshal.SizeOf<sockaddr>();
-#else
-            int namelen = Marshal.SizeOf(typeof(sockaddr));
-#endif
             int result = uv_tcp_getpeername(handle, out sockaddr sockaddr, ref namelen);
             ThrowIfError(result);
             return sockaddr.GetIPEndPoint();
         }
 
-#if NETSTANDARD1_3
         internal static IntPtr Allocate(int size) => Marshal.AllocCoTaskMem(size);
 
         internal static void FreeMemory(IntPtr ptr) => Marshal.FreeCoTaskMem(ptr);
-#else
-        internal static IntPtr Allocate(int size) => Marshal.AllocHGlobal(size);
-
-        internal static void FreeMemory(IntPtr ptr) => Marshal.FreeHGlobal(ptr);
-#endif
 
         internal static IntPtr Allocate(uv_handle_type handleType)
         {

--- a/src/DotNetty.Transport.Libuv/Native/WindowsApi.cs
+++ b/src/DotNetty.Transport.Libuv/Native/WindowsApi.cs
@@ -41,11 +41,8 @@ namespace DotNetty.Transport.Libuv.Native
             IntPtr socket = IntPtr.Zero;
             NativeMethods.uv_fileno(handle.Handle, ref socket);
 
-#if NETSTANDARD1_3
             uint len = (uint)Marshal.SizeOf<FILE_COMPLETION_INFORMATION>();
-#else
-            uint len = (uint)Marshal.SizeOf(typeof(FILE_COMPLETION_INFORMATION));
-#endif
+
             if (NtSetInformationFile(socket, 
                 out statusBlock, this.fileCompletionInfoPtr, len, 
                 FileReplaceCompletionInformation) == STATUS_INVALID_INFO_CLASS)

--- a/src/DotNetty.Transport.Libuv/Native/WriteRequest.cs
+++ b/src/DotNetty.Transport.Libuv/Native/WriteRequest.cs
@@ -26,11 +26,7 @@ namespace DotNetty.Transport.Libuv.Native
 
         static WriteRequest()
         {
-#if NETSTANDARD1_3
             BufferSize = Marshal.SizeOf<uv_buf_t>();
-#else
-            BufferSize = Marshal.SizeOf(typeof(uv_buf_t));
-#endif
         }
 
         readonly int maxBytes;

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketByteChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketByteChannel.cs
@@ -153,19 +153,7 @@ namespace DotNetty.Transport.Channels.Sockets
         protected override void ScheduleSocketRead()
         {
             SocketChannelAsyncOperation operation = this.ReadOperation;
-            bool pending;
-
-            if (ExecutionContext.IsFlowSuppressed())
-            {
-                pending = this.Socket.ReceiveAsync(operation);
-            }
-            else
-            {
-                using (ExecutionContext.SuppressFlow())
-                {
-                    pending = this.Socket.ReceiveAsync(operation);
-                }
-            }
+            bool pending = this.Socket.ReceiveAsync(operation);
 
             if (!pending)
             {
@@ -304,19 +292,7 @@ namespace DotNetty.Transport.Channels.Sockets
             if (scheduleAsync)
             {
                 this.SetState(StateFlags.WriteScheduled);
-                bool pending;
-
-                if (ExecutionContext.IsFlowSuppressed())
-                {
-                    pending = this.Socket.SendAsync(operation);
-                }
-                else
-                {
-                    using (ExecutionContext.SuppressFlow())
-                    {
-                        pending = this.Socket.SendAsync(operation);
-                    }
-                }
+                bool pending = this.Socket.SendAsync(operation);
 
                 if (!pending)
                 {

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketByteChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketByteChannel.cs
@@ -153,22 +153,8 @@ namespace DotNetty.Transport.Channels.Sockets
         protected override void ScheduleSocketRead()
         {
             SocketChannelAsyncOperation operation = this.ReadOperation;
-            bool pending;
-#if NETSTANDARD1_3
-            pending = this.Socket.ReceiveAsync(operation);
-#else
-            if (ExecutionContext.IsFlowSuppressed())
-            {
-                pending = this.Socket.ReceiveAsync(operation);
-            }
-            else
-            {
-                using (ExecutionContext.SuppressFlow())
-                {
-                    pending = this.Socket.ReceiveAsync(operation);
-                }
-            }
-#endif
+            bool pending = this.Socket.ReceiveAsync(operation);
+
             if (!pending)
             {
                 // todo: potential allocation / non-static field?
@@ -306,23 +292,7 @@ namespace DotNetty.Transport.Channels.Sockets
             if (scheduleAsync)
             {
                 this.SetState(StateFlags.WriteScheduled);
-                bool pending;
-
-#if NETSTANDARD1_3
-                pending = this.Socket.SendAsync(operation);
-#else
-                if (ExecutionContext.IsFlowSuppressed())
-                {
-                    pending = this.Socket.SendAsync(operation);
-                }
-                else
-                {
-                    using (ExecutionContext.SuppressFlow())
-                    {
-                        pending = this.Socket.SendAsync(operation);
-                    }
-                }
-#endif
+                bool pending = this.Socket.SendAsync(operation);
 
                 if (!pending)
                 {

--- a/src/DotNetty.Transport/Channels/Sockets/AbstractSocketByteChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/AbstractSocketByteChannel.cs
@@ -153,7 +153,19 @@ namespace DotNetty.Transport.Channels.Sockets
         protected override void ScheduleSocketRead()
         {
             SocketChannelAsyncOperation operation = this.ReadOperation;
-            bool pending = this.Socket.ReceiveAsync(operation);
+            bool pending;
+
+            if (ExecutionContext.IsFlowSuppressed())
+            {
+                pending = this.Socket.ReceiveAsync(operation);
+            }
+            else
+            {
+                using (ExecutionContext.SuppressFlow())
+                {
+                    pending = this.Socket.ReceiveAsync(operation);
+                }
+            }
 
             if (!pending)
             {
@@ -292,7 +304,19 @@ namespace DotNetty.Transport.Channels.Sockets
             if (scheduleAsync)
             {
                 this.SetState(StateFlags.WriteScheduled);
-                bool pending = this.Socket.SendAsync(operation);
+                bool pending;
+
+                if (ExecutionContext.IsFlowSuppressed())
+                {
+                    pending = this.Socket.SendAsync(operation);
+                }
+                else
+                {
+                    using (ExecutionContext.SuppressFlow())
+                    {
+                        pending = this.Socket.SendAsync(operation);
+                    }
+                }
 
                 if (!pending)
                 {

--- a/src/DotNetty.Transport/Channels/Sockets/SocketDatagramChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/SocketDatagramChannel.cs
@@ -114,22 +114,8 @@ namespace DotNetty.Transport.Channels.Sockets
             ArraySegment<byte> bytes = buffer.GetIoBuffer(0, buffer.WritableBytes);
             operation.SetBuffer(bytes.Array, bytes.Offset, bytes.Count);
 
-            bool pending;
-#if NETSTANDARD1_3
-            pending = this.Socket.ReceiveFromAsync(operation);
-#else
-            if (ExecutionContext.IsFlowSuppressed())
-            {
-                pending = this.Socket.ReceiveFromAsync(operation);
-            }
-            else
-            {
-                using (ExecutionContext.SuppressFlow())
-                {
-                    pending = this.Socket.ReceiveFromAsync(operation);
-                }
-            }
-#endif
+            bool pending = this.Socket.ReceiveFromAsync(operation);
+
             if (!pending)
             {
                 this.EventLoop.Execute(ReceiveFromCompletedSyncCallback, this.Unsafe, operation);

--- a/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
+++ b/src/DotNetty.Transport/Channels/Sockets/TcpSocketChannel.cs
@@ -69,7 +69,9 @@ namespace DotNetty.Transport.Channels.Sockets
 
         public bool IsOutputShutdown
         {
-            get { throw new NotImplementedException(); } // todo: impl with stateflags
+            get { 
+                throw new NotImplementedException(); 
+            } // todo: impl with stateflags
         }
 
         public Task ShutdownOutputAsync()

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Transport</PackageId>
     <Description>Transport model in DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: transport model</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -23,7 +23,7 @@
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Azure/DotNetty/</RepositoryUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\shared\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
@@ -32,19 +32,13 @@
     <ProjectReference Include="..\DotNetty.Common\DotNetty.Common.csproj" />
     <ProjectReference Include="..\DotNetty.Buffers\DotNetty.Buffers.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+  <ItemGroup>
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -8,7 +8,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>DotNetty: transport model</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Microsoft</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/shared/SharedAssemblyInfo.cs
+++ b/src/shared/SharedAssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("DotNetty")]
-[assembly: AssemblyVersion("0.6.0")]
-[assembly: AssemblyFileVersion("0.6.0")]
-[assembly: AssemblyCopyright("(c) Microsoft 2015 - 2018")]
+[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.0")]
+[assembly: AssemblyCopyright("(c) Microsoft 2015 - 2021")]
 

--- a/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
+++ b/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj" />

--- a/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
+++ b/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Http.Tests/DotNetty.Codecs.Http.Tests.csproj
+++ b/test/DotNetty.Codecs.Http.Tests/DotNetty.Codecs.Http.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Multipart\file-01.txt" />

--- a/test/DotNetty.Codecs.Http.Tests/DotNetty.Codecs.Http.Tests.csproj
+++ b/test/DotNetty.Codecs.Http.Tests/DotNetty.Codecs.Http.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
+++ b/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
+++ b/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
+++ b/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
+++ b/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
+++ b/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
+++ b/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
+++ b/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
+++ b/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
+++ b/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
+++ b/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
+++ b/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
+++ b/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
+++ b/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
+++ b/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Handlers.Tests/MediationStream.cs
+++ b/test/DotNetty.Handlers.Tests/MediationStream.cs
@@ -39,36 +39,6 @@ namespace DotNetty.Handlers.Tests
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => this.writeDataFunc(new ArraySegment<byte>(buffer, offset, count));
 
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            var tcs = new TaskCompletionSource<int>(state);
-            this.ReadAsync(buffer, offset, count, CancellationToken.None).ContinueWith(
-                t =>
-                {
-                    tcs.TrySetResult(t.Result);
-                    callback?.Invoke(tcs.Task);
-                },
-                TaskContinuationOptions.ExecuteSynchronously);
-            return tcs.Task;
-        }
-
-        public override int EndRead(IAsyncResult asyncResult) => ((Task<int>)asyncResult).Result;
-
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            var tcs = new TaskCompletionSource<int>(state);
-            this.WriteAsync(buffer, offset, count, CancellationToken.None).ContinueWith(
-                t =>
-                {
-                    tcs.TrySetResult(0);
-                    callback?.Invoke(tcs.Task);
-                },
-                TaskContinuationOptions.ExecuteSynchronously);
-            return tcs.Task;
-        }
-
-        public override void EndWrite(IAsyncResult asyncResult) => ((Task<int>)asyncResult).Wait();
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/test/DotNetty.Handlers.Tests/MediationStream.cs
+++ b/test/DotNetty.Handlers.Tests/MediationStream.cs
@@ -39,6 +39,38 @@ namespace DotNetty.Handlers.Tests
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => this.writeDataFunc(new ArraySegment<byte>(buffer, offset, count));
 
+#if !NETCOREAPP1_1
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            var tcs = new TaskCompletionSource<int>(state);
+            this.ReadAsync(buffer, offset, count, CancellationToken.None).ContinueWith(
+                t =>
+                {
+                    tcs.TrySetResult(t.Result);
+                    callback?.Invoke(tcs.Task);
+                },
+                TaskContinuationOptions.ExecuteSynchronously);
+            return tcs.Task;
+        }
+
+        public override int EndRead(IAsyncResult asyncResult) => ((Task<int>)asyncResult).Result;
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            var tcs = new TaskCompletionSource<int>(state);
+            this.WriteAsync(buffer, offset, count, CancellationToken.None).ContinueWith(
+                t =>
+                {
+                    tcs.TrySetResult(0);
+                    callback?.Invoke(tcs.Task);
+                },
+                TaskContinuationOptions.ExecuteSynchronously);
+            return tcs.Task;
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult) => ((Task<int>)asyncResult).Wait();
+#endif
+
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/test/DotNetty.Handlers.Tests/MediationStream.cs
+++ b/test/DotNetty.Handlers.Tests/MediationStream.cs
@@ -39,38 +39,6 @@ namespace DotNetty.Handlers.Tests
 
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => this.writeDataFunc(new ArraySegment<byte>(buffer, offset, count));
 
-#if !NETCOREAPP1_1
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            var tcs = new TaskCompletionSource<int>(state);
-            this.ReadAsync(buffer, offset, count, CancellationToken.None).ContinueWith(
-                t =>
-                {
-                    tcs.TrySetResult(t.Result);
-                    callback?.Invoke(tcs.Task);
-                }, 
-                TaskContinuationOptions.ExecuteSynchronously);
-            return tcs.Task;
-        }
-
-        public override int EndRead(IAsyncResult asyncResult) => ((Task<int>)asyncResult).Result;
-
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
-        {
-            var tcs = new TaskCompletionSource<int>(state);
-            this.WriteAsync(buffer, offset, count, CancellationToken.None).ContinueWith(
-                t =>
-                {
-                    tcs.TrySetResult(0);
-                    callback?.Invoke(tcs.Task);
-                },
-                TaskContinuationOptions.ExecuteSynchronously);
-            return tcs.Task;
-        }
-
-        public override void EndWrite(IAsyncResult asyncResult) => ((Task<int>)asyncResult).Wait();
-#endif
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/test/DotNetty.Microbench/Allocators/AbstractByteBufferAllocatorBenchmark.cs
+++ b/test/DotNetty.Microbench/Allocators/AbstractByteBufferAllocatorBenchmark.cs
@@ -5,11 +5,11 @@ namespace DotNetty.Microbench.Allocators
 {
     using System;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("ByteBufferAllocator")]
     [MemoryDiagnoser]
     public abstract class AbstractByteBufferAllocatorBenchmark

--- a/test/DotNetty.Microbench/Buffers/ByteBufUtilBenchmark.cs
+++ b/test/DotNetty.Microbench/Buffers/ByteBufUtilBenchmark.cs
@@ -5,11 +5,11 @@ namespace DotNetty.Microbench.Buffers
 {
     using System.Text;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("ByteBuffer")]
     public class ByteBufUtilBenchmark
     {

--- a/test/DotNetty.Microbench/Buffers/ByteBufferBenchmark.cs
+++ b/test/DotNetty.Microbench/Buffers/ByteBufferBenchmark.cs
@@ -5,19 +5,11 @@ namespace DotNetty.Microbench.Buffers
 {
     using System;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
-#if NET46
-    using BenchmarkDotNet.Diagnostics.Windows.Configs;
-#endif
 
-#if !NET46
-    [CoreJob]
-#else
-    [ClrJob]
-    [InliningDiagnoser]
-#endif
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("ByteBuffer")]
     public class ByteBufferBenchmark
     {

--- a/test/DotNetty.Microbench/Buffers/PooledByteBufferBenchmark.cs
+++ b/test/DotNetty.Microbench/Buffers/PooledByteBufferBenchmark.cs
@@ -4,19 +4,11 @@
 namespace DotNetty.Microbench.Buffers
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
-#if NET46
-    using BenchmarkDotNet.Diagnostics.Windows.Configs;
-#endif
 
-#if !NET46
-    [CoreJob]
-#else
-    [ClrJob]
-    [InliningDiagnoser]
-#endif
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("ByteBuffer")]
     public class PooledByteBufferBenchmark
     {

--- a/test/DotNetty.Microbench/Buffers/UnpooledByteBufferBenchmark.cs
+++ b/test/DotNetty.Microbench/Buffers/UnpooledByteBufferBenchmark.cs
@@ -4,19 +4,11 @@
 namespace DotNetty.Microbench.Buffers
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Common;
-#if NET46
-    using BenchmarkDotNet.Diagnostics.Windows.Configs;
-#endif
 
-#if !NET46
-    [CoreJob]
-#else
-    [ClrJob]
-    [InliningDiagnoser]
-#endif
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("ByteBuffer")]
     public class UnpooledByteBufferBenchmark
     {

--- a/test/DotNetty.Microbench/Codecs/DateFormatterBenchmark.cs
+++ b/test/DotNetty.Microbench/Codecs/DateFormatterBenchmark.cs
@@ -5,10 +5,10 @@ namespace DotNetty.Microbench.Codecs
 {
     using System;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Codecs;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("Codecs")]
     public class DateFormatterBenchmark
     {

--- a/test/DotNetty.Microbench/Common/AsciiStringBenchmark.cs
+++ b/test/DotNetty.Microbench/Common/AsciiStringBenchmark.cs
@@ -6,19 +6,11 @@ namespace DotNetty.Microbench.Common
     using System;
     using System.Text;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Common.Internal;
     using DotNetty.Common.Utilities;
-#if NET46
-    using BenchmarkDotNet.Diagnostics.Windows.Configs;
-#endif
 
-#if !NET46
-    [CoreJob]
-#else
-    [ClrJob]
-    [InliningDiagnoser]
-#endif
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("Common")]
     public class AsciiStringBenchmark
     {

--- a/test/DotNetty.Microbench/Concurrency/FastThreadLocalBenchmark.cs
+++ b/test/DotNetty.Microbench/Concurrency/FastThreadLocalBenchmark.cs
@@ -4,10 +4,10 @@
 namespace DotNetty.Microbench.Concurrency
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Common;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("Concurrency")]
     public class FastThreadLocalBenchmark
     {

--- a/test/DotNetty.Microbench/Concurrency/SingleThreadEventExecutorBenchmark.cs
+++ b/test/DotNetty.Microbench/Concurrency/SingleThreadEventExecutorBenchmark.cs
@@ -6,7 +6,6 @@ namespace DotNetty.Microbench.Concurrency
     using System;
     using System.Threading;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
     using BenchmarkDotNet.Engines;
     using DotNetty.Common.Concurrency;
     using DotNetty.Common.Internal;

--- a/test/DotNetty.Microbench/DotNetty.Microbench.csproj
+++ b/test/DotNetty.Microbench/DotNetty.Microbench.csproj
@@ -2,20 +2,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
-    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.13" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.10.13" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Codecs.Http\DotNetty.Codecs.Http.csproj" />

--- a/test/DotNetty.Microbench/DotNetty.Microbench.csproj
+++ b/test/DotNetty.Microbench/DotNetty.Microbench.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Codecs.Http\DotNetty.Codecs.Http.csproj" />

--- a/test/DotNetty.Microbench/Headers/HeadersBenchmark.cs
+++ b/test/DotNetty.Microbench/Headers/HeadersBenchmark.cs
@@ -5,7 +5,6 @@ namespace DotNetty.Microbench.Headers
 {
     using System.Collections.Generic;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
     using BenchmarkDotNet.Engines;
     using DotNetty.Codecs;
     using DotNetty.Codecs.Http;

--- a/test/DotNetty.Microbench/Http/ClientCookieDecoderBenchmark.cs
+++ b/test/DotNetty.Microbench/Http/ClientCookieDecoderBenchmark.cs
@@ -4,11 +4,11 @@
 namespace DotNetty.Microbench.Http
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Codecs.Http.Cookies;
     using DotNetty.Common;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("Http")]
     public class ClientCookieDecoderBenchmark
     {

--- a/test/DotNetty.Microbench/Http/HttpRequestDecoderBenchmark.cs
+++ b/test/DotNetty.Microbench/Http/HttpRequestDecoderBenchmark.cs
@@ -5,7 +5,6 @@ namespace DotNetty.Microbench.Http
 {
     using System.Text;
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
     using BenchmarkDotNet.Engines;
     using DotNetty.Buffers;
     using DotNetty.Codecs.Http;

--- a/test/DotNetty.Microbench/Http/HttpRequestEncoderInsertBenchmark.cs
+++ b/test/DotNetty.Microbench/Http/HttpRequestEncoderInsertBenchmark.cs
@@ -4,12 +4,12 @@
 namespace DotNetty.Microbench.Http
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Codecs.Http;
     using DotNetty.Common;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("Http")]
     public class HttpRequestEncoderInsertBenchmark
     {

--- a/test/DotNetty.Microbench/Http/WriteBytesVsShortOrMediumBenchmark.cs
+++ b/test/DotNetty.Microbench/Http/WriteBytesVsShortOrMediumBenchmark.cs
@@ -4,13 +4,13 @@
 namespace DotNetty.Microbench.Http
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Buffers;
     using DotNetty.Codecs.Http;
     using DotNetty.Common;
     using DotNetty.Common.Utilities;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("Http")]
     public class WriteBytesVsShortOrMediumBenchmark
     {

--- a/test/DotNetty.Microbench/Internal/PlatformDependentBenchmark.cs
+++ b/test/DotNetty.Microbench/Internal/PlatformDependentBenchmark.cs
@@ -4,10 +4,10 @@
 namespace DotNetty.Microbench.Internal
 {
     using BenchmarkDotNet.Attributes;
-    using BenchmarkDotNet.Attributes.Jobs;
+    using BenchmarkDotNet.Jobs;
     using DotNetty.Common.Internal;
 
-    [CoreJob]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [BenchmarkCategory("Internal")]
     public class PlatformDependentBenchmark
     {

--- a/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
+++ b/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
@@ -11,10 +11,13 @@
     <EmbeddedResource Include="..\..\shared\contoso.com.pfx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
+++ b/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -1,16 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Buffers\DotNetty.Buffers.csproj" />

--- a/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
+++ b/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
+++ b/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
+++ b/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>

--- a/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
+++ b/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
@@ -4,14 +4,14 @@
   </PropertyGroup>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NBench" Version="1.0.4" />
+    <PackageReference Include="NBench" Version="2.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
+++ b/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\DotNetty.Common\DotNetty.Common.csproj" />

--- a/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
+++ b/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Updated DotNetty.Common to .NETStandard 2.0 to allow this code to be integrated with projects targeting newer versions of the Microsoft.Extensions.* nugets and newer versions of Google.Protobuf

Eliminated Support for .NET45
Eliminated Support for .NETStandard1.3
Updated all nugets consumed to latest version


Ran All Unit Tests:
![image](https://user-images.githubusercontent.com/3885965/118342555-a343d780-b4d8-11eb-9640-9b828f8aa5ef.png)
