### PR TITLE
Make thread executor a background thread.

### DIFF
--- a/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
+++ b/src/DotNetty.Common/Concurrency/SingleThreadEventExecutor.cs
@@ -78,6 +78,7 @@ namespace DotNetty.Common.Concurrency
             {
                 this.thread.Name = threadName;
             }
+            this.thread.IsBackground = true;
             this.thread.Start();
         }
 


### PR DESCRIPTION
The original implementation of XThread created a task on the standard TaskScheduler and did not spin up a parent thread. But instead the XThread container allowed "thread-like" operations to take place. The default TaskScheduler creates background threads by default.

When XThread was replaced with Thread it caused a **_real_** .NET thread to be created. This thread was created as a foreground thread which, when an application is terminated, will leave the application waiting on the termination of the thread. 

**This behavior is different than the _original_ behavior with XThread.** 

Before, closing the application via Environment.Exit or letting it run to completion would kill all background threads. Now, the only way to terminate the executor thread is to call `ShutdownGracefullyAsync`. If the application using DotNetty was already calling `ShutdownGracefullyAsync` then the application would not experience any issues.

https://github.com/Azure/DotNetty/blob/47f5ec7303037f1360615d182939e04d8619a2b3/src/DotNetty.Common/Concurrency/IEventExecutorGroup.cs#L29

[Foreground and background threads](https://docs.microsoft.com/en-us/dotnet/standard/threading/foreground-and-background-threads)