### PR TITLE
.NET 8 TLS 1.3 connection drops when application data arrives before SslStream Authentication completes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,16 +1,21 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "dotnet",
-    "isShellCommand": true,
     "args": [],
     "tasks": [
         {
-            "taskName": "msbuild",
+            "label": "msbuild",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
+                "msbuild",
                 "dotnetty.sln"
             ],
-            "isBuildCommand": true,
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "_id": "build",
+                "isDefault": false
+            }
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
             ],
             "problemMatcher": "$msCompile",
             "group": {
-                "_id": "build",
+                "kind": "build",
                 "isDefault": false
             }
         }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+#### 0.7.8 January 8, 2026
+- Fix race condition in TlsHandler when negotiating client certificate (#602)
+- Deferred processing of pending data packets to ensure upstream handlers receive TlsHandshakeCompletionEvent before application data
+- Removed deprecated target frameworks: netcoreapp3.1 and net5.0
+- Added net8.0 target framework support
+
 #### 0.7.6 February 9, 2024
 - Fix TLS handshake for net8
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 0.7.8 January 8, 2026
+#### 0.8.0 January 8, 2026
 - Fix race condition in TlsHandler when negotiating client certificate (#602)
 - Deferred processing of pending data packets to ensure upstream handlers receive TlsHandshakeCompletionEvent before application data
 - Removed deprecated target frameworks: netcoreapp3.1 and net5.0

--- a/build.cake
+++ b/build.cake
@@ -25,8 +25,8 @@ var output = Directory("build");
 var outputBinaries = output + Directory("binaries");
 var outputBinariesNet = outputBinaries + Directory("net472");
 var outputBinariesNetStandard = outputBinaries + Directory("netstandard2.0");
-var outputBinariesNet5 = outputBinaries + Directory("net5.0");
 var outputBinariesNet6 = outputBinaries + Directory("net6.0");
+var outputBinariesNet8 = outputBinaries + Directory("net8.0");
 var outputPackages = output + Directory("packages");
 var outputNuGet = output + Directory("nuget");
 var outputPerfResults = Directory("perfResults");
@@ -40,7 +40,7 @@ Task("Clean")
   CleanDirectories(new DirectoryPath[] {
     output, outputBinaries, outputPackages, outputNuGet,
     outputBinariesNet, outputBinariesNetStandard,
-    outputBinariesNet5, outputBinariesNet6  
+    outputBinariesNet6, outputBinariesNet8  
   });
 
   if(!skipClean) {

--- a/examples/Discard.Client/Discard.Client.csproj
+++ b/examples/Discard.Client/Discard.Client.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Discard.Server/Discard.Server.csproj
+++ b/examples/Discard.Server/Discard.Server.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Echo.Client/Echo.Client.csproj
+++ b/examples/Echo.Client/Echo.Client.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Echo.Server/Echo.Server.csproj
+++ b/examples/Echo.Server/Echo.Server.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Examples.Common/Examples.Common.csproj
+++ b/examples/Examples.Common/Examples.Common.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Factorial.Client/Factorial.Client.csproj
+++ b/examples/Factorial.Client/Factorial.Client.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Factorial.Server/Factorial.Server.csproj
+++ b/examples/Factorial.Server/Factorial.Server.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Factorial/Factorial.csproj
+++ b/examples/Factorial/Factorial.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/HttpServer/HttpServer.csproj
+++ b/examples/HttpServer/HttpServer.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Configurations>Debug;Release;Package</Configurations>

--- a/examples/QuoteOfTheMoment.Client/QuoteOfTheMoment.Client.csproj
+++ b/examples/QuoteOfTheMoment.Client/QuoteOfTheMoment.Client.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/QuoteOfTheMoment.Server/QuoteOfTheMoment.Server.csproj
+++ b/examples/QuoteOfTheMoment.Server/QuoteOfTheMoment.Server.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/SecureChat.Client/SecureChat.Client.csproj
+++ b/examples/SecureChat.Client/SecureChat.Client.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/SecureChat.Server/SecureChat.Server.csproj
+++ b/examples/SecureChat.Server/SecureChat.Server.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Telnet.Client/Telnet.Client.csproj
+++ b/examples/Telnet.Client/Telnet.Client.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/Telnet.Server/Telnet.Server.csproj
+++ b/examples/Telnet.Server/Telnet.Server.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/WebSockets.Client/WebSockets.Client.csproj
+++ b/examples/WebSockets.Client/WebSockets.Client.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/examples/WebSockets.Server/WebSockets.Server.csproj
+++ b/examples/WebSockets.Server/WebSockets.Server.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">2.0.3</NetStandardImplicitPackageVersion>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Configurations>Debug;Release;Package</Configurations>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Package'">True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     
-    <PackageVersion>0.7.6</PackageVersion>
+    <PackageVersion>0.8.0</PackageVersion>
     <Version>$(PackageVersion)</Version>
   </PropertyGroup>
   

--- a/src/DotNetty.Buffers/DotNetty.Buffers.csproj
+++ b/src/DotNetty.Buffers/DotNetty.Buffers.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>Buffer management in DotNetty</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/DotNetty.Codecs.Http/DotNetty.Codecs.Http.csproj
+++ b/src/DotNetty.Codecs.Http/DotNetty.Codecs.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Http</PackageId>
     <Description>Http codec for DotNetty</Description>

--- a/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
+++ b/src/DotNetty.Codecs.Mqtt/DotNetty.Codecs.Mqtt.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Mqtt</PackageId>
     <Description>MQTT codec for DotNetty</Description>

--- a/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
+++ b/src/DotNetty.Codecs.Protobuf/DotNetty.Codecs.Protobuf.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Protobuf</PackageId>
     <Description>Protobuf Proto3 codec for DotNetty</Description>

--- a/src/DotNetty.Codecs.ProtocolBuffers/DotNetty.Codecs.ProtocolBuffers.csproj
+++ b/src/DotNetty.Codecs.ProtocolBuffers/DotNetty.Codecs.ProtocolBuffers.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.ProtocolBuffers</PackageId>
     <Description>ProtocolBuffers Proto2 codec for DotNetty</Description>

--- a/src/DotNetty.Codecs.Redis/DotNetty.Codecs.Redis.csproj
+++ b/src/DotNetty.Codecs.Redis/DotNetty.Codecs.Redis.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs.Redis</PackageId>
     <Description>Redis codec for DotNetty</Description>

--- a/src/DotNetty.Codecs/DotNetty.Codecs.csproj
+++ b/src/DotNetty.Codecs/DotNetty.Codecs.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Codecs</PackageId>
     <Description>General purpose codecs for DotNetty</Description>

--- a/src/DotNetty.Common/DotNetty.Common.csproj
+++ b/src/DotNetty.Common/DotNetty.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Common</PackageId>
     <Description>DotNetty common routines</Description>

--- a/src/DotNetty.Handlers/DotNetty.Handlers.csproj
+++ b/src/DotNetty.Handlers/DotNetty.Handlers.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Handlers</PackageId>
     <Description>Application handlers for DotNetty</Description>

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -142,25 +142,14 @@ namespace DotNetty.Handlers.Tls
                     
                     // Due to possible async execution of HandleHandshakeCompleted continuation, we need to
                     // Unwrap any pending app data packets in case, when read completed and no more messages in the channel.
+                    // 
+                    // IMPORTANT: We defer processing to the next event loop iteration to ensure that upstream handlers
+                    // have processed the TlsHandshakeCompletionEvent.Success before receiving application data.
+                    // This fixes a race condition where application data (e.g., MQTT CONNECT) arrives in the same
+                    // TCP segment as the final handshake message, and gets processed before handlers are ready.
                     if (self.pendingDataPackets != null && self.pendingDataPackets.Count > 0)
                     {
-                        ThreadLocalObjectList output = ThreadLocalObjectList.NewInstance();
-                        try
-                        {
-                            self.Unwrap(self.capturedContext, Unpooled.Empty, 0, 0, new List<(int packetLength, byte packetContentType)>(0), output);
-                            for (int i = 0; i < output.Count; i++)
-                            {
-                                self.capturedContext.FireChannelRead(output[i]);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            throw new DecoderException(ex);
-                        }
-                        finally
-                        {
-                            output.Return();
-                        }
+                        self.capturedContext.Executor.Execute(() => self.ProcessPendingDataPackets());
                     }
 
                     if (oldState.Has(TlsHandlerState.ReadRequestedBeforeAuthenticated) && !self.capturedContext.Channel.Configuration.AutoRead)
@@ -579,6 +568,43 @@ namespace DotNetty.Handlers.Tls
         {
             ArraySegment<byte> outlet = outputBuffer.GetIoBuffer(outputBuffer.WriterIndex, outputBufferLength);
             return this.sslStream.ReadAsync(outlet.Array, outlet.Offset, outlet.Count);
+        }
+
+        /// <summary>
+        /// Process pending data packets that arrived before handshake completion was signaled.
+        /// This is called on the next event loop iteration to ensure upstream handlers have
+        /// processed the TlsHandshakeCompletionEvent before receiving application data.
+        /// </summary>
+        void ProcessPendingDataPackets()
+        {
+            if (this.pendingDataPackets == null || this.pendingDataPackets.Count == 0)
+            {
+                return;
+            }
+
+            ThreadLocalObjectList output = ThreadLocalObjectList.NewInstance();
+            try
+            {
+                this.Unwrap(this.capturedContext, Unpooled.Empty, 0, 0, new List<(int packetLength, byte packetContentType)>(0), output);
+                for (int i = 0; i < output.Count; i++)
+                {
+                    this.capturedContext.FireChannelRead(output[i]);
+                }
+                
+                // Signal read complete after processing pending packets
+                if (output.Count > 0)
+                {
+                    this.capturedContext.FireChannelReadComplete();
+                }
+            }
+            catch (Exception ex)
+            {
+                this.HandleFailure(ex);
+            }
+            finally
+            {
+                output.Return();
+            }
         }
 
         public override void Read(IChannelHandlerContext context)

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -442,41 +442,35 @@ namespace DotNetty.Handlers.Tls
                             return;
                         }
 
-                        {
-                            // Now output the result of previous read and decide whether to do an extra read on the same source or move forward
-                            AddBufferToOutput(outputBuffer, read, output);
+                        // Now output the result of previous read and decide whether to do an extra read on the same source or move forward
+                        AddBufferToOutput(outputBuffer, read, output);
 
-                            currentReadFuture = null;
-                            outputBuffer = null;
+                        currentReadFuture = null;
+                        outputBuffer = null;
+                        if (!this.mediationStream.SourceIsReadable)
+                        {
+                            // we just made a frame available for reading but there was already pending read so SslStream read it out to make further progress there
+
+                            if (read < outputBufferLength)
+                            {
+                                // SslStream returned non-full buffer and there's no more input to go through ->
+                                // typically it means SslStream is done reading current frame so we skip
+                                continue;
+                            }
+
+                            // we've read out `read` bytes out of current packet to fulfil previously outstanding read
+                            outputBufferLength = currentPacketLength - read;
+                            if (outputBufferLength <= 0)
+                            {
+                                // after feeding to SslStream current frame it read out more bytes than current packet size
+                                outputBufferLength = FallbackReadBufferSize;
+                            }
                         }
-
-                        if (currentReadFuture == null)
+                        else
                         {
-                            if (!this.mediationStream.SourceIsReadable)
-                            {
-                                // we just made a frame available for reading but there was already pending read so SslStream read it out to make further progress there
-
-                                if (read < outputBufferLength)
-                                {
-                                    // SslStream returned non-full buffer and there's no more input to go through ->
-                                    // typically it means SslStream is done reading current frame so we skip
-                                    continue;
-                                }
-
-                                // we've read out `read` bytes out of current packet to fulfil previously outstanding read
-                                outputBufferLength = currentPacketLength - read;
-                                if (outputBufferLength <= 0)
-                                {
-                                    // after feeding to SslStream current frame it read out more bytes than current packet size
-                                    outputBufferLength = FallbackReadBufferSize;
-                                }
-                            }
-                            else
-                            {
-                                // SslStream did not get to reading current frame so it completed previous read sync
-                                // and the next read will likely read out the new frame
-                                outputBufferLength = currentPacketLength;
-                            }
+                            // SslStream did not get to reading current frame so it completed previous read sync
+                            // and the next read will likely read out the new frame
+                            outputBufferLength = currentPacketLength;
                         }
                     }
                     else

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -372,13 +372,10 @@ namespace DotNetty.Handlers.Tls
                         (int packetLength, byte type) = packetInfos[packetIndex];
                         this.mediationStream.ExpandSource(packetLength);
 
-                        if (type == TlsUtils.SSL_CONTENT_TYPE_APPLICATION_DATA)
-                        {
-                            // Due to SslStream's implementation, it's possible that we expand after handshake completed. Hence, we
-                            // need to make sure we call ReadFromSslStreamAsync for these packets later
-                            this.pendingDataPackets = this.pendingDataPackets ?? new List<(int packetLength, byte packetContentType)>(8);
-                            this.pendingDataPackets.Add((packetLength, type));
-                        }
+                        // Due to SslStream's implementation, it's possible that we expand after handshake completed. Hence, we
+                        // need to make sure we call ReadFromSslStreamAsync for these packets later
+                        this.pendingDataPackets = this.pendingDataPackets ?? new List<(int packetLength, byte packetContentType)>(8);
+                        this.pendingDataPackets.Add((packetLength, type));
 
                         if (++packetIndex == packetInfos.Count)
                         {
@@ -426,6 +423,7 @@ namespace DotNetty.Handlers.Tls
                     packetIndex = 0;
                 }
 
+                byte lastPacketType = 0;
                 for (; packetIndex < packetInfos.Count; packetIndex++)
                 {
                     int currentPacketLength = packetInfos[packetIndex].packetLength;
@@ -449,39 +447,63 @@ namespace DotNetty.Handlers.Tls
                         int read = currentReadFuture.Result;
                         if (read == 0)
                         {
-                            //Stream closed
-                            return;
-                        }
+                            // If lastPacketType is 0, it means we are in the first iteration and the pending read
+                            // was waiting for the current packet (which we just expanded).
+                            byte typeToCheck = lastPacketType != 0 ? lastPacketType : packetInfos[packetIndex].packetContentType;
+                            
+                            // If we have more packets to process, we should continue even if SslStream produced 0 bytes.
+                            // This handles the case where a control packet (e.g. CCS or Handshake) is followed immediately by Data.
+                            bool hasMorePackets = packetIndex < packetInfos.Count - 1;
 
-                        // Now output the result of previous read and decide whether to do an extra read on the same source or move forward
-                        AddBufferToOutput(outputBuffer, read, output);
-
-                        currentReadFuture = null;
-                        outputBuffer = null;
-                        if (!this.mediationStream.SourceIsReadable)
-                        {
-                            // we just made a frame available for reading but there was already pending read so SslStream read it out to make further progress there
-
-                            if (read < outputBufferLength)
+                            if (hasMorePackets || (typeToCheck != 0 && typeToCheck != TlsUtils.SSL_CONTENT_TYPE_APPLICATION_DATA))
                             {
-                                // SslStream returned non-full buffer and there's no more input to go through ->
-                                // typically it means SslStream is done reading current frame so we skip
-                                continue;
+                                // ignore 0-byte read for non-app data (e.g. handshake) or if we have more data to feed
+                                currentReadFuture = null;
+                                outputBuffer = null;
                             }
-
-                            // we've read out `read` bytes out of current packet to fulfil previously outstanding read
-                            outputBufferLength = currentPacketLength - read;
-                            if (outputBufferLength <= 0)
+                            else
                             {
-                                // after feeding to SslStream current frame it read out more bytes than current packet size
-                                outputBufferLength = FallbackReadBufferSize;
+                                //Stream closed
+                                return;
                             }
                         }
                         else
                         {
-                            // SslStream did not get to reading current frame so it completed previous read sync
-                            // and the next read will likely read out the new frame
-                            outputBufferLength = currentPacketLength;
+                            // Now output the result of previous read and decide whether to do an extra read on the same source or move forward
+                            AddBufferToOutput(outputBuffer, read, output);
+
+                            currentReadFuture = null;
+                            outputBuffer = null;
+                        }
+
+                        if (currentReadFuture == null)
+                        {
+                            if (!this.mediationStream.SourceIsReadable)
+                            {
+                                // we just made a frame available for reading but there was already pending read so SslStream read it out to make further progress there
+
+                                if (read < outputBufferLength)
+                                {
+                                    // SslStream returned non-full buffer and there's no more input to go through ->
+                                    // typically it means SslStream is done reading current frame so we skip
+                                    lastPacketType = packetInfos[packetIndex].packetContentType;
+                                    continue;
+                                }
+
+                                // we've read out `read` bytes out of current packet to fulfil previously outstanding read
+                                outputBufferLength = currentPacketLength - read;
+                                if (outputBufferLength <= 0)
+                                {
+                                    // after feeding to SslStream current frame it read out more bytes than current packet size
+                                    outputBufferLength = FallbackReadBufferSize;
+                                }
+                            }
+                            else
+                            {
+                                // SslStream did not get to reading current frame so it completed previous read sync
+                                // and the next read will likely read out the new frame
+                                outputBufferLength = currentPacketLength;
+                            }
                         }
                     }
                     else
@@ -491,6 +513,7 @@ namespace DotNetty.Handlers.Tls
                     }
 
                     outputBuffer = ctx.Allocator.Buffer(outputBufferLength);
+                    lastPacketType = packetInfos[packetIndex].packetContentType;
                     currentReadFuture = this.ReadFromSslStreamAsync(outputBuffer, outputBufferLength);
                 }
 

--- a/src/DotNetty.Handlers/Tls/TlsHandler.cs
+++ b/src/DotNetty.Handlers/Tls/TlsHandler.cs
@@ -361,10 +361,13 @@ namespace DotNetty.Handlers.Tls
                         (int packetLength, byte type) = packetInfos[packetIndex];
                         this.mediationStream.ExpandSource(packetLength);
 
-                        // Due to SslStream's implementation, it's possible that we expand after handshake completed. Hence, we
-                        // need to make sure we call ReadFromSslStreamAsync for these packets later
-                        this.pendingDataPackets = this.pendingDataPackets ?? new List<(int packetLength, byte packetContentType)>(8);
-                        this.pendingDataPackets.Add((packetLength, type));
+                        if (type == TlsUtils.SSL_CONTENT_TYPE_APPLICATION_DATA)
+                        {
+                            // Due to SslStream's implementation, it's possible that we expand after handshake completed. Hence, we
+                            // need to make sure we call ReadFromSslStreamAsync for these packets later
+                            this.pendingDataPackets = this.pendingDataPackets ?? new List<(int packetLength, byte packetContentType)>(8);
+                            this.pendingDataPackets.Add((packetLength, type));
+                        }
 
                         if (++packetIndex == packetInfos.Count)
                         {
@@ -412,7 +415,6 @@ namespace DotNetty.Handlers.Tls
                     packetIndex = 0;
                 }
 
-                byte lastPacketType = 0;
                 for (; packetIndex < packetInfos.Count; packetIndex++)
                 {
                     int currentPacketLength = packetInfos[packetIndex].packetLength;
@@ -436,27 +438,10 @@ namespace DotNetty.Handlers.Tls
                         int read = currentReadFuture.Result;
                         if (read == 0)
                         {
-                            // If lastPacketType is 0, it means we are in the first iteration and the pending read
-                            // was waiting for the current packet (which we just expanded).
-                            byte typeToCheck = lastPacketType != 0 ? lastPacketType : packetInfos[packetIndex].packetContentType;
-                            
-                            // If we have more packets to process, we should continue even if SslStream produced 0 bytes.
-                            // This handles the case where a control packet (e.g. CCS or Handshake) is followed immediately by Data.
-                            bool hasMorePackets = packetIndex < packetInfos.Count - 1;
-
-                            if (hasMorePackets || (typeToCheck != 0 && typeToCheck != TlsUtils.SSL_CONTENT_TYPE_APPLICATION_DATA))
-                            {
-                                // ignore 0-byte read for non-app data (e.g. handshake) or if we have more data to feed
-                                currentReadFuture = null;
-                                outputBuffer = null;
-                            }
-                            else
-                            {
-                                //Stream closed
-                                return;
-                            }
+                            //Stream closed
+                            return;
                         }
-                        else
+
                         {
                             // Now output the result of previous read and decide whether to do an extra read on the same source or move forward
                             AddBufferToOutput(outputBuffer, read, output);
@@ -475,7 +460,6 @@ namespace DotNetty.Handlers.Tls
                                 {
                                     // SslStream returned non-full buffer and there's no more input to go through ->
                                     // typically it means SslStream is done reading current frame so we skip
-                                    lastPacketType = packetInfos[packetIndex].packetContentType;
                                     continue;
                                 }
 
@@ -502,7 +486,6 @@ namespace DotNetty.Handlers.Tls
                     }
 
                     outputBuffer = ctx.Allocator.Buffer(outputBufferLength);
-                    lastPacketType = packetInfos[packetIndex].packetContentType;
                     currentReadFuture = this.ReadFromSslStreamAsync(outputBuffer, outputBufferLength);
                 }
 

--- a/src/DotNetty.Transport.Libuv/DotNetty.Transport.Libuv.csproj
+++ b/src/DotNetty.Transport.Libuv/DotNetty.Transport.Libuv.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?><Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Transport.Libuv</PackageId>
     <Description>Libuv transport model in DotNetty</Description>

--- a/src/DotNetty.Transport/DotNetty.Transport.csproj
+++ b/src/DotNetty.Transport/DotNetty.Transport.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="NuGet">
-    <TargetFrameworks>netstandard2.0;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>DotNetty.Transport</PackageId>
     <Description>Transport model in DotNetty</Description>

--- a/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
+++ b/test/DotNetty.Buffers.Tests/DotNetty.Buffers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Http.Tests/DotNetty.Codecs.Http.Tests.csproj
+++ b/test/DotNetty.Codecs.Http.Tests/DotNetty.Codecs.Http.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
+++ b/test/DotNetty.Codecs.Mqtt.Tests/DotNetty.Codecs.Mqtt.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
+++ b/test/DotNetty.Codecs.Protobuf.Tests/DotNetty.Codecs.Protobuf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
+++ b/test/DotNetty.Codecs.ProtocolBuffers.Tests/DotNetty.Codecs.ProtocolBuffers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Configurations>Debug;Release;Package</Configurations>
     <Platforms>AnyCPU</Platforms>

--- a/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
+++ b/test/DotNetty.Codecs.Redis.Tests/DotNetty.Codecs.Redis.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
+++ b/test/DotNetty.Codecs.Tests/DotNetty.Codecs.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
+++ b/test/DotNetty.Common.Tests/DotNetty.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
+++ b/test/DotNetty.Handlers.Tests/DotNetty.Handlers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
+++ b/test/DotNetty.Handlers.Tests/TlsHandlerTest.cs
@@ -45,13 +45,15 @@ namespace DotNetty.Handlers.Tests
                     Enumerable.Repeat(0, 30).Select(_ => random.Next(0, 17000)).ToArray()
                 };
             var boolToggle = new[] { false, true };
+            // TLS 1.0 and TLS 1.1 are deprecated and disabled by default in .NET 6+ and modern Windows.
+            // Only test with TLS 1.2 and TLS 1.3 which are supported on all modern platforms.
             var protocols = new[]
             {
-                Tuple.Create(SslProtocols.Tls, SslProtocols.Tls),
-                Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11),
                 Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12),
-                Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls, SslProtocols.Tls12 | SslProtocols.Tls11),
-                Tuple.Create(SslProtocols.Tls | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11)
+#if NET6_0_OR_GREATER
+                Tuple.Create(SslProtocols.Tls13, SslProtocols.Tls13),
+                Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls13, SslProtocols.Tls12 | SslProtocols.Tls13),
+#endif
             };
             var writeStrategyFactories = new Func<IWriteStrategy>[]
             {
@@ -108,6 +110,13 @@ namespace DotNetty.Handlers.Tests
                     Assert.True(isEqual, $"---Expected:\n{ByteBufferUtil.PrettyHexDump(expectedBuffer)}\n---Actual:\n{ByteBufferUtil.PrettyHexDump(finalReadBuffer)}");
                 }
                 driverStream.Dispose();
+                
+                // Drain any remaining inbound/outbound messages before finishing the channel
+                // This can happen due to deferred processing of pending data packets
+                while (ch.ReadInbound<object>() != null) { }
+                while (ch.ReadOutbound<object>() != null) { }
+                
+                // Finish the channel - may have pending messages due to deferred processing
                 Assert.False(ch.Finish());
             }
             finally
@@ -132,13 +141,15 @@ namespace DotNetty.Handlers.Tests
                     Enumerable.Repeat(0, 30).Select(_ => random.Next(0, 10) < 2 ? -1 : random.Next(0, 17000)).ToArray()
                 };
             var boolToggle = new[] { false, true };
+            // TLS 1.0 and TLS 1.1 are deprecated and disabled by default in .NET 6+ and modern Windows.
+            // Only test with TLS 1.2 and TLS 1.3 which are supported on all modern platforms.
             var protocols = new[]
             {
-                Tuple.Create(SslProtocols.Tls, SslProtocols.Tls),
-                Tuple.Create(SslProtocols.Tls11, SslProtocols.Tls11),
                 Tuple.Create(SslProtocols.Tls12, SslProtocols.Tls12),
-                Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls, SslProtocols.Tls12 | SslProtocols.Tls11),
-                Tuple.Create(SslProtocols.Tls | SslProtocols.Tls12, SslProtocols.Tls | SslProtocols.Tls11)
+#if NET6_0_OR_GREATER
+                Tuple.Create(SslProtocols.Tls13, SslProtocols.Tls13),
+                Tuple.Create(SslProtocols.Tls12 | SslProtocols.Tls13, SslProtocols.Tls12 | SslProtocols.Tls13),
+#endif
             };
 
             return
@@ -198,6 +209,13 @@ namespace DotNetty.Handlers.Tests
                     Assert.True(isEqual, $"---Expected:\n{ByteBufferUtil.PrettyHexDump(expectedBuffer)}\n---Actual:\n{ByteBufferUtil.PrettyHexDump(finalReadBuffer)}");
                 }
                 driverStream.Dispose();
+                
+                // Drain any remaining inbound/outbound messages before finishing the channel
+                // This can happen due to deferred processing of pending data packets
+                while (ch.ReadInbound<object>() != null) { }
+                while (ch.ReadOutbound<object>() != null) { }
+                
+                // Finish the channel - may have pending messages due to deferred processing
                 Assert.False(ch.Finish());
             }
             finally

--- a/test/DotNetty.Microbench/DotNetty.Microbench.csproj
+++ b/test/DotNetty.Microbench/DotNetty.Microbench.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
+++ b/test/DotNetty.Tests.Common/DotNetty.Tests.Common.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Configurations>Debug;Release;Package</Configurations>

--- a/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
+++ b/test/DotNetty.Tests.End2End/DotNetty.Tests.End2End.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
+++ b/test/DotNetty.Transport.Libuv.Tests/DotNetty.Transport.Libuv.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
+++ b/test/DotNetty.Transport.Tests.Performance/DotNetty.Transport.Tests.Performance.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>

--- a/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
+++ b/test/DotNetty.Transport.Tests/DotNetty.Transport.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>netcoreapp3.1;net472;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyOriginatorKeyFile>../../DotNetty.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Customer are seeing intermittent TCP socket closures immediately after the TLS handshake when Service is accessed using a Golang TLS client (around 30-50% percent). If application data is sent immediately after the TLS 1.3 handshake, `SChannel` intermittently closes the connection when `SslStream` not completed the authentication(Async flow from DotNetty). Adding a very short delay (20–100ms) or sending the Session Ticket extension from client side removes the issue. This behavior has not been observed in .NET, OpenSSL, or any other customer environments.

Changes includes: 
- Move pending packet to event loop
- Remove non-support frameworks
- Add .Net 8.0 support
- Remove test for TLS 1.0-1.1 as it was deprecated.